### PR TITLE
Inline suppression in the core (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An auditable Simplified Technical English linter for technical documentation: deterministic textlint
 rules, plus an **optional** semantic-adjudication subsystem that calls a small model served locally by
-llama.cpp.
+llama.cpp. It is meant to run inside a pre-commit hook — Husky, prek, or the Python `pre-commit`
+framework, invoked via `npx` — most often checking documentation an AI agent has just drafted, so the
+agent's vocabulary stays consistent with the project's before the commit lands.
 
 > **This package does not implement ASD-STE100 and makes no claim of conformance with it.** The
 > standard and its dictionary are proprietary and were not available to this repository. Every rule
@@ -22,6 +24,12 @@ schema-validated, threshold-gated, span-anchored and traced.
                     │ preserved throughout)          │   candidates → broker → evaluator → verdict
                     └────────────────────────────────┘        (optional, local, off by default)
 ```
+
+The "protected regions → blocks" step is implemented today by hand-written regex over masked text,
+selected by a `markdown`/`text` format flag. That is being replaced by a pluggable document reader —
+a real parser for Markdown first — feeding the same reader-agnostic rules below; see
+[issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25) and
+[`docs/architecture.md`](docs/architecture.md). It is in progress, not shipped.
 
 ## Install
 
@@ -45,6 +53,64 @@ npx textlint --fix docs/**/*.md     # applies only gated fixes
 
 No model is needed. Semantic analysis is off by default and the deterministic rules never touch the
 network.
+
+## Who this serves, and how
+
+The intended audience is an AI agent generating text, and the goal is keeping that agent's vocabulary
+consistent with the project's own approved/preferred/unapproved terms — plus any further list a
+specific repository wants layered on top of the bundled provisional pack. That serves three distinct
+consumer surfaces, at different stages of readiness. They are not the same shape and should not be
+conflated:
+
+**1. Pre-commit hooks — works today.** Husky, prek, or the Python `pre-commit` framework, invoked via
+`npx`, linting documentation files before a commit lands. Both pieces this needs are real today, not
+proposed:
+
+- `rulePack` (a path to a JSON file, or an inline object) and `approvedTerms` in the shared config let
+  a repository supply its own vocabulary on top of the bundled provisional pack — see
+  [`docs/configuration.md`](docs/configuration.md) and
+  [`docs/rule-pack-import.md`](docs/rule-pack-import.md).
+- The CLI's exit codes are the ones a hook needs: `0` clean, `1` errors present (or review-required
+  with `--fail-on-review`), `2` usage error, `3` semantic-service failure under the `error` policy.
+
+```yaml
+# .pre-commit-config.yaml — works with prek too, same config format
+repos:
+  - repo: local
+    hooks:
+      - id: ste-ai
+        name: Simplified Technical English check
+        entry: npx --yes ste-ai lint --fail-on-review
+        language: system
+        files: \.md$
+```
+
+```sh
+# .husky/pre-commit
+npx ste-ai lint docs/**/*.md --fail-on-review
+```
+
+**2. An authoring agent consulting the vocabulary in-loop — proposed, not built.** The agent checks
+its own draft voluntarily, mid-composition, rather than being checked after the fact: exporting the
+merged vocabulary as a machine-readable artefact to consult _before_ drafting
+([issue #2](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/2)), and an MCP server —
+`check_text`, `lookup_term`, `list_vocabulary` — so the agent can check text and look up terms in-loop
+instead of shelling out to the CLI per iteration
+([issue #5](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/5)). Resolving a rule pack from
+a package name or a URL with a required integrity digest, so an organisation shares one vocabulary
+across repositories instead of copying a JSON file into each, matters to this surface too
+([issue #3](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/3)).
+
+**3. A blocking Claude Code hook gating live agent/user communication — proposed, not built, and
+currently blocked.** Checking that outgoing messages — assistant to user, or between sub-agents and
+an orchestrator — stay on the same agreed vocabulary, before they are sent. This is a different
+integration shape from surface 2: a hook is invoked by the harness, not by the agent's own choice, and
+it conventionally receives text on stdin and reports pass/fail through its exit code, not through MCP.
+It cannot be wired up yet: `lint` only reads files, via `readFileSync`, and exits `2` with no file
+arguments — there is no stdin path. The programmatic API
+(`analyseTextDeterministic`/`analyseText`) already accepts an arbitrary string with no file
+dependency, so this is a gap in the CLI surface only, not in the underlying analysis. Tracked as
+[issue #26](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/26).
 
 ## The 14 rules
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ trigger, rationale and **observed failure modes** are in
 **A model outage is never converted into compliance.** Affected passages become `review-required` and
 a run notice records how many. See [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md).
 
+## Inline suppression
+
+`<!-- ste-ai-ignore-next-line rule-id -- reason -->` withholds one finding instead of disabling a
+provisional rule everywhere; the reason is required, the withheld finding is still recorded in
+`suppressions` and in `--json`, and a claim inside a danger, warning or caution admonition is
+refused by default. See [`docs/suppression.md`](docs/suppression.md).
+
 ## What is protected
 
 Code fences, inline code, shell commands, configuration fragments, URLs, email addresses, file paths,
@@ -194,6 +201,7 @@ npm run eval:semantic -- --split heldout --endpoint http://127.0.0.1:8080   # ne
 | [`docs/rule-authoring.md`](docs/rule-authoring.md)               | writing a rule                                  |
 | [`docs/semantic-evaluators.md`](docs/semantic-evaluators.md)     | evaluators, prompt contract, measurement        |
 | [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md)         | categories, outage policy, autofix policy       |
+| [`docs/suppression.md`](docs/suppression.md)                     | inline directives, and what they record         |
 | [`docs/configuration.md`](docs/configuration.md)                 | every option                                    |
 | [`docs/rule-pack-import.md`](docs/rule-pack-import.md)           | supplying licensed material                     |
 | [`docs/llama-cpp-setup.md`](docs/llama-cpp-setup.md)             | running the model service                       |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,30 @@ Everything downstream of parsing depends on one property: **an offset obtained a
 valid offset into the original source text.** It is maintained by never rewriting text — only masking
 it.
 
+### Document reading: current implementation, and where it is going
+
+The diagram below is what `src/core/document.ts` runs today — regex passes over progressively masked
+text, selected by a two-value `format: 'markdown' | 'text'` flag (`src/core/types.ts:176`) — and it is
+not the intended permanent design. [Issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25)
+records the cost: `noun-cluster-candidate` measured 0 confirmed defects in 35 reviewer-adjudicated
+candidates ([issue #11](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/11)), with the false
+positives traced to a line scanner disagreeing with a table cell, a `See [` link, and a directive name
+followed by its title line — constructs a real parser reads correctly and a line scanner reliably does
+not. `src/textlint/adapter.ts:168-172` already builds a markdown AST via the textlint kernel and
+discards it, calling `getSource(node)` and re-scanning the string with this same regex machinery.
+Prose is not part of that defect: the same three sentences written as one line or as six
+soft-wrapped ones already produce byte-identical diagnostics, because segmentation works over blocks,
+not physical lines — the weakness is specifically structured constructs, not prose in general.
+
+The stated direction (issue #25) is a pluggable `DocumentReader`, one implementation per media type —
+a real parser for Markdown, a minimal reader for plain text, with the interface open to RST, HTML and
+docx readers later without a change below it — feeding a reader-agnostic prose checker. The rule
+contract described further down already qualifies as reader-agnostic: it reads only `sentence.masked`
+and `sentence.words`, never the raw document. Positions would then trace back through the reader's own
+AST rather than through hand-rolled offsets. This is in progress on this branch, being implemented
+separately from this document; nothing below reflects that change yet — the pipeline that follows is
+what actually runs today.
+
 ```
 raw text
   │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,3 +233,307 @@ autofix policy, protected terminology) is read from a shared file — see
 [`configuration.md`](./configuration.md). Option layers are merged key by key, lowest first: shared
 file, `shared` override, the rule's own textlint options. Replacing an object wholesale would drop an
 `enabled: false` set by a lower layer; there is a test for that.
+
+## Document reader — design note (pending review, not yet implemented)
+
+**Status.** Nothing in this section is built. No code under `src/` or `test/` has changed for it. It
+is written to be read, argued with, and either approved or sent back — see the gate at the end. The
+section above this one already states the motivation (issue #25, issue #11's measured 0/35 result on
+`noun-cluster-candidate`) and is not repeated here.
+
+### 1. The `DocumentReader` interface and the text unit
+
+```ts
+/** One reader-recognised span of the document that the checker treats as a unit of judgement. */
+export interface TextUnit {
+  /** Stable within one `read()` call. Not stable across edits to the source — it is not a diff key. */
+  readonly id: string;
+  /** Reader-defined: `'paragraph' | 'heading' | 'list-item' | 'table-cell' | 'blockquote' | …`. */
+  readonly kind: string;
+  /** Offset into the ORIGINAL source text handed to `read()`. See §4 for how this is guaranteed. */
+  readonly range: SourceRange;
+  /** Raw source slice for `range`. */
+  readonly text: string;
+  readonly mode: TextMode;
+  readonly admonition: AdmonitionKind;
+  /** Nesting depth — heading level, list depth, blockquote depth. Same meaning as `TextBlock.depth`. */
+  readonly depth: number;
+}
+
+export interface DocumentReader {
+  readonly mediaType: DocumentFormat;
+  /**
+   * Async even though every v1 implementation is synchronous underneath. A reader for docx or a
+   * remotely-fetched HTML document may need real I/O to produce its next unit, and there must be no
+   * second interface for that later — every caller already awaits.
+   */
+  read(doc: SourceDocument): AsyncIterable<TextUnit>;
+}
+```
+
+This is deliberately close to today's `TextBlock` (`src/core/types.ts:129-142`), not a rewrite of it.
+`TextBlock` already carries `range`, `mode`, `admonition`, `depth` — the four fields a rule actually
+reads. What it does not carry, and `TextUnit` must, is `id` as a first-class, reader-produced value:
+today a candidate's diagnostic id is built by the _rule_ (`` `${spec.meta.id}:${sentence.id}:${range.start}` ``,
+`src/deterministic/rules/candidate-rules.ts:38`) — the rule manufactures unit identity from a
+`Sentence.id` that is itself just a counter. The task requires "on a unit's failure, the report names
+which unit id failed and why," which means the id has to be something the _reader_ is answerable for,
+not the rule.
+
+`Sentence` (`src/core/types.ts:158-174`) does not become `TextUnit`. Sentence segmentation is a
+prose-level operation done _within_ a unit's text (a paragraph is one to several sentences), not a
+structural fact the reader knows. The checker still needs sentence boundaries for anything that
+reasons per-sentence (`sentence-length-procedural`, `one-instruction-per-sentence`); that segmentation
+step stays exactly where it is (`src/core/segmentation.ts`), just fed by `unit.text` instead of by a
+block scanned out of regex-masked source. `words` similarly is not carried on `TextUnit` — masking
+and tokenising happen after reading, over `unit.text`, for the reason in §6: they are not markdown
+concerns.
+
+### 2. Which parser, and why
+
+**Recommendation: `@textlint/markdown-to-ast` (`15.7.1`), not a fresh `remark`/`unified` install.**
+
+This was checked against the real package tree rather than assumed:
+
+- `@textlint/markdown-to-ast` is already resolved in `node_modules` — it is a dependency of
+  `@textlint/textlint-plugin-markdown`, which `textlint` (a devDependency here, `>=13` as an
+  **optional** peer per `package.json`) depends on for its own markdown plugin. It is _not_,
+  however, currently part of this package's own runtime dependency graph — `textlint` is optional,
+  so an installer of `textlint-rule-preset-ste-ai` alone does not necessarily get it. Depending on it
+  directly in `dependencies` is a real, new cost, not a free ride; I want to be honest about that
+  rather than claim it costs nothing because it happens to already be on disk in this dev tree.
+- What it buys: its `TxtNode` shape (`@textlint/ast-node-types`, already a genuine transitive
+  runtime dependency via `sentence-splitter`) is `{ range: readonly [number, number], loc: {...}, ... }`
+  — exactly the AST the textlint kernel itself builds and, per the paragraph above this section,
+  currently discards at `src/textlint/adapter.ts:168-172`. Adopting it means the reader produces the
+  same node shape the rest of this codebase's textlint integration already type-checks against,
+  rather than a second, unrelated AST convention (mdast) existing alongside it for no reason.
+- The version pinned inside `markdown-to-ast` is old — `unified@9.2.2`, `remark-parse@9.0.0`,
+  `mdast-util-from-markdown@0.8.5` — versus current `remark`'s `unified@11`. I checked whether this
+  matters for what this reader needs (offsets, node kinds, determinism) and it does not: the position
+  contract (`node.range`) has been stable across that whole range of versions, and a parse is pure —
+  no I/O, no clock, no locale dependence. It would matter if this project wanted streaming/plugin
+  composition from the modern `unified` ecosystem; it does not need that for a reader that just walks
+  a tree once.
+- **Determinism, checked, not assumed:** two `parse()` calls over the same string produced
+  byte-identical `JSON.stringify` output in a direct run against this tree's installed copy. No
+  further verification of this claim should be needed before relying on it, but I did not want to
+  assert it from documentation.
+
+The runner-up is a direct `unified` + `remark-parse` + `remark-gfm` install (current major versions).
+It gives the same offset guarantee and a more actively maintained toolchain, at the cost of a second,
+unrelated AST convention living next to the one `@textlint/kernel` already builds, and a larger,
+independent set of transitive packages. I would switch the recommendation to this if `@textlint/markdown-to-ast`'s
+tie to `textlint`'s own release cadence turns out to be a problem in practice — it hasn't been
+checked against that risk yet, only against the offset and determinism requirements above.
+
+**Plain text** needs no parser at all. `format: 'text'` today already only splits on blank lines
+(`src/core/structure.ts`, the `options.format === 'text'` branch) — a `PlainTextReader` reproduces
+exactly that with a `String.split(/\n{2,}/)`-equivalent scan and real offsets, zero new dependencies.
+This is the "simplest reader that satisfies the interface" the task asked to keep working.
+
+### 3. Where the module-boundary line sits
+
+**A new top-level module, `src/reader/`, that `core` does not import — not a change to what `core`
+is allowed to import.**
+
+The reasoning, checked against the actual enforcement rather than the prose description of it:
+`test/architecture/module-boundaries.test.ts` has a dedicated assertion, `'core imports no textlint
+package and performs no HTTP'` (line ~124), that greps every import specifier under `src/core` for the
+literal substring `textlint` and fails if it appears — an assertion built, by name, specifically to
+stop what this feature would otherwise do to `core`. `@textlint/markdown-to-ast` contains that
+substring in its own package name. Landing the reader in `core` does not "graze" this rule, it is
+exactly the case the rule's own name describes; changing it would mean deleting one of the three named
+prohibitions the module-boundaries section of this document calls out deliberately, not adjusting an
+incidental detail.
+
+A new `reader` module sidesteps that question entirely rather than answering it by weakening the
+rule:
+
+```
+reader          → core                    DocumentReader interface, TextUnit, MarkdownReader,
+                                          PlainTextReader
+```
+
+- `reader` imports `core` for shared types (`SourceRange`, `TextMode`, `AdmonitionKind`, `SourceDocument`).
+- `analysis` and `cli` gain `reader` in their `ALLOWED` entries; `core` does not change at all — none
+  of its three existing prohibitions needs editing, and the "core depends on nothing internal"
+  assertion (`module-boundaries.test.ts`, the one that currently asserts `core`'s edge list is empty)
+  stays true and stays meaningful, rather than becoming a rule with a carved-out exception nobody
+  reads twice.
+- `textlint` (`src/textlint/`) is deliberately **not** given access to `reader` in this landing. The
+  adapter still calls `analysis`'s `analyseText`/`analyseTextDeterministic` on a raw string
+  (`src/textlint/adapter.ts`, `getAnalysis`), which is what lets the standalone CLI and the textlint
+  path share one analysis pipeline; `reader` is used _inside_ `analysis`, not spliced into the
+  adapter's own kernel-AST handling. A later change that lets the adapter hand its own already-built
+  kernel AST to the reader (avoiding a second parse of the same document) is a real, worthwhile
+  optimisation, but it is out of scope here and would touch the adapter's contract, which this note
+  is deliberately not proposing to change yet.
+
+This is the smaller, more reversible of the two options posed. It costs one new entry in `ALLOWED`
+and zero changes to `core`'s own rules; the alternative (loosen `core`) costs rewriting a rule that
+exists specifically to prevent this, with no way to partially un-rewrite it later if the choice turns
+out to be wrong.
+
+### 4. The offset contract, demonstrated
+
+The requirement: an index into a unit's `text` must be a valid offset into the _original_ source the
+author has open — the same guarantee `positionAt` (`src/core/text.ts:76`) and textlint's `locator`
+rely on today (`docs/architecture.md`, "The offset contract", above). This is checked here against a
+real parse, not asserted:
+
+```js
+const { parse } = require('@textlint/markdown-to-ast');
+const text = [
+  '# Setup',
+  '',
+  '| Step | Action |',
+  '| --- | --- |',
+  '| 1 | Utilise the tool |',
+  '',
+  'See [the guide](./guide.md) before you continue.',
+  '',
+].join('\n');
+const ast = parse(text);
+```
+
+Actual output, this run, this tree:
+
+```
+Document        range=[0,116]
+  Header        range=[0,7]    "# Setup"
+  Table         range=[9,65]
+    TableRow    range=[9,26]   "| Step | Action |"
+    TableRow    range=[41,65]  "| 1 | Utilise the tool |"
+      TableCell range=[46,65]  " Utilise the tool |"
+        Str     range=[47,63]  "Utilise the tool"
+  Paragraph     range=[67,115] "See [the guide](./guide.md) before you continue."
+    Str         range=[67,71]  "See "
+    Link        range=[71,94]  "[the guide](./guide.md)"
+      Str       range=[72,81]  "the guide"
+    Str         range=[94,115] " before you continue."
+```
+
+`text.slice(47, 63) === 'Utilise the tool'` and `text.slice(94, 115) === ' before you continue.'`,
+both directly against the original `text` string — no translation table, no reparse. This is the
+exact defect class issue #11 names: a table cell (`TableCell`'s `Str` child isolates the cell's prose
+from its `|` markup automatically) and a link (`Str` after the `Link` node correctly resumes at offset
+94, past the whole `[text](dest)` construct, with nothing of the link's own syntax leaking into it).
+A `TextUnit` built from either of these nodes carries `range` values obtained by walking the AST, and
+every one of them is already an offset into `text` — the guarantee holds by construction, the same way
+it holds today by never rewriting, only masking.
+
+Determinism was checked the same way: two `parse(text)` calls over the identical string, this run,
+produced byte-identical `JSON.stringify` output.
+
+### 5. `src/core/protected-regions.ts` and `src/core/structure.ts`
+
+**Not a clean deletion of either file. Both split, and only part of each goes away.**
+
+I checked every pass in both files against what the AST gives for free before writing this, rather
+than asserting the files are simply obsolete:
+
+**Retired.** Fenced/indented code, front matter, HTML blocks/inline, reference definitions, link/image
+destinations, autolinks, tables, headings, lists, blockquotes, footnotes, emphasis markers —
+`frontMatterPass`, `fencedCodePass`, `htmlCommentPass`, `htmlBlockPass`, `indentedCodePass`,
+`referenceDefinitionPass`, `inlineCodePass`, `linkDestinationPass`, `autolinkPass`, `tableMarkupPass`,
+`headingMarkerPass`, `blockquoteMarkerPass`, `listMarkerPass`, `footnotePass`, `htmlInlinePass`,
+`emphasisMarkerPass` (`src/core/protected-regions.ts`). This is markdown structure; a real parser gives
+it as node types and exact ranges, which is the entire premise of this change.
+
+**Not retired — moved.** Credentials, quoted literals, approved terms, extra user patterns,
+placeholders, shell command lines, file paths, config-key/value fragments, code-shaped identifiers,
+quantities/units — `credentialPass`, `quotedLiteralPass`, `approvedTermPass`, `extraPatternPass`,
+`placeholderPass`, `shellCommandPass`, `filePathPass`, `configFragmentPass`, `identifierPass`,
+`numericPass`. These are plain regex over already-structurally-masked _prose text_, not markdown
+syntax — confirmed by reading each: `shellCommandPass`, for example, matches
+`/^[ \t]{0,3}[$#][ \t]+\S.*$/gm` against masked text, nothing about markdown. They apply identically
+to a table cell's text, a list item's text, or a plain-text document's paragraph, so they belong
+beside the checker, applied per `TextUnit.text`, not inside the reader.
+
+**Probably retired, not yet confirmed.** Bare URL/email in prose, outside markdown link syntax —
+`urlPass`, `emailPass`. `@textlint/markdown-to-ast` carries `remark-gfm` as a dependency, which
+recognises bare autolinks (GFM's autolink-literal extension) as `Link` nodes without `[]()` syntax.
+Whether that extension is actually wired on for this specific parser's default configuration, versus
+needing to stay as a prose pattern for plain-text documents at least, is exactly the kind of thing the
+implementation stage needs to verify against a real parse before this claim is trusted — flagged here,
+not asserted.
+
+**Not addressed by this parser at all.** Math — `mathPass`. Math has no standard commonmark
+representation; `mathPass` may need to stay as a prose pattern regardless of parser, unless a math
+extension is added deliberately. Not verified either way yet.
+
+The corollary: this is not "delete two files, add one dependency." It is "delete the markdown-structural
+half of `protected-regions.ts` and all of `structure.ts`'s block-scanning, and move the prose-pattern
+half of `protected-regions.ts` to run over `TextUnit.text` wherever the checker layer ends up living."
+`docs/architecture.md`'s own claim above — "the checker layer is CLOSER to reader-agnostic than the
+reader is" — already anticipated this; it undersold it slightly, because the prose-pattern passes
+were never reader logic in the first place, just filed in the same source file as the passes that are.
+
+**One concrete interaction with the suppression feature, found while checking the above, not asked
+for but worth flagging now rather than at implementation time:** `src/core/suppressions.ts` currently
+distinguishes an HTML _comment_ from other raw HTML via a dedicated protected-region kind, `'comment'`
+(`htmlCommentPass`, `src/core/protected-regions.ts`), which `isLiveDirectiveComment` matches on
+exactly. `@textlint/markdown-to-ast` does not produce a distinct comment node — I parsed
+`<!-- a comment -->\n\nProse.\n` and got a single `Html` node covering the comment, with no `Html`
+node distinguishing it from an HTML block that is not a comment. This is a small, containable gap —
+the AST still gives the exact byte range, and `/^<!--[\s\S]*-->$/`-testing that range's raw slice
+recovers "is this Html node a comment" without needing a new node kind — but it is a real seam between
+this work and the suppression feature just finished, and worth a test in whichever stage first touches
+`isLiveDirectiveComment`'s assumptions, not an assumption that the migration is comment-shape-neutral.
+
+### 6. Issue #11's ground truth (`fixtures/verdicts/`)
+
+Checked, not assumed: 4 reviewer files, 18 source documents in `fixtures/original/`, verdicts keyed by
+`(ruleId, span, quote)` exactly as described — e.g.
+`{"passageId":"passive-voice-candidate:s3:399","span":{"start":399,"end":409},"quote":"is deleted",...}`
+in `fixtures/verdicts/reviewer-d.json`.
+
+**If migrating a document to the new reader moves any span the corpus already covers, that is a
+re-review trigger for every verdict keyed against that document — not something a span-remapping
+script should paper over.** A verdict is a person's judgement about a specific quoted passage; if the
+new reader reports the "same" finding two characters to the left because a table cell's leading
+space is now excluded from its `Str` child where the old regex scanner included it, the quote a
+reviewer read may no longer be the quote the tool now reports, and silently rewriting `span` to match
+would be asserting the reviewer verified something they did not look at. The concrete plan, if this is
+approved: before switching a fixture document's family over, run both readers against it, diff every
+`(ruleId, range)` pair the deterministic rules produce, and for every document where a span changed,
+treat every verdict keyed to that document as needing re-review rather than auto-remapping it. This
+should surface as a small number of documents (only ones containing the structures issue #11 named —
+tables, links, directive-plus-title constructs) rather than all 18, but that is a claim to verify
+against the real diff when the migration actually runs, not to state now.
+
+### 7. Explicit v1 scope
+
+**In scope for a first landing:**
+
+- `DocumentReader` interface and `TextUnit` type in `src/reader/`.
+- `MarkdownReader` on `@textlint/markdown-to-ast` (or the `unified`/`remark` runner-up, if §2's
+  concern is resolved against it instead).
+- `PlainTextReader`, dependency-free.
+- `analysis` wired to select a reader by `DocumentFormat` and iterate its units.
+- Migrating the markdown-structural half of `protected-regions.ts` and all of `structure.ts`'s block
+  scanning off; the prose-pattern half moves, not deletes.
+- The suppression-comment seam in §5, tested explicitly rather than discovered by a failing test.
+- The fixture re-review process in §6, run against the real corpus, with its actual result reported —
+  not "no spans moved" asserted in advance.
+
+**Explicitly out of scope, stubbed behind the same interface:**
+
+- RST, HTML, and docx readers. The interface is shaped so that adding one later means implementing
+  `DocumentReader` and registering it by `DocumentFormat` — no change below that line — but none of
+  the three is implemented, and `DocumentFormat` itself (`src/core/types.ts:176`, currently
+  `'markdown' | 'text'`) is not extended for them in this landing. A reader that isn't backed by a
+  real parser yet is not stubbed as a fake pass-through either — better to leave the format
+  unsupported than to ship a reader that silently mis-reports positions for a format nobody has
+  actually implemented.
+- The adapter optimisation in §3 (reusing textlint's own kernel-built AST instead of a second parse).
+- Any change to `DiagnosticCategory`, the suppression directive syntax, or the rule contract's public
+  shape (`meta`, `optionsSchema`, `run`) — this is a reader change, not a rule-contract change, and
+  the existing 434 tests passing unmodified is exactly what would demonstrate that boundary held.
+
+### Gate
+
+No implementation starts from this note alone. The reviewing party reads this against the real
+source and replies "proceed" or with specific pushback, the same as any other change on this branch —
+this section makes no claim to have settled that already.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,16 @@ They are read once from a shared file, resolved in this order (first hit wins):
     // "allowInAdmonitions" cannot be set to true.
   },
 
+  // Inline `ste-ai-ignore-*` directives. See docs/suppression.md.
+  "suppressions": {
+    // Honour inline directives. Set false to make every directive inert: nothing is
+    // scanned, nothing is withheld, and the file is reported as if it carried no directives.
+    "enabled": true,
+    // Permit a directive to withhold a finding inside a danger, warning or caution
+    // admonition. Off by default; every suppression is recorded either way.
+    "allowInAdmonitions": false,
+  },
+
   "diagnostics": {
     "reportReviewRequired": true,
     "reportSuppressed": false,
@@ -147,6 +157,16 @@ For a rule's options, lowest first:
 
 Layers are merged key by key, so a lower layer's `enabled: false` is not lost when a higher layer sets
 an unrelated key.
+
+### Inline suppression is not one of these layers
+
+`suppressions` is read only from the shared file; there is no per-rule or per-textlint-options form
+of it. Inline `ste-ai-ignore-*` directives are applied after every rule has run, to the diagnostics
+the run produced, so they cannot change a rule's options and a rule cannot see them.
+
+A suppressed finding is withheld from `diagnostics` but recorded in `AnalysisResult.suppressions`,
+in `--json`, and in a `suppressions-applied` notice. See
+[suppression.md](suppression.md).
 
 ## Offline, deterministic-only mode
 

--- a/docs/diagnostic-policy.md
+++ b/docs/diagnostic-policy.md
@@ -52,6 +52,30 @@ When semantic analysis is simply **disabled**, candidates become `review-require
 All of the above is testable and tested — the outage-policy block in the integration suite covers
 `notice`, `error`, `silent`, malformed replies, and the deterministic-set invariant.
 
+## A suppression is an authored claim
+
+An inline `ste-ai-ignore-*` directive does not delete a finding. It records that a person read the
+finding and decided it does not apply, and it carries their reason — a directive without a reason is
+inert and reported as `suppression-reason-missing`.
+
+The rule above governs this too. A withheld finding leaves `diagnostics` and does not leave the
+result: it appears in `AnalysisResult.suppressions`, in `ste-ai lint --json`, in the CLI's
+`suppressed` lines, and in a `suppressions-applied` notice carrying the count. A file that is clean
+because of six suppressions is not the same file as one that is clean, and the output says which it
+is.
+
+Inside a `danger`, `warning` or `caution` admonition a claim is **refused** by default: the
+diagnostic is kept and `suppression-refused-in-admonition` is emitted at `warning`. Setting
+`suppressions.allowInAdmonitions: true` permits it. That option exists at all — while
+`autofix.allowInAdmonitions` is typed `z.literal(false)` and cannot — because rewriting the source
+of a safety notice and withholding a report about one are different acts. The first changes what a
+reader in front of the equipment is told. The second is an operator's decision about the linter's
+output, permitted when taken explicitly and always recorded.
+
+Suppression is applied to candidates as well as to diagnostics, before adjudication: a suppressed
+passage is never sent to a semantic service. Full syntax and semantics are in
+[`suppression.md`](./suppression.md).
+
 ## Autofix policy
 
 A fix may exist only if one of two conditions holds:

--- a/docs/extension-roadmap.md
+++ b/docs/extension-roadmap.md
@@ -199,6 +199,15 @@ should route through that, not around it.
 
 ## 5. Proposed sequence
 
+**Out of scope here:** replacing the regex-based protected-region and structure scanner with a
+real document parser is tracked separately in
+[issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25), not sequenced in the
+list below. It carries different constraints — a possible new dependency for the deliberately thin
+`core` module, an offset-contract obligation to re-verify, and measured evidence
+([issue #11](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/11)) about what the current
+scanner already gets wrong — so it is tracked on its own rather than competing for priority with
+steps 1–7, which take today's document-analysis layer as given.
+
 Ordered so each step is independently useful and none depends on resolving the licence
 question.
 

--- a/docs/extension-roadmap.md
+++ b/docs/extension-roadmap.md
@@ -131,11 +131,12 @@ currently ask.
 
 ### 3.4 Things to take outright
 
-- **Inline suppression.** We have none. A textlint user can install
-  `textlint-filter-rule-comments` separately, but the framework-neutral core and the CLI
-  have no way to say "this usage is intentional". For a linter making provisional claims
-  this is close to a requirement — without it, a false positive can only be silenced by
-  disabling the rule globally. Their `copy-ignore` line marker is the minimum viable form.
+- **Inline suppression.** Taken, and now implemented in the core rather than left to
+  `textlint-filter-rule-comments`. For a linter making provisional claims this was close to a
+  requirement — without it, a false positive can only be silenced by disabling the rule
+  globally. Their `copy-ignore` line marker was the minimum viable form; what shipped adds a
+  required reason, a range form, and a record of every withheld finding. See
+  [suppression.md](suppression.md).
 - **Per-category document thresholds.** Their `--strict` fails only when a category reaches
   a count (2 hits, not 1), which is the right shape for a heuristic with known
   false positives. Our CLI has an exit-code contract but no "fail if more than N of X".
@@ -201,8 +202,10 @@ should route through that, not around it.
 Ordered so each step is independently useful and none depends on resolving the licence
 question.
 
-1. **Inline suppression in the core.** Highest value per line of code. Unblocks adoption of
-   every provisional rule, and needed regardless of anything else here.
+1. **Inline suppression in the core.** _Implemented._ Three `ste-ai-ignore-*` HTML-comment
+   directives, honoured in both `markdown` and `text` documents, with a required reason, a
+   refusal inside safety admonitions, and every withheld finding recorded in
+   `AnalysisResult.suppressions` rather than discarded. See [suppression.md](suppression.md).
 2. **Block position in `RuleInput`.** Small, enables position-sensitive rules of any kind.
 3. **The `observation` diagnostic category, plus the first document metrics** — sentence and
    paragraph length distribution, and reading-level-adjacent counts. Directly useful for

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -142,6 +142,16 @@ alone. A reviewer is not obliged to satisfy a heuristic, and the tests are built
 not fail the build — a fixture with no accepted change must simply be a `hard-negative` or carry a
 `notes` explanation, and must record something as `disputed` or `deferred`.
 
+`originalSpans`, and the `candidateAdjudications` merged in from `fixtures/verdicts/` (see
+[`provisional-rules.md`](./provisional-rules.md#measured-precision-of-the-candidate-heuristics)),
+both bind a verdict to a specific `(ruleId, span, quote)`, on the assumption that spans are derived
+the way they are today, by the regex-based scanner.
+[Issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25) proposes deriving spans
+from a real parser instead; if that change moves a span, the verdict recorded against the old span
+no longer describes the new one and needs fresh review.
+`scripts/ci/check-candidate-ground-truth.sh` already enforces this for candidate verdicts; a parser
+adoption would need the same discipline applied to `originalSpans`.
+
 ## Corpus tests
 
 `test/fixtures/corpus.test.ts` asserts, over the real corpus:

--- a/docs/provisional-rules.md
+++ b/docs/provisional-rules.md
@@ -219,6 +219,8 @@ candidates.** Reviewers found that most spans are not noun runs at all — they 
 (`allows`, `include`, `named`), a parenthetical, a table cell, a `See [` link, or a title line
 immediately below a directive name — and that the remainder name real components. Treat any finding
 from this rule as unsubstantiated until the span detection is corrected and the corpus re-reviewed.
+The architectural cause — hand-written regex scanning rather than a real parser — and the proposed
+fix are tracked in [issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25).
 
 ### ambiguous-pronoun-candidate
 

--- a/docs/rule-authoring.md
+++ b/docs/rule-authoring.md
@@ -96,6 +96,12 @@ The runner applies these after your rule returns, so do not attempt them:
 Never run a regex over `doc.text`. Use `sentence.masked` or `doc.maskedText`; that is what keeps code,
 URLs, identifiers and quantities from being read as prose.
 
+That contract — read only `sentence.masked` and `sentence.words`, never `doc.text` — is what stays
+stable while the document-reading layer is rearchitected
+([issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25)). A rule that only touches
+already-masked, sentence-level data does not depend on whether a block came from the current regex
+scanner or a future parser-backed reader.
+
 ## Offering a fix
 
 Set `meta.fixable: true` and attach a `TextFix`. Then expect it to be refused, and make sure the

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -77,6 +77,29 @@ reason `directive text is not prose`. Without this, a `format: 'text'` document 
 are not masked out — would report findings on the directive line, which is not text anyone wrote
 for a reader.
 
+### Reformatting the prose
+
+Because `ste-ai-ignore-next-line` claims exactly one line, a formatter that rewraps prose can move
+the offending text off the claimed line and the suppression stops applying. Measured on a
+paragraph reflowed so the offending word moved to the second line:
+
+| Document                                          | Finding reported | Withheld | `suppression-unused` |
+| ------------------------------------------------- | ---------------: | -------: | -------------------: |
+| directive, offending word on the next line        |                0 |        1 |                    0 |
+| directive, word reflowed onto the second line     |                1 |        0 |                    1 |
+| `ignore-start` / `ignore-end` over the same prose |                0 |        1 |                    0 |
+| no directive, for comparison                      |                1 |        0 |                    0 |
+
+Prettier does not rewrap prose unless it is configured to. Its `proseWrap` option defaults to
+`preserve`, and this repository sets no value for it, so running Prettier over a document does not
+move a claimed line. A formatter run with `proseWrap: always`, or an author rewrapping a paragraph
+by hand, does.
+
+Note the second row: the finding comes back **and** `suppression-unused` is emitted. Drift of this
+kind fails towards reporting, never towards false silence, and the notice names the line so the
+directive can be moved. Where prose is expected to be reflowed, prefer the range form, which is not
+sensitive to where a line ends.
+
 ## Configuration
 
 ```jsonc

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -1,0 +1,202 @@
+# Inline suppression
+
+Every rule this package ships is `provisional`. A provisional rule will sometimes be wrong about a
+particular sentence, and before inline suppression existed the only remedy was to disable the rule
+for the whole run — losing every other finding it would have made. An inline directive narrows that
+to one line or one region, and says in the source why.
+
+A suppression is an **authored claim**: someone looked at this finding and decided it does not
+apply here. It is treated as a claim throughout — recorded, attributed to a reason, and reported —
+not as a way of deleting the finding.
+
+## Syntax
+
+Three directive forms, written as HTML comments:
+
+```
+<!-- ste-ai-ignore-next-line [rule-id, rule-id] -- reason text -->
+<!-- ste-ai-ignore-start [rule-id, rule-id] -- reason text -->
+<!-- ste-ai-ignore-end -->
+```
+
+- The keyword is the first token inside the comment, and keywords are case-sensitive.
+- Rule ids are separated by commas and/or whitespace and appear before the separator, which is a
+  double hyphen with a space on each side. An empty list means every rule.
+- The reason is everything after the first such separator, trimmed.
+- `ste-ai-ignore-end` takes no rule ids and no reason.
+- The same HTML-comment form is used in `markdown` and in `text` documents. In markdown a comment
+  is already a protected region and produces no prose; in `text` it is ordinary prose, so the
+  scanner reads the source directly rather than relying on protected regions.
+
+### A reason is required
+
+A directive with no reason, or with an empty reason, is **not applied**. It is inert, the finding
+it named is still reported, and `suppression-reason-missing` is emitted.
+
+This is the one piece of syntax with no convenience form. A suppression without a reason is
+indistinguishable from a mistake six months later, and a linter that lets a reader see the silence
+but not the argument for it has replaced one unverified claim with another.
+
+## What a directive claims
+
+| Form                      | Span claimed                                                                                          |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `ste-ai-ignore-next-line` | the whole of the next eligible line after the line containing the directive, including its terminator |
+| `ste-ai-ignore-start`     | from the end of the `ignore-start` comment to the start of the matching `ignore-end`                  |
+| `ste-ai-ignore-end`       | nothing; it closes the open `ignore-start`                                                            |
+
+A line is **eligible** for `ste-ai-ignore-next-line` when it contains at least one non-whitespace
+character and is not itself entirely a suppression directive. Blank lines are skipped because a
+blank line between an HTML comment and the paragraph beneath it is ordinary Markdown formatting,
+and a directive that claimed the blank line would claim nothing. Directive-only lines are skipped
+so that directives stack, each claiming the same prose line for its own rule id and its own reason:
+
+```markdown
+<!-- ste-ai-ignore-next-line unapproved-vocabulary -- "terminate" is the vendor's API verb -->
+<!-- ste-ai-ignore-next-line sentence-length-procedural -- quoted verbatim from PN-4417 -->
+
+Terminate the session before you remove the module.
+```
+
+A finding is claimed when its **start offset** falls in `[span.start, span.end)` and the
+directive's rule-id list is empty or contains the finding's rule id. Where two directives both
+claim a finding, the first in source order wins.
+
+Anchoring on the start offset rather than on span overlap is what makes a multi-line finding
+behave predictably. A sentence-length diagnostic covers a sentence that may run over four lines;
+under an overlap rule, a `next-line` directive anywhere in those four lines would claim it, and a
+reader could not tell from the directive which finding it was aimed at. Under the start-offset
+rule a finding is claimed by the line it is _reported on_ — the line the CLI prints next to it.
+
+`ste-ai-ignore-start` does not nest. A second `ignore-start` seen before an `ignore-end` closes the
+first at its own start position and emits `suppression-unclosed-range`. An `ignore-start` that is
+never closed runs to the end of the document and emits the same notice.
+
+Any finding anchored inside a directive comment itself is suppressed unconditionally, with the
+reason `directive text is not prose`. Without this, a `format: 'text'` document — where comments
+are not masked out — would report findings on the directive line, which is not text anyone wrote
+for a reader.
+
+## Configuration
+
+```jsonc
+{
+  "suppressions": {
+    // Inline directives are honoured. Set false to make every directive inert.
+    "enabled": true,
+    // Permit a directive to withhold a finding inside a danger, warning or caution admonition.
+    "allowInAdmonitions": false,
+  },
+}
+```
+
+With `suppressions.enabled: false` no scan runs at all: no directive is applied, no suppression is
+recorded, and every finding is reported as though the directives were not in the file. This is the
+setting for an audit run that needs to see what the document contains rather than what its authors
+have ruled on.
+
+## Admonitions
+
+A claim is **refused** when the block containing the anchor offset is a `danger`, `warning` or
+`caution` admonition and `allowInAdmonitions` is false, which is the default. The diagnostic is
+kept and `suppression-refused-in-admonition` is emitted at `warning`. `note` is not a safety
+register and never triggers the refusal.
+
+### Why this differs from autofix
+
+`autofix.allowInAdmonitions` is typed `z.literal(false)` (`src/core/config.ts:50`) and can never be
+set to true. `suppressions.allowInAdmonitions` is an ordinary boolean, default false. The asymmetry
+is deliberate.
+
+Rewriting the source of a safety notice and withholding a report about one are different acts. The
+first changes what a reader in front of the equipment is told, and no model verdict or rule
+substitution in this package is trusted to do that. The second changes only what the linter says
+about wording that a person has already read and ruled on; it is an operator decision, and one an
+operator is entitled to take — but only explicitly, only with a reason in the source, and always
+with the withheld finding still recorded.
+
+## Suppressions are recorded, never discarded
+
+The load-bearing rule of this project is that silence must never mean compliant
+([`diagnostic-policy.md`](./diagnostic-policy.md#service-failure-is-never-compliance)). It applies
+to a suppressed finding exactly as it applies to a passage a model failed to adjudicate: the
+finding leaves the diagnostic list, and it does not leave the result.
+
+Every withheld finding is visible on every surface that reports the run:
+
+| Surface          | Where                                                                                                                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Programmatic API | `AnalysisResult.suppressions` — rule id, category, range, the message the finding would have carried, the reason, and the directive's own span |
+| CLI `--json`     | a `suppressions` array on each file's result object                                                                                            |
+| CLI human output | one `suppressed  {ruleId} at {line}:{column} — {reason}` line per record                                                                       |
+| Run notices      | `suppressions-applied` at `info`, once per run, with the count                                                                                 |
+
+Exit-code logic is unchanged by this feature. A suppressed diagnostic is simply not in the
+diagnostic list, so a suppression can turn exit `1` into exit `0`. That is what a suppression is
+for; the record of what was withheld is what makes it auditable rather than invisible.
+
+### A suppressed candidate is never sent to the model
+
+Candidates are filtered before adjudication, not after. A candidate whose start offset is claimed
+for its rule id is dropped from the run before anything else happens to it, and recorded as a
+suppression with category `review-required` and the candidate's own reason as its message.
+
+Two consequences, both intended. An operator who has already ruled on a passage does not pay for a
+model to adjudicate it again. And the text of that passage never leaves the process — a suppression
+is therefore also the mechanism for keeping a specific passage away from a semantic service.
+
+## Notice codes
+
+| Code                                | Level     | Detail                   | Meaning                                                                  |
+| ----------------------------------- | --------- | ------------------------ | ------------------------------------------------------------------------ |
+| `suppressions-applied`              | `info`    | `{ count }`              | emitted once when at least one finding was withheld                      |
+| `suppression-reason-missing`        | `warning` | `{ line }`               | directive ignored                                                        |
+| `suppression-unknown-rule`          | `warning` | `{ ruleId }`             | the named id is not a known rule; it never matches                       |
+| `suppression-unclosed-range`        | `warning` | `{ line }`               | `ignore-start` with no `ignore-end`                                      |
+| `suppression-end-without-start`     | `warning` | `{ line }`               | stray `ignore-end`                                                       |
+| `suppression-unused`                | `info`    | `{ line }`               | the directive claimed nothing — keeps dead suppressions reviewable       |
+| `suppression-refused-in-admonition` | `warning` | `{ ruleId, admonition }` | the claim was refused and the diagnostic kept                            |
+| `suppression-malformed`             | `warning` | `{ line }`               | the comment starts `ste-ai-ignore` but parses as none of the three forms |
+
+`line` values are 1-based.
+
+`suppression-unused` exists because a suppression that no longer claims anything is the same
+problem as a stale comment: the sentence it was written for may have been rewritten, and nobody
+finds out unless the tool says so.
+
+## Known limitation: suppressions are not visible in a textlint report
+
+The textlint adapter surfaces run notices only at `warning` and `error`
+(`src/textlint/adapter.ts:215`), so the `info`-level `suppressions-applied` and
+`suppression-unused` notices do not reach a textlint report. Suppressed diagnostics themselves
+never reach the adapter at all, by design — suppressing a finding is the core's decision, expressed
+by not producing the diagnostic.
+
+The consequence is that `npx textlint` shows a clean file and gives no indication of how much was
+withheld to make it clean. Audit suppressions through the CLI or the programmatic API instead:
+
+```bash
+npx ste-ai lint docs/install.md --json    # per-file `suppressions` array
+npx ste-ai lint docs/install.md           # `suppressed` lines under each file
+```
+
+The `warning`-level suppression notices — a missing reason, an unknown rule id, an unclosed range,
+a refused claim in an admonition — do reach a textlint report.
+
+## Example
+
+```markdown
+<!-- ste-ai-ignore-next-line unapproved-vocabulary -- "terminate" is the vendor's API verb, PN-4417 -->
+
+Terminate the session before you remove the module.
+
+<!-- ste-ai-ignore-start sentence-length-descriptive -- quoted verbatim from the supplier manual -->
+
+The controller monitors the bus continuously and, if it detects a fault condition that persists for
+longer than the configured interval, isolates the affected segment and raises an alarm.
+
+<!-- ste-ai-ignore-end -->
+```
+
+Both findings are withheld from `diagnostics`, both appear in `suppressions` with their reasons,
+and `suppressions-applied` reports a count of two.

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -39,17 +39,27 @@ but not the argument for it has replaced one unverified claim with another.
 
 ## What a directive claims
 
-| Form                      | Span claimed                                                                                          |
-| ------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `ste-ai-ignore-next-line` | the whole of the next eligible line after the line containing the directive, including its terminator |
-| `ste-ai-ignore-start`     | from the end of the `ignore-start` comment to the start of the matching `ignore-end`                  |
-| `ste-ai-ignore-end`       | nothing; it closes the open `ignore-start`                                                            |
+| Form                      | Span claimed                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `ste-ai-ignore-next-line` | the next block of prose                                                              |
+| `ste-ai-ignore-start`     | from the end of the `ignore-start` comment to the start of the matching `ignore-end` |
+| `ste-ai-ignore-end`       | nothing; it closes the open `ignore-start`                                           |
 
-A line is **eligible** for `ste-ai-ignore-next-line` when it contains at least one non-whitespace
-character and is not itself entirely a suppression directive. Blank lines are skipped because a
-blank line between an HTML comment and the paragraph beneath it is ordinary Markdown formatting,
-and a directive that claimed the blank line would claim nothing. Directive-only lines are skipped
-so that directives stack, each claiming the same prose line for its own rule id and its own reason:
+**A block, not a line.** `ste-ai-ignore-next-line` claims the first block whose end lies after the
+directive, with the span clamped to begin at the directive's own end. A block is a paragraph, a
+heading, a list item, a table cell, a block quote or a caption — the same unit every rule works in.
+
+The keyword keeps the name every other linter uses, because that is the name a reader reaches for.
+What it claims is a block, and the distinction matters in three places:
+
+- **A soft-wrapped paragraph is one block**, so the claim does not move when the prose is rewrapped.
+  See [Reformatting the prose](#reformatting-the-prose).
+- **A directive written directly above its paragraph, with no blank line, is absorbed into that
+  paragraph's block** — the block therefore starts before the directive. The clamp is what keeps
+  such a directive claiming the rest of its own paragraph rather than the prose above it.
+- **Blank lines and blockquote markers need no special handling.** A directive separated from its
+  paragraph by a blank line produces no block of its own in markdown, and a directive inside a
+  blockquote is not prose either, so stacking works in both without a rule for either:
 
 ```markdown
 <!-- ste-ai-ignore-next-line unapproved-vocabulary -- "terminate" is the vendor's API verb -->
@@ -57,6 +67,12 @@ so that directives stack, each claiming the same prose line for its own rule id 
 
 Terminate the session before you remove the module.
 ```
+
+Both directives above claim the same paragraph, each for its own rule id and its own reason.
+
+Claiming a block is wider than claiming a line: a directive above a paragraph of five sentences
+covers all five for the rule ids it names. Name the rule ids to keep the claim narrow, and prefer a
+directive per paragraph over a range covering several.
 
 A finding is claimed when its **start offset** falls in `[span.start, span.end)` and the
 directive's rule-id list is empty or contains the finding's rule id. Where two directives both
@@ -79,26 +95,31 @@ for a reader.
 
 ### Reformatting the prose
 
-Because `ste-ai-ignore-next-line` claims exactly one line, a formatter that rewraps prose can move
-the offending text off the claimed line and the suppression stops applying. Measured on a
-paragraph reflowed so the offending word moved to the second line:
+Rewrapping a paragraph does not change what a directive claims. This linter reads wording, not
+whitespace: a soft wrap is not a boundary any part of the analysis recognises, so the same prose
+wrapped and unwrapped is the same prose.
 
-| Document                                          | Finding reported | Withheld | `suppression-unused` |
-| ------------------------------------------------- | ---------------: | -------: | -------------------: |
-| directive, offending word on the next line        |                0 |        1 |                    0 |
-| directive, word reflowed onto the second line     |                1 |        0 |                    1 |
-| `ignore-start` / `ignore-end` over the same prose |                0 |        1 |                    0 |
-| no directive, for comparison                      |                1 |        0 |                    0 |
+Measured over the same three sentences written as one long line and as six soft-wrapped ones:
 
-Prettier does not rewrap prose unless it is configured to. Its `proseWrap` option defaults to
-`preserve`, and this repository sets no value for it, so running Prettier over a document does not
-move a claimed line. A formatter run with `proseWrap: always`, or an author rewrapping a paragraph
-by hand, does.
+| Property           | Unwrapped | Wrapped   |
+| ------------------ | --------- | --------- |
+| lines              | 1         | 6         |
+| blocks             | 1         | 1         |
+| sentences          | 3         | 3         |
+| words per sentence | 12, 24, 8 | 12, 24, 8 |
+| diagnostics        | —         | identical |
+| candidates         | —         | identical |
 
-Note the second row: the finding comes back **and** `suppression-unused` is emitted. Drift of this
-kind fails towards reporting, never towards false silence, and the notice names the line so the
-directive can be moved. Where prose is expected to be reflowed, prefer the range form, which is not
-sensitive to where a line ends.
+Suppressions inherit that property from the block unit, and a test asserts it directly: the same
+paragraph, wrapped and unwrapped, withholds the same findings and emits no `suppression-unused`.
+
+An earlier revision of this feature claimed a physical line, and a paragraph rewrapped so the
+offending word moved to a later line stopped being covered. That is fixed. It is recorded here
+because the failure was instructive: the line was the only unit in this package that whitespace
+could move, and it was borrowed from linters that read code, where a line is structural.
+
+Line breaks that _are_ structural — a table row, a list item, a heading — are block boundaries and
+continue to be honoured as such.
 
 ## Configuration
 

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -156,6 +156,14 @@ interface CandidateSuppressionPass {
   readonly records: readonly SuppressionRecord[];
   /** Directives that claimed a candidate, so the applier does not call them dead. */
   readonly claimed: readonly SuppressionDirective[];
+  /**
+   * Candidates refused inside a safety admonition, already reported here.
+   *
+   * A refused candidate proceeds to adjudication and produces a diagnostic that `applySuppressions`
+   * will match against the very same directive — passed through so it does not report the same
+   * refusal a second time.
+   */
+  readonly refused: readonly { readonly ruleId: string; readonly range: SourceRange }[];
 }
 
 /**
@@ -174,7 +182,7 @@ function suppressCandidates(
   // `enabled: false` means the document is not read for directives at all, not that the directives
   // are parsed and ignored — an audit run must see the document as written.
   if (!config.suppressions.enabled) {
-    return { directives: [], notices: [], candidates, records: [], claimed: [] };
+    return { directives: [], notices: [], candidates, records: [], claimed: [], refused: [] };
   }
 
   const scan = scanSuppressions(document);
@@ -182,6 +190,7 @@ function suppressCandidates(
   const kept: CandidatePassage[] = [];
   const records: SuppressionRecord[] = [];
   const claimed = new Set<SuppressionDirective>();
+  const refused: { ruleId: string; range: SourceRange }[] = [];
 
   for (const candidate of candidates) {
     // Unconditional, and ahead of any directive match: in `format: 'text'` the comment is not
@@ -215,6 +224,7 @@ function suppressCandidates(
     );
     if (refusal !== undefined) {
       notices.push(refusal);
+      refused.push({ ruleId: candidate.ruleId, range: candidate.range });
       kept.push(redactDirectiveComments(candidate, scan.commentRanges));
       continue;
     }
@@ -222,7 +232,14 @@ function suppressCandidates(
     records.push(candidateRecord(candidate, directive.reason, directive.directiveRange));
   }
 
-  return { directives: scan.directives, notices, candidates: kept, records, claimed: [...claimed] };
+  return {
+    directives: scan.directives,
+    notices,
+    candidates: kept,
+    records,
+    claimed: [...claimed],
+    refused,
+  };
 }
 
 /**
@@ -299,6 +316,7 @@ function suppressDiagnostics(
     allowInAdmonitions: config.suppressions.allowInAdmonitions,
     knownRuleIds: deterministicRules.map((rule) => rule.meta.id),
     alreadyClaimed: pass.claimed,
+    alreadyRefused: pass.refused,
   });
 
   const suppressions = [...pass.records, ...applied.suppressions].sort(

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -1,6 +1,7 @@
 import { resolveConfig, type SteAiConfig, type SteAiConfigInput } from '../core/config.js';
 import { analyseDocument } from '../core/document.js';
 import { runDeterministicRules } from '../core/runner.js';
+import { applySuppressions, directiveFor, scanSuppressions } from '../core/suppressions.js';
 import type {
   AnalysedDocument,
   CandidatePassage,
@@ -9,6 +10,8 @@ import type {
   RulePack,
   RunNotice,
   SemanticTrace,
+  SuppressionDirective,
+  SuppressionRecord,
 } from '../core/types.js';
 import { deterministicRules } from '../deterministic/index.js';
 import { LlamaCppClient } from '../model-client/llama-client.js';
@@ -50,6 +53,14 @@ export interface AnalysisResult {
    * spans, and recomputing it from diagnostics would not recover the evaluator routing or payload.
    */
   readonly candidates: readonly CandidatePassage[];
+  /**
+   * Findings an inline directive withheld, with the reason the author gave.
+   *
+   * A suppression is an authored claim, not a deletion. `docs/diagnostic-policy.md` forbids silence
+   * from meaning compliance, so what was withheld leaves the diagnostic list and stays in the
+   * result.
+   */
+  readonly suppressions: readonly SuppressionRecord[];
   readonly notices: readonly RunNotice[];
   readonly traces: readonly SemanticTrace[];
   readonly pack: RulePack;
@@ -83,29 +94,159 @@ export function analyseTextDeterministic(
 
   const run = runDeterministicRules({ doc: document, rules: deterministicRules, config, pack });
 
+  const pass = suppressCandidates(document, run.candidates, config);
+
   // Candidates are passages no deterministic rule could decide. Returning only `run.diagnostics`
   // discarded them, so a document whose only findings needed adjudication reported clean — the
   // exact "silence means compliant" failure the diagnostic policy exists to prevent.
   const undecided = undecidedCandidateDiagnostics(
-    run.candidates,
+    pass.candidates,
     config,
     verifiedAuthority(pack, config.trustedRulePackIds),
   );
 
+  const suppressed = suppressDiagnostics(
+    document,
+    [...run.diagnostics, ...undecided.diagnostics],
+    pass,
+    config,
+  );
+
   return {
     document,
-    candidates: run.candidates,
-    diagnostics: [...run.diagnostics, ...undecided.diagnostics].sort(
+    candidates: pass.candidates,
+    suppressions: suppressed.suppressions,
+    diagnostics: [...suppressed.diagnostics].sort(
       (a, b) =>
         a.range.start - b.range.start ||
         a.range.end - b.range.end ||
         a.ruleId.localeCompare(b.ruleId),
     ),
-    notices: [...run.notices, ...undecided.notices],
+    notices: [...run.notices, ...undecided.notices, ...suppressed.notices],
     traces: [],
     pack,
     config,
   };
+}
+
+/** What the candidate pass removed, and what the diagnostic pass needs to know about it. */
+interface CandidateSuppressionPass {
+  readonly directives: readonly SuppressionDirective[];
+  readonly notices: readonly RunNotice[];
+  /** The candidates that survived. */
+  readonly candidates: readonly CandidatePassage[];
+  readonly records: readonly SuppressionRecord[];
+  /** Directives that claimed a candidate, so the applier does not call them dead. */
+  readonly claimed: readonly SuppressionDirective[];
+}
+
+/**
+ * Scan for inline directives and drop every candidate one of them claims.
+ *
+ * Candidates are filtered here — before adjudication — rather than alongside the diagnostics.
+ * Filtering afterwards would withhold the diagnostic but still have sent the passage to the model:
+ * an operator who has already ruled on a passage would keep paying for it to be re-adjudicated, and
+ * text they had deliberately marked as settled would still leave the process.
+ */
+function suppressCandidates(
+  document: AnalysedDocument,
+  candidates: readonly CandidatePassage[],
+  config: SteAiConfig,
+): CandidateSuppressionPass {
+  // `enabled: false` means the document is not read for directives at all, not that the directives
+  // are parsed and ignored — an audit run must see the document as written.
+  if (!config.suppressions.enabled) {
+    return { directives: [], notices: [], candidates, records: [], claimed: [] };
+  }
+
+  const scan = scanSuppressions(document);
+  const kept: CandidatePassage[] = [];
+  const records: SuppressionRecord[] = [];
+  const claimed = new Set<SuppressionDirective>();
+
+  for (const candidate of candidates) {
+    const directive = directiveFor(scan.directives, candidate.ruleId, candidate.range.start);
+    if (directive === undefined) {
+      kept.push(candidate);
+      continue;
+    }
+    claimed.add(directive);
+    records.push({
+      ruleId: candidate.ruleId,
+      // A candidate would have become a `review-required` diagnostic had it survived, so that is
+      // what the record says was withheld.
+      category: 'review-required',
+      range: candidate.range,
+      message: candidate.reason,
+      reason: directive.reason,
+      directiveRange: directive.directiveRange,
+    });
+  }
+
+  return {
+    directives: scan.directives,
+    notices: scan.notices,
+    candidates: kept,
+    records,
+    claimed: [...claimed],
+  };
+}
+
+interface DiagnosticSuppressionResult {
+  readonly diagnostics: readonly Diagnostic[];
+  readonly suppressions: readonly SuppressionRecord[];
+  readonly notices: readonly RunNotice[];
+}
+
+/** Apply the directives found by {@link suppressCandidates} to the final diagnostic list. */
+function suppressDiagnostics(
+  document: AnalysedDocument,
+  diagnostics: readonly Diagnostic[],
+  pass: CandidateSuppressionPass,
+  config: SteAiConfig,
+): DiagnosticSuppressionResult {
+  if (!config.suppressions.enabled) return { diagnostics, suppressions: [], notices: [] };
+
+  const applied = applySuppressions({
+    doc: document,
+    diagnostics,
+    directives: pass.directives,
+    allowInAdmonitions: config.suppressions.allowInAdmonitions,
+    knownRuleIds: deterministicRules.map((rule) => rule.meta.id),
+    alreadyClaimed: pass.claimed,
+  });
+
+  const suppressions = [...pass.records, ...applied.suppressions].sort(
+    (a, b) => a.range.start - b.range.start || a.ruleId.localeCompare(b.ruleId),
+  );
+
+  return {
+    diagnostics: applied.diagnostics,
+    suppressions,
+    notices: [...pass.notices, ...withRunTotal(applied.notices, suppressions.length)],
+  };
+}
+
+/**
+ * Restate `suppressions-applied` over the whole run.
+ *
+ * `applySuppressions` can only count the diagnostics it withheld; the candidates were filtered
+ * before it ran and never reach it. Left alone its count would disagree with the `suppressions`
+ * array it purports to describe, and a count that under-reports what was withheld is precisely the
+ * failure this feature's record keeping exists to prevent.
+ */
+function withRunTotal(notices: readonly RunNotice[], total: number): RunNotice[] {
+  const rest = notices.filter((notice) => notice.code !== 'suppressions-applied');
+  if (total === 0) return rest;
+  return [
+    ...rest,
+    {
+      code: 'suppressions-applied',
+      level: 'info',
+      message: `${total} finding(s) were withheld by an inline suppression directive.`,
+      detail: { count: total },
+    },
+  ];
 }
 
 /**
@@ -184,6 +325,8 @@ export async function analyseText(
 
   const run = runDeterministicRules({ doc: document, rules: deterministicRules, config, pack });
 
+  const pass = suppressCandidates(document, run.candidates, config);
+
   const transport: ModelTransport =
     options.transport ??
     new LlamaCppClient({
@@ -196,7 +339,7 @@ export async function analyseText(
 
   const semantic = await analyseSemantically({
     doc: document,
-    candidates: run.candidates,
+    candidates: pass.candidates,
     broker,
     config: config.semantic,
     policy: config.diagnostics,
@@ -210,7 +353,8 @@ export async function analyseText(
   // Overlap resolution must see deterministic and semantic fixes together.
   const merged = resolveOverlappingFixes([...run.diagnostics, ...semantic.diagnostics]);
 
-  merged.diagnostics.sort(
+  const suppressed = suppressDiagnostics(document, merged.diagnostics, pass, config);
+  const diagnostics = [...suppressed.diagnostics].sort(
     (a, b) =>
       a.range.start - b.range.start ||
       a.range.end - b.range.end ||
@@ -220,9 +364,10 @@ export async function analyseText(
 
   return {
     document,
-    candidates: run.candidates,
-    diagnostics: merged.diagnostics,
-    notices: [...run.notices, ...semantic.notices, ...merged.notices],
+    candidates: pass.candidates,
+    suppressions: suppressed.suppressions,
+    diagnostics,
+    notices: [...run.notices, ...semantic.notices, ...merged.notices, ...suppressed.notices],
     traces: semantic.traces,
     pack,
     config,

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -8,6 +8,7 @@ import {
   refuseInAdmonition,
   scanSuppressions,
 } from '../core/suppressions.js';
+import { maskRanges } from '../core/text.js';
 import type {
   AnalysedDocument,
   CandidatePassage,
@@ -197,7 +198,7 @@ function suppressCandidates(
 
     const directive = directiveFor(scan.directives, candidate.ruleId, candidate.range.start);
     if (directive === undefined) {
-      kept.push(candidate);
+      kept.push(redactDirectiveComments(candidate, scan.commentRanges));
       continue;
     }
     // Counted as used even when the claim is refused below: the directive did point at a real
@@ -214,7 +215,7 @@ function suppressCandidates(
     );
     if (refusal !== undefined) {
       notices.push(refusal);
-      kept.push(candidate);
+      kept.push(redactDirectiveComments(candidate, scan.commentRanges));
       continue;
     }
 
@@ -222,6 +223,36 @@ function suppressCandidates(
   }
 
   return { directives: scan.directives, notices, candidates: kept, records, claimed: [...claimed] };
+}
+
+/**
+ * Mask any directive-comment text caught inside a surviving candidate's passage.
+ *
+ * `passage` is built from the whole sentence a candidate's match falls in
+ * (`pushCandidate` in `src/deterministic/rules/candidate-rules.ts`), and a directive comment can
+ * share a sentence with the prose it annotates — in `format: 'text'` a comment is not masked out at
+ * all, and even in markdown a sentence can run from a comment straight into unpunctuated prose. A
+ * candidate anchored in the prose therefore is not itself suppressed, but without this its passage
+ * would still carry the comment's raw text — an unrelated rule id, another rule's reason, the
+ * directive's own reason — out to the semantic service. `docs/suppression.md` promises a suppressed
+ * passage never leaves the process; a passage that merely shares a sentence with one should not
+ * leak the directive's text either.
+ *
+ * Masked with {@link maskRanges} rather than deleted, so `passageOffset` stays a valid arithmetic
+ * base for every span in the passage, exactly as `doc.maskedText` never changes length.
+ */
+function redactDirectiveComments(
+  candidate: CandidatePassage,
+  commentRanges: readonly SourceRange[],
+): CandidatePassage {
+  const local = commentRanges
+    .map((range) => ({
+      start: range.start - candidate.passageOffset,
+      end: range.end - candidate.passageOffset,
+    }))
+    .filter((range) => range.end > 0 && range.start < candidate.passage.length);
+  if (local.length === 0) return candidate;
+  return { ...candidate, passage: maskRanges(candidate.passage, local) };
 }
 
 /**

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -99,7 +99,15 @@ export function analyseTextDeterministic(
     },
   );
 
-  const run = runDeterministicRules({ doc: document, rules: deterministicRules, config, pack });
+  // Fix conflicts are resolved below instead, once the suppressed findings are out of the list: a
+  // finding nobody will be shown must not be able to veto another finding's fix.
+  const run = runDeterministicRules({
+    doc: document,
+    rules: deterministicRules,
+    config,
+    pack,
+    resolveFixes: false,
+  });
 
   const pass = suppressCandidates(document, run.candidates, config);
 
@@ -119,17 +127,19 @@ export function analyseTextDeterministic(
     config,
   );
 
+  const resolved = resolveOverlappingFixes(suppressed.diagnostics);
+
   return {
     document,
     candidates: pass.candidates,
     suppressions: suppressed.suppressions,
-    diagnostics: [...suppressed.diagnostics].sort(
+    diagnostics: [...resolved.diagnostics].sort(
       (a, b) =>
         a.range.start - b.range.start ||
         a.range.end - b.range.end ||
         a.ruleId.localeCompare(b.ruleId),
     ),
-    notices: [...run.notices, ...undecided.notices, ...suppressed.notices],
+    notices: [...run.notices, ...undecided.notices, ...suppressed.notices, ...resolved.notices],
     traces: [],
     pack,
     config,
@@ -367,7 +377,15 @@ export async function analyseText(
     },
   );
 
-  const run = runDeterministicRules({ doc: document, rules: deterministicRules, config, pack });
+  // Overlap resolution is deferred to the merged, post-suppression list below. It has to see the
+  // semantic fixes anyway, and a withheld finding must not veto a surviving finding's fix.
+  const run = runDeterministicRules({
+    doc: document,
+    rules: deterministicRules,
+    config,
+    pack,
+    resolveFixes: false,
+  });
 
   const pass = suppressCandidates(document, run.candidates, config);
 
@@ -394,11 +412,17 @@ export async function analyseText(
     ...(options.signal === undefined ? {} : { signal: options.signal }),
   });
 
-  // Overlap resolution must see deterministic and semantic fixes together.
-  const merged = resolveOverlappingFixes([...run.diagnostics, ...semantic.diagnostics]);
+  const suppressed = suppressDiagnostics(
+    document,
+    [...run.diagnostics, ...semantic.diagnostics],
+    pass,
+    config,
+  );
 
-  const suppressed = suppressDiagnostics(document, merged.diagnostics, pass, config);
-  const diagnostics = [...suppressed.diagnostics].sort(
+  // Overlap resolution must see deterministic and semantic fixes together, and must see only the
+  // findings that survived suppression.
+  const merged = resolveOverlappingFixes(suppressed.diagnostics);
+  const diagnostics = [...merged.diagnostics].sort(
     (a, b) =>
       a.range.start - b.range.start ||
       a.range.end - b.range.end ||
@@ -411,7 +435,7 @@ export async function analyseText(
     candidates: pass.candidates,
     suppressions: suppressed.suppressions,
     diagnostics,
-    notices: [...run.notices, ...semantic.notices, ...merged.notices, ...suppressed.notices],
+    notices: [...run.notices, ...semantic.notices, ...suppressed.notices, ...merged.notices],
     traces: semantic.traces,
     pack,
     config,

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -1,7 +1,13 @@
 import { resolveConfig, type SteAiConfig, type SteAiConfigInput } from '../core/config.js';
 import { analyseDocument } from '../core/document.js';
 import { runDeterministicRules } from '../core/runner.js';
-import { applySuppressions, directiveFor, scanSuppressions } from '../core/suppressions.js';
+import {
+  applySuppressions,
+  DIRECTIVE_TEXT_REASON,
+  directiveFor,
+  refuseInAdmonition,
+  scanSuppressions,
+} from '../core/suppressions.js';
 import type {
   AnalysedDocument,
   CandidatePassage,
@@ -10,6 +16,7 @@ import type {
   RulePack,
   RunNotice,
   SemanticTrace,
+  SourceRange,
   SuppressionDirective,
   SuppressionRecord,
 } from '../core/types.js';
@@ -160,35 +167,72 @@ function suppressCandidates(
   }
 
   const scan = scanSuppressions(document);
+  const notices: RunNotice[] = [...scan.notices];
   const kept: CandidatePassage[] = [];
   const records: SuppressionRecord[] = [];
   const claimed = new Set<SuppressionDirective>();
 
   for (const candidate of candidates) {
+    // Unconditional, and ahead of any directive match: in `format: 'text'` the comment is not
+    // masked, so the reason an author wrote inside one is lintable prose and would otherwise be
+    // shipped to the model — spending a request on text nobody wrote for a reader, and sending the
+    // very passage the directive exists to keep in the process.
+    const commentRange = scan.commentRanges.find(
+      (range) => candidate.range.start >= range.start && candidate.range.start < range.end,
+    );
+    if (commentRange !== undefined) {
+      records.push(candidateRecord(candidate, DIRECTIVE_TEXT_REASON, commentRange));
+      continue;
+    }
+
     const directive = directiveFor(scan.directives, candidate.ruleId, candidate.range.start);
     if (directive === undefined) {
       kept.push(candidate);
       continue;
     }
+    // Counted as used even when the claim is refused below: the directive did point at a real
+    // passage, so `suppression-unused` would be a second and misleading complaint about it.
     claimed.add(directive);
-    records.push({
-      ruleId: candidate.ruleId,
-      // A candidate would have become a `review-required` diagnostic had it survived, so that is
-      // what the record says was withheld.
-      category: 'review-required',
-      range: candidate.range,
-      message: candidate.reason,
-      reason: directive.reason,
-      directiveRange: directive.directiveRange,
-    });
+
+    // A refused claim leaves the candidate in the run, so the passage is still adjudicated and
+    // still reported. Withholding it here would silence a safety notice more completely than any
+    // directive aimed at a diagnostic can.
+    const refusal = refuseInAdmonition(
+      candidate.ruleId,
+      candidate.admonition,
+      config.suppressions.allowInAdmonitions,
+    );
+    if (refusal !== undefined) {
+      notices.push(refusal);
+      kept.push(candidate);
+      continue;
+    }
+
+    records.push(candidateRecord(candidate, directive.reason, directive.directiveRange));
   }
 
+  return { directives: scan.directives, notices, candidates: kept, records, claimed: [...claimed] };
+}
+
+/**
+ * A record for a candidate withheld before adjudication.
+ *
+ * `review-required` is the category the candidate would have carried had it survived, so that is
+ * what the record says was withheld; its `reason` field is the candidate's own, which is the
+ * message the diagnostic would have explained itself with.
+ */
+function candidateRecord(
+  candidate: CandidatePassage,
+  reason: string,
+  directiveRange: SourceRange,
+): SuppressionRecord {
   return {
-    directives: scan.directives,
-    notices: scan.notices,
-    candidates: kept,
-    records,
-    claimed: [...claimed],
+    ruleId: candidate.ruleId,
+    category: 'review-required',
+    range: candidate.range,
+    message: candidate.reason,
+    reason,
+    directiveRange,
   };
 }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,7 +3,7 @@ import { readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { analyseText, analyseTextDeterministic } from '../analysis/analyse.js';
 import type { SteAiConfigInput } from '../core/config.js';
-import type { Diagnostic, RunNotice } from '../core/types.js';
+import type { AnalysedDocument, Diagnostic, RunNotice, SuppressionRecord } from '../core/types.js';
 import { deterministicRules } from '../deterministic/index.js';
 import { evaluatorDefinitions } from '../semantic/evaluators.js';
 import { packPermitsConformanceClaim, verifiedAuthority } from '../rule-pack/loader.js';
@@ -141,10 +141,15 @@ async function lint(args: Args): Promise<number> {
     file: string;
     diagnostics: Diagnostic[];
     notices: readonly RunNotice[];
+    suppressions: readonly SuppressionRecord[];
     packAuthority: string;
     declaredAuthority: string;
     conformanceClaim: string;
   }[] = [];
+
+  // Kept beside `results` rather than in it: the entries above are serialised verbatim by `--json`,
+  // and a document is neither serialisable nor anything a consumer of that output asked for.
+  const documents: AnalysedDocument[] = [];
 
   for (const file of args.files) {
     const text = readFileSync(file, 'utf8');
@@ -168,10 +173,12 @@ async function lint(args: Args): Promise<number> {
             },
           },
         });
+    documents.push(analysis.document);
     results.push({
       file,
       diagnostics: analysis.diagnostics.filter((d) => SEVERITY_ORDER[d.severity] >= threshold),
       notices: analysis.notices,
+      suppressions: analysis.suppressions,
       packAuthority: verifiedAuthority(analysis.pack, analysis.config.trustedRulePackIds),
       declaredAuthority: analysis.pack.metadata.authority,
       conformanceClaim: packPermitsConformanceClaim(
@@ -213,7 +220,7 @@ async function lint(args: Args): Promise<number> {
       )}\n`,
     );
   } else {
-    for (const result of results) {
+    for (const [index, result] of results.entries()) {
       process.stdout.write(`\n${result.file}\n`);
       if (result.diagnostics.length === 0) {
         process.stdout.write('  no diagnostics\n');
@@ -231,6 +238,16 @@ async function lint(args: Args): Promise<number> {
       for (const notice of result.notices) {
         process.stdout.write(
           `  notice  ${notice.level.padEnd(7)} ${notice.code}: ${notice.message}\n`,
+        );
+      }
+      // What a suppression withheld is printed even though it is not a diagnostic: a run that says
+      // nothing about the findings an author ruled out is a run that reports silence as compliance.
+      const document = documents[index];
+      for (const suppression of result.suppressions) {
+        const position = document?.positionAt(suppression.range.start);
+        process.stdout.write(
+          `  suppressed  ${suppression.ruleId} at ${position?.line ?? 0}:${position?.column ?? 0}` +
+            ` — ${suppression.reason}\n`,
         );
       }
     }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -245,8 +245,12 @@ async function lint(args: Args): Promise<number> {
       const document = documents[index];
       for (const suppression of result.suppressions) {
         const position = document?.positionAt(suppression.range.start);
+        // `positionAt` returns the textlint AST's 0-based column, which is right for an AST and
+        // wrong for a line a person reads next to their editor's gutter. The JSON range is left
+        // as the raw offset it is.
+        const column = position === undefined ? 1 : position.column + 1;
         process.stdout.write(
-          `  suppressed  ${suppression.ruleId} at ${position?.line ?? 0}:${position?.column ?? 0}` +
+          `  suppressed  ${suppression.ruleId} at ${position?.line ?? 1}:${column}` +
             ` — ${suppression.reason}\n`,
         );
       }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -58,6 +58,21 @@ export const autofixPolicySchema = z.object({
 
 export type AutofixPolicy = z.output<typeof autofixPolicySchema>;
 
+export const suppressionPolicySchema = z.object({
+  /**
+   * Inline directives are honoured. When false the document is not scanned at all: no directive
+   * is parsed, no record is produced and no suppression notice is emitted.
+   */
+  enabled: z.boolean().default(true),
+  /**
+   * Permit an inline directive to withhold a finding inside a danger, warning or caution
+   * admonition. Off by default, and every such suppression is recorded either way.
+   */
+  allowInAdmonitions: z.boolean().default(false),
+});
+
+export type SuppressionPolicy = z.output<typeof suppressionPolicySchema>;
+
 export const semanticConfigSchema = z.object({
   enabled: z.boolean().default(false),
   /** llama.cpp server base URL. The OpenAI-compatible `/v1/chat/completions` route is used. */
@@ -125,6 +140,7 @@ export const steAiConfigSchema = z.object({
   autofix: autofixPolicySchema.prefault({}),
   semantic: semanticConfigSchema.prefault({}),
   diagnostics: diagnosticPolicySchema.prefault({}),
+  suppressions: suppressionPolicySchema.prefault({}),
   /** Per-rule options, keyed by bare rule id (for example `sentence-length-procedural`). */
   rules: z.record(z.string(), ruleUserConfigSchema).prefault({}),
 });

--- a/src/core/document.ts
+++ b/src/core/document.ts
@@ -31,7 +31,7 @@ import type {
  * Protected kinds that are pure markup. They must stay visible while blocks are being scanned
  * (the scanner needs the markers to find blocks) and they contribute no words.
  */
-const STRUCTURAL_MARKER_KINDS: ReadonlySet<ProtectedRegionKind> = new Set([
+export const STRUCTURAL_MARKER_KINDS: ReadonlySet<ProtectedRegionKind> = new Set([
   'list-marker',
   'heading-marker',
   'blockquote-marker',

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,4 +7,5 @@ export * from './document.js';
 export * from './config.js';
 export * from './rule.js';
 export * from './runner.js';
+export * from './suppressions.js';
 export { IMPERATIVE_VERBS } from './imperative-verbs.js';

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -24,6 +24,15 @@ export interface RunOptions {
   readonly pack: RulePack;
   /** Restrict the run to a single rule id. Used by the per-rule textlint adapters. */
   readonly onlyRuleId?: string;
+  /**
+   * Resolve overlapping fixes before returning. Default true.
+   *
+   * The analysis layer sets it false and resolves after inline suppression has run instead. A
+   * withheld diagnostic must not count as a party to a fix conflict: resolving first left the
+   * survivor of a suppressed pair permanently unfixable, and emitted an `overlapping-fixes-refused`
+   * notice describing a disagreement with a diagnostic that is not in the output.
+   */
+  readonly resolveFixes?: boolean;
 }
 
 /**
@@ -104,7 +113,10 @@ export function runDeterministicRules(options: RunOptions): DeterministicRunResu
     candidates.push(...output.candidates);
   }
 
-  const { diagnostics: resolved, notices: fixNotices } = resolveOverlappingFixes(diagnostics);
+  const { diagnostics: resolved, notices: fixNotices } =
+    (options.resolveFixes ?? true)
+      ? resolveOverlappingFixes(diagnostics)
+      : { diagnostics, notices: [] };
   notices.push(...fixNotices);
 
   resolved.sort(

--- a/src/core/structure.ts
+++ b/src/core/structure.ts
@@ -113,6 +113,40 @@ export function detectAdmonition(line: string): AdmonitionKind {
   return 'none';
 }
 
+/**
+ * Whether `line` is a "bare" admonition opener — mkdocs (`!!! warning`), a MyST fence
+ * (`:::warning` / `:::{warning}`), a GFM alert (`> [!WARNING]`), or an RST/MyST directive
+ * (`.. warning::`) — that names a register and carries no prose of its own.
+ *
+ * Exported so a caller outside block scanning can recognise the same "this line only opens a
+ * register" shape without re-deriving the patterns. `suppressions.ts`'s gap check is the reason:
+ * a `next-line` directive written above one of these lines is pointing at the block the line
+ * introduces, not stepping over content the author wrote, and it has to use exactly this test to
+ * agree with what `scanBlocks` itself already decided.
+ */
+export function isBareAdmonitionOpener(line: string): boolean {
+  return (
+    /^\s*(?:!!!|\?\?\?)\+?\s+[A-Za-z]+\s*(?:"[^"]*")?\s*$/.test(line) ||
+    /^\s*:{3,}\s*\{?[A-Za-z]+\}?\s*$/.test(line) ||
+    /^\s*>\s*\[![A-Za-z]+\]\s*$/.test(line) ||
+    // reStructuredText/MyST: `.. warning::`, optionally with a title on the same line. The body
+    // is indented under it, which is exactly the scope the indent container models.
+    RST_DIRECTIVE_RE.test(line)
+  );
+}
+
+/**
+ * Whether `line` is an AsciiDoc block label — `[WARNING]` alone on its own line — naming the
+ * register of the block that follows without itself carrying prose.
+ *
+ * Exported for the same reason as {@link isBareAdmonitionOpener}: `suppressions.ts` needs to
+ * recognise this shape too, even though `scanBlocks` scopes it differently (one block only,
+ * rather than by indent).
+ */
+export function isAdmonitionLabelLine(line: string): boolean {
+  return ASCIIDOC_LABEL_RE.test(line);
+}
+
 // ---------------------------------------------------------------------------
 // Mode detection
 // ---------------------------------------------------------------------------
@@ -249,22 +283,14 @@ export function scanBlocks(
     // Container-only admonition openers: the line names a register and carries no prose of its
     // own, so the register belongs to what follows.
     const opener = detectAdmonition(line.raw);
-    const isBareOpener =
-      opener !== 'none' &&
-      (/^\s*(?:!!!|\?\?\?)\+?\s+[A-Za-z]+\s*(?:"[^"]*")?\s*$/.test(line.raw) ||
-        /^\s*:{3,}\s*\{?[A-Za-z]+\}?\s*$/.test(line.raw) ||
-        /^\s*>\s*\[![A-Za-z]+\]\s*$/.test(line.raw) ||
-        // reStructuredText/MyST: `.. warning::`, optionally with a title on the same line. The
-        // body is indented under it, which is exactly the scope the indent container models.
-        RST_DIRECTIVE_RE.test(line.raw));
-    if (isBareOpener) {
+    if (opener !== 'none' && isBareAdmonitionOpener(line.raw)) {
       containerAdmonition = opener;
       containerIndent = /^\s*/.exec(line.raw)?.[0].length ?? 0;
       i += 1;
       continue;
     }
     // AsciiDoc: `[WARNING]` labels the block that follows it at the same indent.
-    if (opener !== 'none' && ASCIIDOC_LABEL_RE.test(line.raw)) {
+    if (opener !== 'none' && isAdmonitionLabelLine(line.raw)) {
       pendingAdmonition = opener;
       i += 1;
       continue;

--- a/src/core/suppressions.ts
+++ b/src/core/suppressions.ts
@@ -1,0 +1,422 @@
+import { computeLineStarts, positionAt } from './text.js';
+import type {
+  AdmonitionKind,
+  AnalysedDocument,
+  Diagnostic,
+  RunNotice,
+  SourceRange,
+  SuppressionDirective,
+  SuppressionRecord,
+} from './types.js';
+
+/**
+ * Inline suppression: an author's claim that a finding is intentional.
+ *
+ * The claim is honoured by withholding the diagnostic and **recorded** as a
+ * {@link SuppressionRecord}, never simply dropped. `docs/diagnostic-policy.md` forbids silence
+ * from meaning compliance, and an invisible suppression is exactly that.
+ *
+ * Everything here reads `doc.text` directly rather than the protected regions. In `format: 'text'`
+ * documents an HTML comment is ordinary prose — there is no comment pass in `PLAIN_TEXT_PASSES` —
+ * so a directive would be invisible to a region-based scan.
+ */
+
+/** Every directive keyword begins with this, which is also what makes a typo reportable. */
+const KEYWORD_PREFIX = 'ste-ai-ignore';
+const NEXT_LINE_KEYWORD = 'ste-ai-ignore-next-line';
+const START_KEYWORD = 'ste-ai-ignore-start';
+const END_KEYWORD = 'ste-ai-ignore-end';
+
+/** The reason separator. Spaced so that a hyphenated rule id can never be mistaken for it. */
+const REASON_SEPARATOR = ' -- ';
+
+const COMMENT_RE = /<!--([\s\S]*?)-->/g;
+
+/** Safety registers where a suppression is refused unless the operator has opted in. */
+const GUARDED_ADMONITIONS: ReadonlySet<AdmonitionKind> = new Set<AdmonitionKind>([
+  'danger',
+  'warning',
+  'caution',
+]);
+
+const DIRECTIVE_TEXT_REASON = 'directive text is not prose';
+
+export interface SuppressionScanResult {
+  readonly directives: readonly SuppressionDirective[];
+  readonly notices: readonly RunNotice[];
+}
+
+/** A comment that looks like a directive, before it is known to be well formed. */
+interface DirectiveComment {
+  readonly directiveRange: SourceRange;
+  readonly keyword: string;
+  readonly rest: string;
+  readonly line: number;
+}
+
+/** An `ignore-start` waiting for its `ignore-end`. */
+interface OpenRange {
+  readonly directiveRange: SourceRange;
+  readonly ruleIds: readonly string[];
+  readonly reason: string;
+  readonly line: number;
+}
+
+/** Parse every inline directive in the document. Pure; reads `doc.text` only. */
+export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
+  const text = doc.text;
+  const lineStarts = computeLineStarts(text);
+  const directiveLines = directiveOnlyLines(text, lineStarts);
+  const directives: SuppressionDirective[] = [];
+  const notices: RunNotice[] = [];
+  let open: OpenRange | undefined;
+
+  const closeOpen = (endOffset: number): void => {
+    if (open === undefined) return;
+    directives.push({
+      kind: 'range',
+      directiveRange: open.directiveRange,
+      range: { start: open.directiveRange.end, end: Math.max(open.directiveRange.end, endOffset) },
+      ruleIds: open.ruleIds,
+      reason: open.reason,
+    });
+    open = undefined;
+  };
+
+  for (const comment of directiveComments(text, lineStarts)) {
+    if (comment.keyword === END_KEYWORD) {
+      if (open === undefined) {
+        notices.push(
+          notice('suppression-end-without-start', 'warning', 'A suppression range was ended', {
+            line: comment.line,
+          }),
+        );
+        continue;
+      }
+      closeOpen(comment.directiveRange.start);
+      continue;
+    }
+
+    if (comment.keyword !== NEXT_LINE_KEYWORD && comment.keyword !== START_KEYWORD) {
+      notices.push(
+        notice(
+          'suppression-malformed',
+          'warning',
+          `"${comment.keyword}" is not a suppression directive`,
+          { line: comment.line },
+        ),
+      );
+      continue;
+    }
+
+    const parsed = parseRuleIdsAndReason(comment.rest);
+    if (parsed === undefined) {
+      notices.push(
+        notice(
+          'suppression-reason-missing',
+          'warning',
+          'A suppression directive carries no reason and was ignored',
+          { line: comment.line },
+        ),
+      );
+      continue;
+    }
+
+    if (comment.keyword === NEXT_LINE_KEYWORD) {
+      directives.push({
+        kind: 'next-line',
+        directiveRange: comment.directiveRange,
+        range: nextEligibleLineRange(text, lineStarts, directiveLines, comment.directiveRange.end),
+        ruleIds: parsed.ruleIds,
+        reason: parsed.reason,
+      });
+      continue;
+    }
+
+    // Nesting is not supported: an inner start would make the reason recorded against a finding
+    // ambiguous, so the outer range is closed here and reported as unterminated.
+    if (open !== undefined) {
+      notices.push(unclosedRange(open.line));
+      closeOpen(comment.directiveRange.start);
+    }
+    open = {
+      directiveRange: comment.directiveRange,
+      ruleIds: parsed.ruleIds,
+      reason: parsed.reason,
+      line: comment.line,
+    };
+  }
+
+  if (open !== undefined) {
+    notices.push(unclosedRange(open.line));
+    closeOpen(text.length);
+  }
+
+  // A range directive is only complete once its end is seen, so the list is put back into source
+  // order — `directiveFor` resolves ties by taking the first match.
+  directives.sort(
+    (a, b) => a.directiveRange.start - b.directiveRange.start || a.range.start - b.range.start,
+  );
+  return { directives, notices };
+}
+
+/**
+ * The directive that claims a finding for `ruleId` anchored at `offset`, if any.
+ * First matching directive in source order wins.
+ */
+export function directiveFor(
+  directives: readonly SuppressionDirective[],
+  ruleId: string,
+  offset: number,
+): SuppressionDirective | undefined {
+  return directives.find(
+    (directive) =>
+      offset >= directive.range.start &&
+      offset < directive.range.end &&
+      (directive.ruleIds.length === 0 || directive.ruleIds.includes(ruleId)),
+  );
+}
+
+export interface ApplySuppressionsInput {
+  readonly doc: AnalysedDocument;
+  readonly diagnostics: readonly Diagnostic[];
+  readonly directives: readonly SuppressionDirective[];
+  readonly allowInAdmonitions: boolean;
+  /** Every rule id the run knows about, for the unknown-id notice. */
+  readonly knownRuleIds: readonly string[];
+}
+
+export interface ApplySuppressionsResult {
+  readonly diagnostics: readonly Diagnostic[];
+  readonly suppressions: readonly SuppressionRecord[];
+  readonly notices: readonly RunNotice[];
+}
+
+export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressionsResult {
+  const { doc, diagnostics, directives, allowInAdmonitions, knownRuleIds } = input;
+  const lineStarts = computeLineStarts(doc.text);
+  const known = new Set(knownRuleIds);
+  const commentRanges = directiveCommentRanges(doc.text);
+  const kept: Diagnostic[] = [];
+  const suppressions: SuppressionRecord[] = [];
+  const notices: RunNotice[] = [];
+  const claimed = new Set<SuppressionDirective>();
+
+  const reported = new Set<string>();
+  for (const directive of directives) {
+    for (const ruleId of directive.ruleIds) {
+      if (known.has(ruleId) || reported.has(ruleId)) continue;
+      reported.add(ruleId);
+      notices.push(
+        notice(
+          'suppression-unknown-rule',
+          'warning',
+          `A suppression directive names "${ruleId}", which is not a known rule, so it suppresses nothing`,
+          { ruleId },
+        ),
+      );
+    }
+  }
+
+  for (const diagnostic of diagnostics) {
+    const anchor = diagnostic.range.start;
+
+    // Every directive comment is withheld, valid or not. In `format: 'text'` the comment is not
+    // masked, so without this a directive would be reported as prose by the rules it disables.
+    const commentRange = commentRanges.find((range) => anchor >= range.start && anchor < range.end);
+    if (commentRange !== undefined) {
+      suppressions.push(record(diagnostic, DIRECTIVE_TEXT_REASON, commentRange));
+      continue;
+    }
+
+    const directive = directiveFor(directives, diagnostic.ruleId, anchor);
+    if (directive === undefined) {
+      kept.push(diagnostic);
+      continue;
+    }
+    // Counted as used even when the claim is refused below: the directive did point at a real
+    // finding, so `suppression-unused` would be a second, misleading complaint about it.
+    claimed.add(directive);
+
+    const admonition = admonitionAt(doc, anchor);
+    if (!allowInAdmonitions && GUARDED_ADMONITIONS.has(admonition)) {
+      notices.push(
+        notice(
+          'suppression-refused-in-admonition',
+          'warning',
+          `A suppression of "${diagnostic.ruleId}" was refused inside a ${admonition} admonition and the finding was kept`,
+          { ruleId: diagnostic.ruleId, admonition },
+        ),
+      );
+      kept.push(diagnostic);
+      continue;
+    }
+    suppressions.push(record(diagnostic, directive.reason, directive.directiveRange));
+  }
+
+  for (const directive of directives) {
+    if (claimed.has(directive)) continue;
+    notices.push(
+      notice('suppression-unused', 'info', 'A suppression directive claimed no finding', {
+        line: positionAt(lineStarts, directive.directiveRange.start).line,
+      }),
+    );
+  }
+
+  if (suppressions.length > 0) {
+    notices.push(
+      notice(
+        'suppressions-applied',
+        'info',
+        `${suppressions.length} finding(s) were withheld by an inline suppression directive`,
+        { count: suppressions.length },
+      ),
+    );
+  }
+
+  return { diagnostics: kept, suppressions, notices };
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function* directiveComments(
+  text: string,
+  lineStarts: readonly number[],
+): Generator<DirectiveComment> {
+  for (const match of text.matchAll(COMMENT_RE)) {
+    const body = (match[1] ?? '').trim();
+    if (!body.startsWith(KEYWORD_PREFIX)) continue;
+    const keyword = /^\S+/.exec(body)?.[0] ?? '';
+    yield {
+      directiveRange: { start: match.index, end: match.index + match[0].length },
+      keyword,
+      rest: body.slice(keyword.length),
+      line: positionAt(lineStarts, match.index).line,
+    };
+  }
+}
+
+/** Spans of every comment that opens with the keyword prefix, well formed or not. */
+function directiveCommentRanges(text: string): SourceRange[] {
+  const out: SourceRange[] = [];
+  for (const match of text.matchAll(COMMENT_RE)) {
+    if (!(match[1] ?? '').trim().startsWith(KEYWORD_PREFIX)) continue;
+    out.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return out;
+}
+
+/** `undefined` when the directive carries no reason, which makes it inert. */
+function parseRuleIdsAndReason(
+  rest: string,
+): { ruleIds: readonly string[]; reason: string } | undefined {
+  const separator = rest.indexOf(REASON_SEPARATOR);
+  if (separator < 0) return undefined;
+  const reason = rest.slice(separator + REASON_SEPARATOR.length).trim();
+  if (reason.length === 0) return undefined;
+  const ruleIds = rest
+    .slice(0, separator)
+    // Brackets are tolerated so that a reader who copies the documented shape literally is not
+    // silently left with a directive that names a rule id of "[unapproved-vocabulary".
+    .replace(/[[\]]/g, ' ')
+    .split(/[,\s]+/)
+    .filter((id) => id.length > 0);
+  return { ruleIds, reason };
+}
+
+// ---------------------------------------------------------------------------
+// Geometry
+// ---------------------------------------------------------------------------
+
+/**
+ * The whole of the next eligible line after the line holding `offset`, terminator included.
+ *
+ * Blank lines are skipped because a blank line between an HTML comment and the paragraph it
+ * annotates is ordinary Markdown formatting, and directive-only lines are skipped so that
+ * directives stack — one line of prose, one directive per rule id and reason.
+ */
+function nextEligibleLineRange(
+  text: string,
+  lineStarts: readonly number[],
+  directiveLines: ReadonlySet<number>,
+  offset: number,
+): SourceRange {
+  const line = positionAt(lineStarts, offset).line;
+  for (let index = line; index < lineStarts.length; index += 1) {
+    const start = lineStarts[index];
+    if (start === undefined) break;
+    if (directiveLines.has(index + 1)) continue;
+    const end = lineStarts[index + 1] ?? text.length;
+    if (text.slice(start, end).trim().length === 0) continue;
+    return { start, end };
+  }
+  // Nothing left to claim. An empty span claims nothing and surfaces as `suppression-unused`.
+  return { start: text.length, end: text.length };
+}
+
+/** 1-based numbers of the lines whose entire content is one directive comment. */
+function directiveOnlyLines(text: string, lineStarts: readonly number[]): Set<number> {
+  const out = new Set<number>();
+  for (let index = 0; index < lineStarts.length; index += 1) {
+    const start = lineStarts[index];
+    if (start === undefined) continue;
+    const end = lineStarts[index + 1] ?? text.length;
+    const trimmed = text.slice(start, end).trim();
+    const inner = /^<!--([\s\S]*?)-->$/.exec(trimmed)?.[1];
+    if (inner !== undefined && inner.trim().startsWith(KEYWORD_PREFIX)) out.add(index + 1);
+  }
+  return out;
+}
+
+/** The safety register of the block holding `offset`; `'none'` when no block does. */
+function admonitionAt(doc: AnalysedDocument, offset: number): AdmonitionKind {
+  for (const block of doc.blocks) {
+    if (offset >= block.range.start && offset < block.range.end) return block.admonition;
+  }
+  return 'none';
+}
+
+// ---------------------------------------------------------------------------
+// Construction helpers
+// ---------------------------------------------------------------------------
+
+function record(
+  diagnostic: Diagnostic,
+  reason: string,
+  directiveRange: SourceRange,
+): SuppressionRecord {
+  return {
+    ruleId: diagnostic.ruleId,
+    category: diagnostic.category,
+    range: diagnostic.range,
+    message: diagnostic.message,
+    reason,
+    directiveRange,
+  };
+}
+
+function notice(
+  code: string,
+  level: RunNotice['level'],
+  message: string,
+  detail: Readonly<Record<string, string | number | boolean>>,
+): RunNotice {
+  const line = detail['line'];
+  return {
+    code,
+    level,
+    message: typeof line === 'number' ? `${message} (line ${line}).` : `${message}.`,
+    detail,
+  };
+}
+
+function unclosedRange(line: number): RunNotice {
+  return notice(
+    'suppression-unclosed-range',
+    'warning',
+    'A suppression range was never ended and runs to the next range or the end of the document',
+    { line },
+  );
+}

--- a/src/core/suppressions.ts
+++ b/src/core/suppressions.ts
@@ -184,6 +184,15 @@ export interface ApplySuppressionsInput {
   readonly allowInAdmonitions: boolean;
   /** Every rule id the run knows about, for the unknown-id notice. */
   readonly knownRuleIds: readonly string[];
+  /**
+   * Directives an earlier stage already matched against something it withheld.
+   *
+   * Candidates are filtered out before the diagnostics exist, so a directive whose only target was
+   * a candidate has claimed nothing by the time this runs. Without this the caller's own successful
+   * suppression would come back as `suppression-unused`, telling an author to delete a directive
+   * that is doing exactly what it was written to do.
+   */
+  readonly alreadyClaimed?: readonly SuppressionDirective[];
 }
 
 export interface ApplySuppressionsResult {
@@ -200,7 +209,7 @@ export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressi
   const kept: Diagnostic[] = [];
   const suppressions: SuppressionRecord[] = [];
   const notices: RunNotice[] = [];
-  const claimed = new Set<SuppressionDirective>();
+  const claimed = new Set<SuppressionDirective>(input.alreadyClaimed ?? []);
 
   const reported = new Set<string>();
   for (const directive of directives) {

--- a/src/core/suppressions.ts
+++ b/src/core/suppressions.ts
@@ -1,3 +1,4 @@
+import { STRUCTURAL_MARKER_KINDS } from './document.js';
 import { computeLineStarts, positionAt } from './text.js';
 import type {
   AdmonitionKind,
@@ -448,8 +449,49 @@ function nextBlockRange(
     }
   }
   // Nothing left to claim. An empty span claims nothing and surfaces as `suppression-unused`.
-  if (chosen === undefined) return { start: doc.text.length, end: doc.text.length };
-  return { start: Math.max(chosen.start, directiveRange.end), end: chosen.end };
+  const nothing = { start: doc.text.length, end: doc.text.length };
+  if (chosen === undefined) return nothing;
+  const start = Math.max(chosen.start, directiveRange.end);
+  if (!gapIsClear(doc, commentRanges, directiveRange.end, start)) return nothing;
+  return { start, end: chosen.end };
+}
+
+/**
+ * Whether nothing but skippable material lies between a directive and the block it would claim.
+ *
+ * A claim must not travel. Content that yields no block of its own — a fenced or indented sample,
+ * an HTML block, a paragraph made entirely of protected content — was stepped over in silence, and
+ * the directive then withheld a finding in a paragraph the author had never pointed at.
+ *
+ * Three things are skippable, and only three. Whitespace, so that the reflow invariance of block
+ * claiming survives. Live directive comments, so that stacked directives keep claiming the same
+ * block. Structural markers — a list bullet, a heading's hashes, a blockquote's arrow — because a
+ * block's range begins after its own marker, so the marker is the introduction to the claimed block
+ * rather than content standing between the author and it.
+ */
+function gapIsClear(
+  doc: AnalysedDocument,
+  commentRanges: readonly SourceRange[],
+  from: number,
+  to: number,
+): boolean {
+  if (to <= from) return true;
+
+  const skippable = [
+    ...commentRanges,
+    ...doc.protectedRegions
+      .filter((region) => STRUCTURAL_MARKER_KINDS.has(region.kind))
+      .map((region) => region.range),
+  ].sort((a, b) => a.start - b.start || a.end - b.end);
+
+  let cursor = from;
+  for (const span of skippable) {
+    if (span.end <= cursor || span.start >= to) continue;
+    if (doc.text.slice(cursor, Math.min(span.start, to)).trim().length > 0) return false;
+    cursor = Math.max(cursor, span.end);
+    if (cursor >= to) return true;
+  }
+  return doc.text.slice(cursor, to).trim().length === 0;
 }
 
 /** The safety register of the block holding `offset`; `'none'` when no block does. */

--- a/src/core/suppressions.ts
+++ b/src/core/suppressions.ts
@@ -1,4 +1,5 @@
 import { STRUCTURAL_MARKER_KINDS } from './document.js';
+import { detectAdmonition, isAdmonitionLabelLine, isBareAdmonitionOpener } from './structure.js';
 import { computeLineStarts, positionAt } from './text.js';
 import type {
   AdmonitionKind,
@@ -8,6 +9,7 @@ import type {
   SourceRange,
   SuppressionDirective,
   SuppressionRecord,
+  TextBlock,
 } from './types.js';
 
 /**
@@ -96,6 +98,21 @@ export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
 
   for (const comment of directiveComments(doc, lineStarts)) {
     if (comment.keyword === END_KEYWORD) {
+      // `ste-ai-ignore-end` takes no rule ids and no reason. A typo that appends one — most
+      // plausibly a rule id, expecting it to scope the close — must not silently close the range:
+      // leaving it open is the safer failure, since it surfaces as `suppression-unclosed-range`
+      // rather than ending the region one comment early with nothing to say why.
+      if (comment.rest.trim().length > 0) {
+        notices.push(
+          notice(
+            'suppression-malformed',
+            'warning',
+            `"${comment.keyword}" takes no rule ids or reason and was not treated as a terminator`,
+            { line: comment.line },
+          ),
+        );
+        continue;
+      }
       if (open === undefined) {
         notices.push(
           notice('suppression-end-without-start', 'warning', 'A suppression range was ended', {
@@ -204,6 +221,16 @@ export interface ApplySuppressionsInput {
    * that is doing exactly what it was written to do.
    */
   readonly alreadyClaimed?: readonly SuppressionDirective[];
+  /**
+   * Candidates an earlier stage already refused to suppress inside a safety admonition, and
+   * already reported.
+   *
+   * A refused candidate is kept and proceeds to adjudication, so the diagnostic it produces
+   * reaches this function and is matched again by the same directive — without this, the same
+   * refusal is reported a second time for what is, to a reader, one decision about one passage.
+   * Identity is `(ruleId, range)`, which is what `directiveFor` itself matches on.
+   */
+  readonly alreadyRefused?: readonly { readonly ruleId: string; readonly range: SourceRange }[];
 }
 
 export interface ApplySuppressionsResult {
@@ -221,6 +248,7 @@ export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressi
   const suppressions: SuppressionRecord[] = [];
   const notices: RunNotice[] = [];
   const claimed = new Set<SuppressionDirective>(input.alreadyClaimed ?? []);
+  const alreadyRefused = input.alreadyRefused ?? [];
 
   const reported = new Set<string>();
   for (const directive of directives) {
@@ -264,7 +292,15 @@ export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressi
       allowInAdmonitions,
     );
     if (refusal !== undefined) {
-      notices.push(refusal);
+      // An earlier stage may have refused this exact candidate already and reported it there —
+      // the diagnostic it produced is not a second decision, so it must not become a second notice.
+      const alreadyReported = alreadyRefused.some(
+        (entry) =>
+          entry.ruleId === diagnostic.ruleId &&
+          entry.range.start === diagnostic.range.start &&
+          entry.range.end === diagnostic.range.end,
+      );
+      if (!alreadyReported) notices.push(refusal);
       kept.push(diagnostic);
       continue;
     }
@@ -431,7 +467,7 @@ function nextBlockRange(
   commentRanges: readonly SourceRange[],
   directiveRange: SourceRange,
 ): SourceRange {
-  let chosen: SourceRange | undefined;
+  let chosen: TextBlock | undefined;
   for (const block of doc.blocks) {
     if (block.range.end <= directiveRange.end) continue;
     const inComment = commentRanges.some(
@@ -442,18 +478,18 @@ function nextBlockRange(
     // never widened into its container.
     if (
       chosen === undefined ||
-      block.range.start < chosen.start ||
-      (block.range.start === chosen.start && block.range.end < chosen.end)
+      block.range.start < chosen.range.start ||
+      (block.range.start === chosen.range.start && block.range.end < chosen.range.end)
     ) {
-      chosen = block.range;
+      chosen = block;
     }
   }
   // Nothing left to claim. An empty span claims nothing and surfaces as `suppression-unused`.
   const nothing = { start: doc.text.length, end: doc.text.length };
   if (chosen === undefined) return nothing;
-  const start = Math.max(chosen.start, directiveRange.end);
-  if (!gapIsClear(doc, commentRanges, directiveRange.end, start)) return nothing;
-  return { start, end: chosen.end };
+  const start = Math.max(chosen.range.start, directiveRange.end);
+  if (!gapIsClear(doc, commentRanges, directiveRange.end, start, chosen.admonition)) return nothing;
+  return { start, end: chosen.range.end };
 }
 
 /**
@@ -463,17 +499,25 @@ function nextBlockRange(
  * an HTML block, a paragraph made entirely of protected content — was stepped over in silence, and
  * the directive then withheld a finding in a paragraph the author had never pointed at.
  *
- * Three things are skippable, and only three. Whitespace, so that the reflow invariance of block
- * claiming survives. Live directive comments, so that stacked directives keep claiming the same
- * block. Structural markers — a list bullet, a heading's hashes, a blockquote's arrow — because a
- * block's range begins after its own marker, so the marker is the introduction to the claimed block
- * rather than content standing between the author and it.
+ * Four things are skippable. Whitespace, so that the reflow invariance of block claiming survives.
+ * Live directive comments, so that stacked directives keep claiming the same block. Structural
+ * markers — a list bullet, a heading's hashes, a blockquote's arrow — because a block's range
+ * begins after its own marker, so the marker is the introduction to the claimed block rather than
+ * content standing between the author and it. And, when the chosen block carries an admonition, the
+ * marker line that opened that register: a GFM alert (`> [!WARNING]`), an RST/MyST directive
+ * (`.. warning::`), an mkdocs container (`!!! warning`) or an AsciiDoc label (`[WARNING]`) is
+ * exactly like a list bullet or a blockquote arrow — structure that introduces the claimed block,
+ * not prose the directive stepped over. Without this, a directive written above an admonition never
+ * claims it: the marker line is neither whitespace nor a structural-region kind, so the claim was
+ * silently voided and the safety-admonition refusal (which depends on the claim reaching the
+ * diagnostic in the first place) never had anything to refuse.
  */
 function gapIsClear(
   doc: AnalysedDocument,
   commentRanges: readonly SourceRange[],
   from: number,
   to: number,
+  blockAdmonition: AdmonitionKind,
 ): boolean {
   if (to <= from) return true;
 
@@ -482,6 +526,7 @@ function gapIsClear(
     ...doc.protectedRegions
       .filter((region) => STRUCTURAL_MARKER_KINDS.has(region.kind))
       .map((region) => region.range),
+    ...admonitionOpenerRanges(doc.text, from, to, blockAdmonition),
   ].sort((a, b) => a.start - b.start || a.end - b.end);
 
   let cursor = from;
@@ -492,6 +537,35 @@ function gapIsClear(
     if (cursor >= to) return true;
   }
   return doc.text.slice(cursor, to).trim().length === 0;
+}
+
+/**
+ * Spans, within `[from, to)`, of lines that only open `blockAdmonition` — the register the claimed
+ * block itself carries. Matched by kind, not merely by "some admonition", so a directive is never
+ * read as stepping past a *different* register's marker on its way to an unrelated block.
+ */
+function admonitionOpenerRanges(
+  text: string,
+  from: number,
+  to: number,
+  blockAdmonition: AdmonitionKind,
+): SourceRange[] {
+  if (blockAdmonition === 'none') return [];
+  const out: SourceRange[] = [];
+  let cursor = from;
+  while (cursor < to) {
+    const newline = text.indexOf('\n', cursor);
+    const lineEnd = newline === -1 || newline >= to ? to : newline + 1;
+    const raw = text.slice(cursor, lineEnd).replace(/\n$/, '');
+    if (
+      detectAdmonition(raw) === blockAdmonition &&
+      (isBareAdmonitionOpener(raw) || isAdmonitionLabelLine(raw))
+    ) {
+      out.push({ start: cursor, end: lineEnd });
+    }
+    cursor = lineEnd;
+  }
+  return out;
 }
 
 /** The safety register of the block holding `offset`; `'none'` when no block does. */

--- a/src/core/suppressions.ts
+++ b/src/core/suppressions.ts
@@ -32,15 +32,6 @@ const REASON_SEPARATOR = ' -- ';
 
 const COMMENT_RE = /<!--([\s\S]*?)-->/g;
 
-/**
- * Blockquote markers, stripped before a line is tested for being nothing but a directive.
- *
- * `> <!-- ... -->` is a directive line in every sense that matters: the marker is structural markup,
- * not content. Without this, stacked directives inside a blockquote each claimed the next one's
- * line instead of the prose beneath them.
- */
-const BLOCKQUOTE_PREFIX = /^[ \t]*(?:>[ \t]*)+/;
-
 /** Safety registers where a suppression is refused unless the operator has opted in. */
 const GUARDED_ADMONITIONS: ReadonlySet<AdmonitionKind> = new Set<AdmonitionKind>([
   'danger',
@@ -85,7 +76,7 @@ interface OpenRange {
 export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
   const text = doc.text;
   const lineStarts = computeLineStarts(text);
-  const directiveLines = directiveOnlyLines(text, lineStarts);
+  const commentRanges = directiveCommentRanges(doc);
   const directives: SuppressionDirective[] = [];
   const notices: RunNotice[] = [];
   let open: OpenRange | undefined;
@@ -145,7 +136,7 @@ export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
       directives.push({
         kind: 'next-line',
         directiveRange: comment.directiveRange,
-        range: nextEligibleLineRange(text, lineStarts, directiveLines, comment.directiveRange.end),
+        range: nextBlockRange(doc, commentRanges, comment.directiveRange),
         ruleIds: parsed.ruleIds,
         reason: parsed.reason,
       });
@@ -176,7 +167,7 @@ export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
   directives.sort(
     (a, b) => a.directiveRange.start - b.directiveRange.start || a.range.start - b.range.start,
   );
-  return { directives, notices, commentRanges: directiveCommentRanges(doc) };
+  return { directives, notices, commentRanges };
 }
 
 /**
@@ -415,43 +406,50 @@ function parseRuleIdsAndReason(
 // ---------------------------------------------------------------------------
 
 /**
- * The whole of the next eligible line after the line holding `offset`, terminator included.
+ * The span a `next-line` directive claims: the remainder of the first block that ends after it.
  *
- * Blank lines are skipped because a blank line between an HTML comment and the paragraph it
- * annotates is ordinary Markdown formatting, and directive-only lines are skipped so that
- * directives stack — one line of prose, one directive per rule id and reason.
+ * A **block**, not a line. This linter judges wording, and rewrapping a paragraph is not an edit to
+ * its wording — but under line-claiming, reflowing a paragraph so that the offending word moved to
+ * the second line silently revoked the suppression and reported the finding. Block boundaries come
+ * from blank lines and structure, so they survive a rewrap.
+ *
+ * The chosen block is the first one *ending* after the directive rather than the first one starting
+ * after it. A directive written immediately above its paragraph, with no blank line — the idiom
+ * every user brings from eslint — is absorbed into that paragraph's own block, which therefore
+ * starts at the comment rather than after it. Clamping the span to begin at the end of the comment
+ * is what stops such a directive from also claiming prose written above it.
+ *
+ * Blocks lying wholly inside a directive comment are skipped: in `format: 'text'` a comment is not
+ * masked, so a directive followed by a blank line is a paragraph in its own right.
+ *
+ * The keyword is still `ste-ai-ignore-next-line`; the idiom is what users expect to type, and the
+ * precision belongs in the documentation rather than in a name nobody would guess.
  */
-function nextEligibleLineRange(
-  text: string,
-  lineStarts: readonly number[],
-  directiveLines: ReadonlySet<number>,
-  offset: number,
+function nextBlockRange(
+  doc: AnalysedDocument,
+  commentRanges: readonly SourceRange[],
+  directiveRange: SourceRange,
 ): SourceRange {
-  const line = positionAt(lineStarts, offset).line;
-  for (let index = line; index < lineStarts.length; index += 1) {
-    const start = lineStarts[index];
-    if (start === undefined) break;
-    if (directiveLines.has(index + 1)) continue;
-    const end = lineStarts[index + 1] ?? text.length;
-    if (text.slice(start, end).trim().length === 0) continue;
-    return { start, end };
+  let chosen: SourceRange | undefined;
+  for (const block of doc.blocks) {
+    if (block.range.end <= directiveRange.end) continue;
+    const inComment = commentRanges.some(
+      (comment) => block.range.start >= comment.start && block.range.end <= comment.end,
+    );
+    if (inComment) continue;
+    // Earliest block wins; where two share a start the narrower one does, so a nested block is
+    // never widened into its container.
+    if (
+      chosen === undefined ||
+      block.range.start < chosen.start ||
+      (block.range.start === chosen.start && block.range.end < chosen.end)
+    ) {
+      chosen = block.range;
+    }
   }
   // Nothing left to claim. An empty span claims nothing and surfaces as `suppression-unused`.
-  return { start: text.length, end: text.length };
-}
-
-/** 1-based numbers of the lines whose entire content is one directive comment. */
-function directiveOnlyLines(text: string, lineStarts: readonly number[]): Set<number> {
-  const out = new Set<number>();
-  for (let index = 0; index < lineStarts.length; index += 1) {
-    const start = lineStarts[index];
-    if (start === undefined) continue;
-    const end = lineStarts[index + 1] ?? text.length;
-    const trimmed = text.slice(start, end).replace(BLOCKQUOTE_PREFIX, '').trim();
-    const inner = /^<!--([\s\S]*?)-->$/.exec(trimmed)?.[1];
-    if (inner !== undefined && inner.trim().startsWith(KEYWORD_PREFIX)) out.add(index + 1);
-  }
-  return out;
+  if (chosen === undefined) return { start: doc.text.length, end: doc.text.length };
+  return { start: Math.max(chosen.start, directiveRange.end), end: chosen.end };
 }
 
 /** The safety register of the block holding `offset`; `'none'` when no block does. */

--- a/src/core/suppressions.ts
+++ b/src/core/suppressions.ts
@@ -32,6 +32,15 @@ const REASON_SEPARATOR = ' -- ';
 
 const COMMENT_RE = /<!--([\s\S]*?)-->/g;
 
+/**
+ * Blockquote markers, stripped before a line is tested for being nothing but a directive.
+ *
+ * `> <!-- ... -->` is a directive line in every sense that matters: the marker is structural markup,
+ * not content. Without this, stacked directives inside a blockquote each claimed the next one's
+ * line instead of the prose beneath them.
+ */
+const BLOCKQUOTE_PREFIX = /^[ \t]*(?:>[ \t]*)+/;
+
 /** Safety registers where a suppression is refused unless the operator has opted in. */
 const GUARDED_ADMONITIONS: ReadonlySet<AdmonitionKind> = new Set<AdmonitionKind>([
   'danger',
@@ -39,11 +48,21 @@ const GUARDED_ADMONITIONS: ReadonlySet<AdmonitionKind> = new Set<AdmonitionKind>
   'caution',
 ]);
 
-const DIRECTIVE_TEXT_REASON = 'directive text is not prose';
+/** Recorded against anything found inside a directive comment, valid directive or not. */
+export const DIRECTIVE_TEXT_REASON = 'directive text is not prose';
 
 export interface SuppressionScanResult {
   readonly directives: readonly SuppressionDirective[];
   readonly notices: readonly RunNotice[];
+  /**
+   * Spans of every live directive comment, well formed or not.
+   *
+   * Exposed because the analysis layer has to withhold candidates anchored in one *before* they are
+   * adjudicated. In `format: 'text'` a comment is ordinary prose, so the reason an author wrote to
+   * justify a suppression is itself lintable text — and left alone it is transmitted to the model,
+   * which is exactly what a suppression is supposed to prevent.
+   */
+  readonly commentRanges: readonly SourceRange[];
 }
 
 /** A comment that looks like a directive, before it is known to be well formed. */
@@ -83,7 +102,7 @@ export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
     open = undefined;
   };
 
-  for (const comment of directiveComments(text, lineStarts)) {
+  for (const comment of directiveComments(doc, lineStarts)) {
     if (comment.keyword === END_KEYWORD) {
       if (open === undefined) {
         notices.push(
@@ -157,7 +176,7 @@ export function scanSuppressions(doc: AnalysedDocument): SuppressionScanResult {
   directives.sort(
     (a, b) => a.directiveRange.start - b.directiveRange.start || a.range.start - b.range.start,
   );
-  return { directives, notices };
+  return { directives, notices, commentRanges: directiveCommentRanges(doc) };
 }
 
 /**
@@ -205,7 +224,7 @@ export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressi
   const { doc, diagnostics, directives, allowInAdmonitions, knownRuleIds } = input;
   const lineStarts = computeLineStarts(doc.text);
   const known = new Set(knownRuleIds);
-  const commentRanges = directiveCommentRanges(doc.text);
+  const commentRanges = directiveCommentRanges(doc);
   const kept: Diagnostic[] = [];
   const suppressions: SuppressionRecord[] = [];
   const notices: RunNotice[] = [];
@@ -247,16 +266,13 @@ export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressi
     // finding, so `suppression-unused` would be a second, misleading complaint about it.
     claimed.add(directive);
 
-    const admonition = admonitionAt(doc, anchor);
-    if (!allowInAdmonitions && GUARDED_ADMONITIONS.has(admonition)) {
-      notices.push(
-        notice(
-          'suppression-refused-in-admonition',
-          'warning',
-          `A suppression of "${diagnostic.ruleId}" was refused inside a ${admonition} admonition and the finding was kept`,
-          { ruleId: diagnostic.ruleId, admonition },
-        ),
-      );
+    const refusal = refuseInAdmonition(
+      diagnostic.ruleId,
+      admonitionAt(doc, anchor),
+      allowInAdmonitions,
+    );
+    if (refusal !== undefined) {
+      notices.push(refusal);
       kept.push(diagnostic);
       continue;
     }
@@ -286,20 +302,44 @@ export function applySuppressions(input: ApplySuppressionsInput): ApplySuppressi
   return { diagnostics: kept, suppressions, notices };
 }
 
+/**
+ * The notice for a claim refused inside a safety admonition, or `undefined` when the claim stands.
+ *
+ * Exported because candidates are filtered out before adjudication, in the analysis layer, and that
+ * path is the *stronger* silencing of the two: the passage is not merely left unreported, it is
+ * never judged at all. It has to refuse on exactly these terms and say so in exactly these words,
+ * or the refusal becomes bypassable by aiming a directive at a candidate instead of a diagnostic.
+ */
+export function refuseInAdmonition(
+  ruleId: string,
+  admonition: AdmonitionKind,
+  allowInAdmonitions: boolean,
+): RunNotice | undefined {
+  if (allowInAdmonitions || !GUARDED_ADMONITIONS.has(admonition)) return undefined;
+  return notice(
+    'suppression-refused-in-admonition',
+    'warning',
+    `A suppression of "${ruleId}" was refused inside a ${admonition} admonition and the finding was kept`,
+    { ruleId, admonition },
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Parsing
 // ---------------------------------------------------------------------------
 
 function* directiveComments(
-  text: string,
+  doc: AnalysedDocument,
   lineStarts: readonly number[],
 ): Generator<DirectiveComment> {
-  for (const match of text.matchAll(COMMENT_RE)) {
+  for (const match of doc.text.matchAll(COMMENT_RE)) {
     const body = (match[1] ?? '').trim();
     if (!body.startsWith(KEYWORD_PREFIX)) continue;
+    const range = { start: match.index, end: match.index + match[0].length };
+    if (!isLiveDirectiveComment(doc, range)) continue;
     const keyword = /^\S+/.exec(body)?.[0] ?? '';
     yield {
-      directiveRange: { start: match.index, end: match.index + match[0].length },
+      directiveRange: range,
       keyword,
       rest: body.slice(keyword.length),
       line: positionAt(lineStarts, match.index).line,
@@ -307,14 +347,49 @@ function* directiveComments(
   }
 }
 
-/** Spans of every comment that opens with the keyword prefix, well formed or not. */
-function directiveCommentRanges(text: string): SourceRange[] {
+/** Spans of every live comment that opens with the keyword prefix, well formed or not. */
+function directiveCommentRanges(doc: AnalysedDocument): SourceRange[] {
   const out: SourceRange[] = [];
-  for (const match of text.matchAll(COMMENT_RE)) {
+  for (const match of doc.text.matchAll(COMMENT_RE)) {
     if (!(match[1] ?? '').trim().startsWith(KEYWORD_PREFIX)) continue;
-    out.push({ start: match.index, end: match.index + match[0].length });
+    const range = { start: match.index, end: match.index + match[0].length };
+    if (isLiveDirectiveComment(doc, range)) out.push(range);
   }
   return out;
+}
+
+/**
+ * Whether a comment is a directive the document is *giving* rather than one it is *showing*.
+ *
+ * Documentation for this feature has to be able to quote its own syntax, and before this every such
+ * sample was parsed as live — `docs/suppression.md` suppressed findings in any document that
+ * included it. Two shapes have to be excluded, and the pass order in `protected-regions.ts` means
+ * they present differently: `fencedCodePass` runs *before* `htmlCommentPass`, so a fenced sample is
+ * masked and never becomes a `comment` region at all; `inlineCodePass` and `indentedCodePass` run
+ * *after* it, so those samples do become `comment` regions but sit inside a wider opaque region that
+ * claimed the span. Hence both tests: a comment region of exactly this span must exist, and nothing
+ * opaque may enclose it.
+ *
+ * `format: 'text'` has no comment pass at all — a comment there is ordinary prose — so the raw scan
+ * stands and every match is live.
+ */
+function isLiveDirectiveComment(doc: AnalysedDocument, range: SourceRange): boolean {
+  if (doc.format !== 'markdown') return true;
+  let recognised = false;
+  for (const region of doc.protectedRegions) {
+    if (
+      region.kind === 'comment' &&
+      region.range.start === range.start &&
+      region.range.end === range.end
+    ) {
+      recognised = true;
+      continue;
+    }
+    if (region.opaque && region.range.start <= range.start && region.range.end >= range.end) {
+      return false;
+    }
+  }
+  return recognised;
 }
 
 /** `undefined` when the directive carries no reason, which makes it inert. */
@@ -372,7 +447,7 @@ function directiveOnlyLines(text: string, lineStarts: readonly number[]): Set<nu
     const start = lineStarts[index];
     if (start === undefined) continue;
     const end = lineStarts[index + 1] ?? text.length;
-    const trimmed = text.slice(start, end).trim();
+    const trimmed = text.slice(start, end).replace(BLOCKQUOTE_PREFIX, '').trim();
     const inner = /^<!--([\s\S]*?)-->$/.exec(trimmed)?.[1];
     if (inner !== undefined && inner.trim().startsWith(KEYWORD_PREFIX)) out.add(index + 1);
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -249,6 +249,38 @@ export interface RunNotice {
 }
 
 // ---------------------------------------------------------------------------
+// Inline suppression
+// ---------------------------------------------------------------------------
+
+/** A parsed inline suppression directive. */
+export interface SuppressionDirective {
+  readonly kind: 'next-line' | 'range';
+  /** Span of the directive comment itself. */
+  readonly directiveRange: SourceRange;
+  /** Span of source this directive suppresses. */
+  readonly range: SourceRange;
+  /** Rule ids named by the directive. Empty means every rule. */
+  readonly ruleIds: readonly string[];
+  readonly reason: string;
+}
+
+/**
+ * A finding that was withheld because an inline directive claimed it as intentional.
+ *
+ * Recorded rather than discarded: a suppression is a claim by the author, and the diagnostic
+ * policy does not allow a claim to become invisible.
+ */
+export interface SuppressionRecord {
+  readonly ruleId: string;
+  readonly category: DiagnosticCategory;
+  readonly range: SourceRange;
+  /** The message the withheld diagnostic would have carried. */
+  readonly message: string;
+  readonly reason: string;
+  readonly directiveRange: SourceRange;
+}
+
+// ---------------------------------------------------------------------------
 // Rules
 // ---------------------------------------------------------------------------
 

--- a/test/e2e/textlint-run.test.ts
+++ b/test/e2e/textlint-run.test.ts
@@ -113,6 +113,36 @@ describe('textlint lint run', () => {
     expect(result.messages).toHaveLength(1);
   });
 
+  it('an inline suppression directive silences the finding it names', async () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+      'Prior to installation, remove the bracket.',
+      '',
+    ].join('\n');
+    const result = await kernel.lintText(text, options(['unapproved-vocabulary']));
+    expect(result.messages).toEqual([]);
+  });
+
+  it('reports the same document once the directive is removed', async () => {
+    const text = ['Prior to installation, remove the bracket.', ''].join('\n');
+    const result = await kernel.lintText(text, options(['unapproved-vocabulary']));
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.message).toContain('"Prior to" is not approved');
+  });
+
+  it('a rule-scoped directive leaves another rule on the same line reporting', async () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+      "Prior to installation, don't remove the bracket.",
+      '',
+    ].join('\n');
+    const result = await kernel.lintText(
+      text,
+      options(['unapproved-vocabulary', 'no-contractions']),
+    );
+    expect(result.messages.map((m) => m.ruleId)).toEqual(['no-contractions']);
+  });
+
   it('offers suggestions alongside the diagnostic', async () => {
     const result = await kernel.lintText(
       'Commence the test.\n',

--- a/test/integration/cli-output.test.ts
+++ b/test/integration/cli-output.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { main } from '../../src/cli/main.js';
+
+/**
+ * What the CLI prints, as a reader sees it.
+ *
+ * The programmatic result is asserted elsewhere; what is asserted here is the presentation, because
+ * a position printed in the AST's own convention is a position that does not match the reader's
+ * editor. `main` is driven in-process rather than spawned so the test does not depend on `dist/`.
+ */
+
+let directory: string | undefined;
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'ste-ai-cli-'));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (directory !== undefined) rmSync(directory, { recursive: true, force: true });
+  directory = undefined;
+});
+
+async function lint(name: string, text: string, ...flags: string[]): Promise<string> {
+  const file = join(directory ?? tmpdir(), name);
+  writeFileSync(file, text, 'utf8');
+  const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+  const argv = process.argv;
+  process.argv = ['node', 'ste-ai', 'lint', file, ...flags];
+  try {
+    await main();
+    return stdout.mock.calls.map((call) => String(call[0])).join('');
+  } finally {
+    process.argv = argv;
+    stdout.mockRestore();
+  }
+}
+
+const DOC = [
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+  'The technician will utilise the bracket.',
+  '',
+].join('\n');
+
+describe('ste-ai lint output', () => {
+  it('prints one suppressed line per withheld finding, at a one-based column', async () => {
+    const output = await lint('suppressed.md', DOC);
+    // "utilise" is the 21st character of line 2, which is the column an editor shows.
+    expect(output).toContain(
+      '  suppressed  unapproved-vocabulary at 2:21 — Vendor spelling fixed by contract.\n',
+    );
+  });
+
+  it('carries the withheld findings in --json', async () => {
+    const output = await lint('suppressed.md', DOC, '--json');
+    const parsed = JSON.parse(output) as {
+      results: { suppressions: { ruleId: string; reason: string; range: { start: number } }[] }[];
+    };
+    const record = parsed.results[0]?.suppressions[0];
+    expect(record?.ruleId).toBe('unapproved-vocabulary');
+    expect(record?.reason).toBe('Vendor spelling fixed by contract.');
+    // The machine-readable range stays a raw offset; only the printed line is reader-facing.
+    expect(record?.range.start).toBe(DOC.indexOf('utilise'));
+  });
+});

--- a/test/integration/suppression.test.ts
+++ b/test/integration/suppression.test.ts
@@ -45,6 +45,16 @@ const CANDIDATE_DOC = [
   '',
 ].join('\n');
 
+const admonitionDoc = (kind: 'WARNING' | 'NOTE'): string =>
+  [
+    `> [!${kind}]`,
+    '> <!-- ste-ai-ignore-next-line passive-voice-candidate -- Quoted verbatim. -->',
+    '> The bracket is removed by the technician.',
+    '',
+  ].join('\n');
+
+const CANDIDATE_RULE = 'passive-voice-candidate';
+
 /** Only the vocabulary findings: the fixtures also raise candidates the assertions do not concern. */
 function vocabulary(findings: readonly { readonly ruleId: string }[]): string[] {
   return findings.filter((d) => d.ruleId === 'unapproved-vocabulary').map((d) => d.ruleId);
@@ -101,6 +111,42 @@ describe('inline suppression in a deterministic run', () => {
   });
 });
 
+describe('a claim on a candidate inside a safety admonition', () => {
+  it('is refused, and the candidate survives to be adjudicated', () => {
+    const text = admonitionDoc('WARNING');
+    const result = analyseTextDeterministic(text);
+
+    expect(result.candidates.map((c) => c.ruleId)).toEqual([CANDIDATE_RULE]);
+    expect(result.suppressions.filter((s) => s.ruleId === CANDIDATE_RULE)).toEqual([]);
+
+    const refusal = result.notices.find((n) => n.code === 'suppression-refused-in-admonition');
+    expect(refusal?.level).toBe('warning');
+    expect(refusal?.detail).toEqual({ ruleId: CANDIDATE_RULE, admonition: 'warning' });
+
+    // Filtering a candidate is the stronger silencing of the two, so the refusal must not leave the
+    // passage unreported either: it still becomes a review-required diagnostic.
+    expect(result.diagnostics.map((d) => d.ruleId)).toContain(CANDIDATE_RULE);
+  });
+
+  it('is honoured once the operator allows it', () => {
+    const result = analyseTextDeterministic(admonitionDoc('WARNING'), {
+      config: { suppressions: { allowInAdmonitions: true } },
+    });
+
+    expect(result.candidates).toEqual([]);
+    expect(result.suppressions.map((s) => s.ruleId)).toEqual([CANDIDATE_RULE]);
+    expect(result.notices.map((n) => n.code)).not.toContain('suppression-refused-in-admonition');
+  });
+
+  it('is honoured without the flag inside a note, which is not a safety register', () => {
+    const result = analyseTextDeterministic(admonitionDoc('NOTE'));
+
+    expect(result.candidates).toEqual([]);
+    expect(result.suppressions.map((s) => s.ruleId)).toEqual([CANDIDATE_RULE]);
+    expect(result.notices.map((n) => n.code)).not.toContain('suppression-refused-in-admonition');
+  });
+});
+
 describe('a suppressed candidate is never sent to the model', () => {
   it('dispatches the unclaimed passage and not the claimed one', async () => {
     const bodies: string[] = [];
@@ -145,5 +191,94 @@ describe('a suppressed candidate is never sent to the model', () => {
     expect(record?.message).toBe('Auxiliary plus past participle.');
     expect(record?.reason).toBe('Quoted verbatim from the supplier.');
     expect(result.notices.map((n) => n.code)).not.toContain('suppression-unused');
+  });
+
+  it('never dispatches the directive comment itself in a plain-text document', async () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- The bracket is removed by the technician. -->',
+      'Utilise the cover.',
+      '',
+      'The filter is opened by the operator.',
+      '',
+    ].join('\n');
+    const bodies: string[] = [];
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        bodies.push(JSON.stringify(body));
+        return {
+          content: verdictJson({
+            ruleId: CANDIDATE_RULE,
+            status: 'compliant',
+            confidence: 0.9,
+            explanation: 'ok',
+            suggestedReplacements: [],
+          }),
+        };
+      },
+    });
+
+    const result = await analyseText(text, {
+      format: 'text',
+      config: {
+        semantic: {
+          enabled: true,
+          endpoint: service.url,
+          model: 'fake',
+          cache: false,
+          maxRepairAttempts: 0,
+        },
+      },
+    });
+
+    // Positive control: the genuine passage is still adjudicated.
+    expect(service.requestCount()).toBe(1);
+    const sent = bodies.join('\n');
+    expect(sent).toContain('The filter is opened by the operator');
+
+    // The reason a person wrote to explain a suppression is not prose for a reader, and it must
+    // not leave the process to be judged as though it were.
+    expect(sent).not.toContain('The bracket is removed by the technician');
+    expect(sent).not.toContain('ste-ai-ignore-next-line');
+
+    // The withheld candidate is still on the record, with the reason the diagnostic path uses.
+    const record = result.suppressions.find((s) => s.ruleId === CANDIDATE_RULE);
+    expect(record?.reason).toBe('directive text is not prose');
+    expect(record?.category).toBe('review-required');
+    expect(record?.message).toBe('Auxiliary plus past participle.');
+  });
+
+  it('dispatches a candidate whose claim was refused inside a safety admonition', async () => {
+    const bodies: string[] = [];
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        bodies.push(JSON.stringify(body));
+        return {
+          content: verdictJson({
+            ruleId: CANDIDATE_RULE,
+            status: 'compliant',
+            confidence: 0.9,
+            explanation: 'ok',
+            suggestedReplacements: [],
+          }),
+        };
+      },
+    });
+
+    await analyseText(admonitionDoc('WARNING'), {
+      config: {
+        semantic: {
+          enabled: true,
+          endpoint: service.url,
+          model: 'fake',
+          cache: false,
+          maxRepairAttempts: 0,
+        },
+      },
+    });
+
+    // The refusal has to reach the wire. A refused claim that still kept the passage out of the
+    // model would be the refusal in name only.
+    expect(service.requestCount()).toBe(1);
+    expect(bodies.join('\n')).toContain('The bracket is removed by the technician');
   });
 });

--- a/test/integration/suppression.test.ts
+++ b/test/integration/suppression.test.ts
@@ -111,6 +111,73 @@ describe('inline suppression in a deterministic run', () => {
   });
 });
 
+describe('overlapping fixes are resolved after suppression', () => {
+  const CONFLICT = 'Utilise utilise the bracket.';
+  const SUPPRESSED = [
+    '<!-- ste-ai-ignore-next-line no-repeated-words -- Repetition quoted verbatim. -->',
+    CONFLICT,
+    '',
+  ].join('\n');
+
+  it('leaves a surviving diagnostic its fix when the conflicting one was withheld', () => {
+    const result = analyseTextDeterministic(SUPPRESSED);
+
+    expect(result.suppressions.map((s) => s.ruleId)).toEqual(['no-repeated-words']);
+    expect(result.diagnostics.map((d) => d.ruleId)).toEqual([
+      'unapproved-vocabulary',
+      'unapproved-vocabulary',
+    ]);
+    // A withheld finding is not a party to a fix conflict. Before this the survivor was left
+    // permanently unfixable by a diagnostic that is not in the output.
+    expect(result.diagnostics.filter((d) => d.fix === undefined)).toEqual([]);
+    expect(result.notices.map((n) => n.code)).not.toContain('overlapping-fixes-refused');
+    for (const diagnostic of result.diagnostics) {
+      expect(diagnostic.message).not.toContain('No automatic fix');
+    }
+  });
+
+  it('still refuses both fixes when the conflict is real', () => {
+    const result = analyseTextDeterministic(`${CONFLICT}\n`);
+
+    const refused = result.notices.find((n) => n.code === 'overlapping-fixes-refused');
+    expect(refused?.detail?.['count']).toBe(2);
+    expect(result.diagnostics.find((d) => d.ruleId === 'no-repeated-words')?.fix).toBeUndefined();
+    expect(result.diagnostics.filter((d) => d.fix === undefined)).toHaveLength(2);
+  });
+
+  it('resolves a genuine conflict through the semantic entry point', async () => {
+    service = await startFakeSemanticService({
+      handler: () => ({
+        content: verdictJson({
+          ruleId: CANDIDATE_RULE,
+          status: 'compliant',
+          confidence: 0.9,
+          explanation: 'ok',
+          suggestedReplacements: [],
+        }),
+      }),
+    });
+
+    const result = await analyseText(`${CONFLICT} The cover is opened by the operator.\n`, {
+      config: {
+        semantic: {
+          enabled: true,
+          endpoint: service.url,
+          model: 'fake',
+          cache: false,
+          maxRepairAttempts: 0,
+        },
+      },
+    });
+
+    // Positive control: semantic diagnostics really were merged in before resolution ran.
+    expect(service.requestCount()).toBe(1);
+    const refused = result.notices.find((n) => n.code === 'overlapping-fixes-refused');
+    expect(refused?.detail?.['count']).toBe(2);
+    expect(result.diagnostics.find((d) => d.ruleId === 'no-repeated-words')?.fix).toBeUndefined();
+  });
+});
+
 describe('a claim on a candidate inside a safety admonition', () => {
   it('is refused, and the candidate survives to be adjudicated', () => {
     const text = admonitionDoc('WARNING');

--- a/test/integration/suppression.test.ts
+++ b/test/integration/suppression.test.ts
@@ -214,6 +214,59 @@ describe('a claim on a candidate inside a safety admonition', () => {
   });
 });
 
+describe('a refused candidate reports its refusal exactly once', () => {
+  const RANGE_OVER_ALERT = [
+    '<!-- ste-ai-ignore-start passive-voice-candidate -- reviewed, keep as written -->',
+    '',
+    '> [!WARNING]',
+    '> The cover is opened by the operator.',
+    '',
+    '<!-- ste-ai-ignore-end -->',
+    '',
+  ].join('\n');
+
+  it('emits one notice through the deterministic entry point', () => {
+    const result = analyseTextDeterministic(RANGE_OVER_ALERT);
+
+    const refusals = result.notices.filter((n) => n.code === 'suppression-refused-in-admonition');
+    expect(refusals).toHaveLength(1);
+    // The finding is kept, not discarded — a refused claim is not a silent one.
+    expect(result.diagnostics.map((d) => d.ruleId)).toContain(CANDIDATE_RULE);
+  });
+
+  it('emits one notice through the semantic entry point', async () => {
+    service = await startFakeSemanticService({
+      handler: () => ({
+        content: verdictJson({
+          ruleId: CANDIDATE_RULE,
+          status: 'uncertain',
+          confidence: 0.5,
+          explanation: 'inconclusive',
+          suggestedReplacements: [],
+        }),
+      }),
+    });
+
+    const result = await analyseText(RANGE_OVER_ALERT, {
+      config: {
+        semantic: {
+          enabled: true,
+          endpoint: service.url,
+          model: 'fake',
+          cache: false,
+          maxRepairAttempts: 0,
+        },
+      },
+    });
+
+    // Positive control: the refused candidate really did reach adjudication.
+    expect(service.requestCount()).toBe(1);
+    const refusals = result.notices.filter((n) => n.code === 'suppression-refused-in-admonition');
+    expect(refusals).toHaveLength(1);
+    expect(result.diagnostics.map((d) => d.ruleId)).toContain(CANDIDATE_RULE);
+  });
+});
+
 describe('a suppressed candidate is never sent to the model', () => {
   it('dispatches the unclaimed passage and not the claimed one', async () => {
     const bodies: string[] = [];

--- a/test/integration/suppression.test.ts
+++ b/test/integration/suppression.test.ts
@@ -314,6 +314,56 @@ describe('a suppressed candidate is never sent to the model', () => {
     expect(record?.message).toBe('Auxiliary plus past participle.');
   });
 
+  it('redacts a directive comment from a surviving candidate that merely shares its sentence', async () => {
+    // No blank line between the comment and the prose, so sentence-splitter does not treat the
+    // directive as its own sentence: the candidate for "is opened by" is anchored in the prose,
+    // outside the comment's own span, and is NOT claimed — the directive names a different rule
+    // entirely. It survives to be dispatched. Its `passage`, built from the whole sentence, would
+    // carry the comment's raw text without the redaction this test is for.
+    const text =
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- vendor spelling fixed by contract -->' +
+      ' The cover is opened by the operator.\n';
+    const bodies: string[] = [];
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        bodies.push(JSON.stringify(body));
+        return {
+          content: verdictJson({
+            ruleId: CANDIDATE_RULE,
+            status: 'compliant',
+            confidence: 0.9,
+            explanation: 'ok',
+            suggestedReplacements: [],
+          }),
+        };
+      },
+    });
+
+    await analyseText(text, {
+      format: 'text',
+      config: {
+        semantic: {
+          enabled: true,
+          endpoint: service.url,
+          model: 'fake',
+          cache: false,
+          maxRepairAttempts: 0,
+        },
+      },
+    });
+
+    // Positive control: the candidate this test is about really was dispatched.
+    expect(service.requestCount()).toBe(1);
+    const sent = bodies.join('\n');
+    expect(sent).toContain('is opened by the operator');
+
+    // The leak this test guards against: an unrelated directive's syntax, rule id and reason must
+    // not travel to the model just because it shares a sentence with a genuine candidate.
+    expect(sent).not.toContain('ste-ai-ignore-next-line');
+    expect(sent).not.toContain('unapproved-vocabulary');
+    expect(sent).not.toContain('vendor spelling fixed by contract');
+  });
+
   it('dispatches a candidate whose claim was refused inside a safety admonition', async () => {
     const bodies: string[] = [];
     service = await startFakeSemanticService({

--- a/test/integration/suppression.test.ts
+++ b/test/integration/suppression.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { analyseText, analyseTextDeterministic } from '../../src/analysis/analyse.js';
+import {
+  startFakeSemanticService,
+  verdictJson,
+  type FakeService,
+} from '../helpers/fake-semantic-service.js';
+
+/**
+ * Inline suppression through the real pipeline.
+ *
+ * The unit tests prove the scanner and the applier in isolation. What is proved here is the wiring:
+ * that a directive written in a real document reaches real rule output, that turning the feature off
+ * restores the finding, and — the case a unit test cannot reach — that a suppressed candidate never
+ * becomes an HTTP request. A suppression that withheld the diagnostic but still shipped the passage
+ * to a model would satisfy every assertion in the unit suite and still leak the text.
+ */
+
+let service: FakeService | undefined;
+
+afterEach(async () => {
+  await service?.close();
+  service = undefined;
+});
+
+const MARKDOWN_DOC = [
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+  'Utilise the bracket.',
+  '',
+  'Utilise the filter.',
+  '',
+].join('\n');
+
+const TEXT_DOC = [
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Utilise is the vendor spelling. -->',
+  'Utilise the bracket.',
+  '',
+].join('\n');
+
+const CANDIDATE_DOC = [
+  '<!-- ste-ai-ignore-next-line passive-voice-candidate -- Quoted verbatim from the supplier. -->',
+  'The bracket is removed by the technician.',
+  '',
+  'The cover is opened by the operator.',
+  '',
+].join('\n');
+
+/** Only the vocabulary findings: the fixtures also raise candidates the assertions do not concern. */
+function vocabulary(findings: readonly { readonly ruleId: string }[]): string[] {
+  return findings.filter((d) => d.ruleId === 'unapproved-vocabulary').map((d) => d.ruleId);
+}
+
+describe('inline suppression in a deterministic run', () => {
+  it('withholds the claimed diagnostic and records it', () => {
+    const result = analyseTextDeterministic(MARKDOWN_DOC);
+
+    // Positive control: the unclaimed occurrence on the later line is still reported.
+    expect(vocabulary(result.diagnostics)).toEqual(['unapproved-vocabulary']);
+    expect(result.diagnostics[0]?.range.start).toBe(MARKDOWN_DOC.indexOf('Utilise the filter'));
+
+    expect(result.suppressions).toHaveLength(1);
+    const record = result.suppressions[0];
+    expect(record?.ruleId).toBe('unapproved-vocabulary');
+    expect(record?.range.start).toBe(MARKDOWN_DOC.indexOf('Utilise the bracket'));
+    expect(record?.reason).toBe('Vendor spelling fixed by contract.');
+    expect(record?.message).toContain('Utilise');
+
+    const applied = result.notices.find((n) => n.code === 'suppressions-applied');
+    expect(applied?.level).toBe('info');
+    expect(applied?.detail?.['count']).toBe(1);
+  });
+
+  it('makes every directive inert when suppressions are disabled', () => {
+    const result = analyseTextDeterministic(MARKDOWN_DOC, {
+      config: { suppressions: { enabled: false } },
+    });
+
+    expect(vocabulary(result.diagnostics)).toEqual([
+      'unapproved-vocabulary',
+      'unapproved-vocabulary',
+    ]);
+    expect(result.suppressions).toEqual([]);
+    expect(result.notices.filter((n) => n.code.startsWith('suppression'))).toEqual([]);
+  });
+
+  it('honours a directive in a plain-text document and reports nothing on the directive line', () => {
+    const result = analyseTextDeterministic(TEXT_DOC, { format: 'text' });
+
+    // In `format: 'text'` the comment is ordinary prose, so "Utilise" inside the directive is a
+    // vocabulary violation until the applier withholds it as directive text.
+    expect(vocabulary(result.diagnostics)).toEqual([]);
+    expect(
+      result.suppressions.filter((s) => s.ruleId === 'unapproved-vocabulary').map((s) => s.reason),
+    ).toEqual(['directive text is not prose', 'Utilise is the vendor spelling.']);
+
+    // Nothing at all is reported on the directive line, whichever rule looked at it.
+    const onDirectiveLine = result.diagnostics.filter(
+      (d) => result.document.positionAt(d.range.start).line === 1,
+    );
+    expect(onDirectiveLine).toEqual([]);
+  });
+});
+
+describe('a suppressed candidate is never sent to the model', () => {
+  it('dispatches the unclaimed passage and not the claimed one', async () => {
+    const bodies: string[] = [];
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        bodies.push(JSON.stringify(body));
+        return {
+          content: verdictJson({
+            ruleId: 'passive-voice-candidate',
+            status: 'compliant',
+            confidence: 0.9,
+            explanation: 'ok',
+            suggestedReplacements: [],
+          }),
+        };
+      },
+    });
+
+    const result = await analyseText(CANDIDATE_DOC, {
+      config: {
+        semantic: {
+          enabled: true,
+          endpoint: service.url,
+          model: 'fake',
+          cache: false,
+          maxRepairAttempts: 0,
+        },
+      },
+    });
+
+    // Positive control: the run really did contact the service, so the negative below is meaningful.
+    expect(service.requestCount()).toBe(1);
+    const sent = bodies.join('\n');
+    expect(sent).toContain('The cover is opened by the operator');
+    expect(sent).not.toContain('The bracket is removed by the technician');
+
+    expect(result.candidates.map((c) => c.range.start)).toEqual([
+      CANDIDATE_DOC.indexOf('is opened by'),
+    ]);
+    const record = result.suppressions.find((s) => s.ruleId === 'passive-voice-candidate');
+    expect(record?.category).toBe('review-required');
+    expect(record?.message).toBe('Auxiliary plus past participle.');
+    expect(record?.reason).toBe('Quoted verbatim from the supplier.');
+    expect(result.notices.map((n) => n.code)).not.toContain('suppression-unused');
+  });
+});

--- a/test/unit/suppressions.test.ts
+++ b/test/unit/suppressions.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from 'vitest';
+import { analyseDocument } from '../../src/core/document.js';
+import { applySuppressions, directiveFor, scanSuppressions } from '../../src/core/suppressions.js';
+import type {
+  Diagnostic,
+  DocumentFormat,
+  RunNotice,
+  SuppressionDirective,
+  SuppressionRecord,
+} from '../../src/core/types.js';
+
+const KNOWN_RULE_IDS = ['unapproved-vocabulary', 'sentence-length-procedural'];
+
+function diagnosticFor(
+  text: string,
+  quote: string,
+  ruleId = 'unapproved-vocabulary',
+  endQuote?: string,
+): Diagnostic {
+  const start = text.indexOf(quote);
+  expect(start, `fixture does not contain "${quote}"`).toBeGreaterThanOrEqual(0);
+  const end =
+    endQuote === undefined ? start + quote.length : text.indexOf(endQuote) + endQuote.length;
+  return {
+    ruleId,
+    ruleStatus: 'provisional',
+    category: 'deterministic-violation',
+    severity: 'error',
+    message: `"${quote}" is not an approved term.`,
+    range: { start, end },
+    producedBy: 'deterministic',
+  };
+}
+
+interface RunOptions {
+  readonly format?: DocumentFormat;
+  readonly allowInAdmonitions?: boolean;
+  readonly knownRuleIds?: readonly string[];
+}
+
+interface RunResult {
+  readonly directives: readonly SuppressionDirective[];
+  readonly diagnostics: readonly Diagnostic[];
+  readonly suppressions: readonly SuppressionRecord[];
+  readonly notices: readonly RunNotice[];
+  readonly codes: readonly string[];
+}
+
+function run(
+  text: string,
+  diagnostics: readonly Diagnostic[],
+  options: RunOptions = {},
+): RunResult {
+  const doc = analyseDocument({ id: 't', format: options.format ?? 'markdown', text });
+  const scan = scanSuppressions(doc);
+  const applied = applySuppressions({
+    doc,
+    diagnostics,
+    directives: scan.directives,
+    allowInAdmonitions: options.allowInAdmonitions ?? false,
+    knownRuleIds: options.knownRuleIds ?? KNOWN_RULE_IDS,
+  });
+  const notices = [...scan.notices, ...applied.notices];
+  return {
+    directives: scan.directives,
+    diagnostics: applied.diagnostics,
+    suppressions: applied.suppressions,
+    notices,
+    codes: notices.map((notice) => notice.code),
+  };
+}
+
+function noticeWith(result: RunResult, code: string): RunNotice | undefined {
+  return result.notices.find((notice) => notice.code === code);
+}
+
+const NEXT_LINE = [
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+  'Utilise the bracket.',
+  'Utilise the filter.',
+  '',
+].join('\n');
+
+const SCOPED = [
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+  'Utilise the bracket assembly to hold the sensor in position.',
+  '',
+].join('\n');
+
+const UNSCOPED = [
+  '<!-- ste-ai-ignore-next-line -- Vendor spelling fixed by contract. -->',
+  'Utilise the bracket assembly to hold the sensor in position.',
+  '',
+].join('\n');
+
+const RANGE = [
+  'Utilise the tool before the block.',
+  '<!-- ste-ai-ignore-start -- Legacy chapter frozen for the 2026 revision. -->',
+  'Utilise the bracket.',
+  'Utilise the filter.',
+  '<!-- ste-ai-ignore-end -->',
+  'Utilise the cover.',
+  '',
+].join('\n');
+
+const WARNING_DOC = [
+  'WARNING: Do not touch the live conductor.',
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
+  'Utilise the bracket.',
+  '',
+].join('\n');
+
+const NOTE_DOC = [
+  '> [!NOTE]',
+  '> Background information follows.',
+  '> <!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+  '> Utilise the bracket.',
+  '',
+].join('\n');
+
+describe('scanSuppressions', () => {
+  it('parses a next-line directive with its rule ids and reason', () => {
+    const doc = analyseDocument({ id: 't', format: 'markdown', text: NEXT_LINE });
+    const { directives, notices } = scanSuppressions(doc);
+    expect(notices).toEqual([]);
+    expect(directives).toHaveLength(1);
+    const directive = directives[0];
+    expect(directive?.kind).toBe('next-line');
+    expect(directive?.ruleIds).toEqual(['unapproved-vocabulary']);
+    expect(directive?.reason).toBe('Vendor spelling fixed by contract.');
+    expect(directive?.directiveRange).toEqual({
+      start: 0,
+      end: NEXT_LINE.indexOf('-->') + 3,
+    });
+    // The span is the whole of the following line, terminator included.
+    expect(directive?.range).toEqual({
+      start: NEXT_LINE.indexOf('Utilise the bracket.'),
+      end: NEXT_LINE.indexOf('Utilise the filter.'),
+    });
+  });
+
+  it('returns directives in source order', () => {
+    const doc = analyseDocument({ id: 't', format: 'markdown', text: RANGE });
+    const { directives } = scanSuppressions(doc);
+    expect(directives.map((d) => d.kind)).toEqual(['range']);
+    expect(directives[0]?.range).toEqual({
+      start: RANGE.indexOf('-->') + 3,
+      end: RANGE.indexOf('<!-- ste-ai-ignore-end'),
+    });
+  });
+
+  it('reports a comment that starts with the keyword but parses as no known form', () => {
+    const text =
+      '<!-- ste-ai-ignore-everything -- Reason recorded for the audit. -->\nUtilise it.\n';
+    const doc = analyseDocument({ id: 't', format: 'markdown', text });
+    const { directives, notices } = scanSuppressions(doc);
+    expect(directives).toEqual([]);
+    expect(notices.map((n) => n.code)).toEqual(['suppression-malformed']);
+    expect(notices[0]?.detail?.['line']).toBe(1);
+  });
+});
+
+describe('directiveFor', () => {
+  it('returns the claiming directive for an offset inside its span and nothing outside', () => {
+    const doc = analyseDocument({ id: 't', format: 'markdown', text: RANGE });
+    const { directives } = scanSuppressions(doc);
+    const inside = RANGE.indexOf('Utilise the bracket.');
+    const outside = RANGE.indexOf('Utilise the cover.');
+    expect(directiveFor(directives, 'unapproved-vocabulary', inside)).toBe(directives[0]);
+    expect(directiveFor(directives, 'unapproved-vocabulary', outside)).toBeUndefined();
+  });
+});
+
+describe('applySuppressions', () => {
+  it('claims a finding on the following line and not on the line after that', () => {
+    const result = run(NEXT_LINE, [
+      diagnosticFor(NEXT_LINE, 'Utilise the bracket'),
+      diagnosticFor(NEXT_LINE, 'Utilise the filter'),
+    ]);
+    expect(result.diagnostics.map((d) => d.message)).toEqual([
+      '"Utilise the filter" is not an approved term.',
+    ]);
+    expect(result.suppressions.map((s) => s.message)).toEqual([
+      '"Utilise the bracket" is not an approved term.',
+    ]);
+  });
+
+  it('claims only the named rule when the directive is rule-scoped', () => {
+    const result = run(SCOPED, [
+      diagnosticFor(SCOPED, 'Utilise'),
+      diagnosticFor(
+        SCOPED,
+        'Utilise the bracket assembly to hold the sensor in position.',
+        'sentence-length-procedural',
+      ),
+    ]);
+    expect(result.diagnostics.map((d) => d.ruleId)).toEqual(['sentence-length-procedural']);
+    expect(result.suppressions.map((s) => s.ruleId)).toEqual(['unapproved-vocabulary']);
+  });
+
+  it('claims every rule on the line when the directive names none', () => {
+    const result = run(UNSCOPED, [
+      diagnosticFor(UNSCOPED, 'Utilise'),
+      diagnosticFor(
+        UNSCOPED,
+        'Utilise the bracket assembly to hold the sensor in position.',
+        'sentence-length-procedural',
+      ),
+    ]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions.map((s) => s.ruleId)).toEqual([
+      'unapproved-vocabulary',
+      'sentence-length-procedural',
+    ]);
+  });
+
+  it('claims everything between start and end and nothing outside', () => {
+    const result = run(RANGE, [
+      diagnosticFor(RANGE, 'Utilise the tool'),
+      diagnosticFor(RANGE, 'Utilise the bracket'),
+      diagnosticFor(RANGE, 'Utilise the filter'),
+      diagnosticFor(RANGE, 'Utilise the cover'),
+    ]);
+    expect(result.diagnostics.map((d) => d.message)).toEqual([
+      '"Utilise the tool" is not an approved term.',
+      '"Utilise the cover" is not an approved term.',
+    ]);
+    expect(result.suppressions.map((s) => s.message)).toEqual([
+      '"Utilise the bracket" is not an approved term.',
+      '"Utilise the filter" is not an approved term.',
+    ]);
+  });
+
+  it('leaves a directive with no reason inert and reports it', () => {
+    const text = ['<!-- ste-ai-ignore-next-line unapproved-vocabulary -->', 'Utilise it.', ''].join(
+      '\n',
+    );
+    const result = run(text, [diagnosticFor(text, 'Utilise it')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    expect(result.codes).toContain('suppression-reason-missing');
+    expect(noticeWith(result, 'suppression-reason-missing')?.detail?.['line']).toBe(1);
+  });
+
+  it('reports an unknown rule id and claims nothing for it', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line no-such-rule -- Reason recorded for the audit. -->',
+      'Utilise it.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise it')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    expect(result.codes).toContain('suppression-unknown-rule');
+    expect(noticeWith(result, 'suppression-unknown-rule')?.detail?.['ruleId']).toBe('no-such-rule');
+  });
+
+  it('reports a stray ignore-end', () => {
+    const text = ['Utilise it.', '<!-- ste-ai-ignore-end -->', ''].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise it')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.codes).toContain('suppression-end-without-start');
+    expect(noticeWith(result, 'suppression-end-without-start')?.detail?.['line']).toBe(2);
+  });
+
+  it('runs an unterminated ignore-start to the end of the document and reports it', () => {
+    const text = [
+      '<!-- ste-ai-ignore-start -- Legacy chapter frozen for the 2026 revision. -->',
+      'Utilise the bracket.',
+      'Utilise the filter.',
+      '',
+    ].join('\n');
+    const result = run(text, [
+      diagnosticFor(text, 'Utilise the bracket'),
+      diagnosticFor(text, 'Utilise the filter'),
+    ]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(2);
+    expect(result.codes).toContain('suppression-unclosed-range');
+    expect(noticeWith(result, 'suppression-unclosed-range')?.detail?.['line']).toBe(1);
+  });
+
+  it('reports a directive that claims nothing', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Reason recorded for the audit. -->',
+      'The cover is in place.',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    expect(result.codes).toContain('suppression-unused');
+    expect(noticeWith(result, 'suppression-unused')?.detail?.['line']).toBe(1);
+  });
+
+  it('refuses a claim inside a warning admonition and keeps the diagnostic', () => {
+    const result = run(WARNING_DOC, [diagnosticFor(WARNING_DOC, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    const notice = noticeWith(result, 'suppression-refused-in-admonition');
+    expect(notice?.level).toBe('warning');
+    expect(notice?.detail).toEqual({ ruleId: 'unapproved-vocabulary', admonition: 'warning' });
+  });
+
+  it('honours a claim inside a warning admonition when the operator allows it', () => {
+    const result = run(WARNING_DOC, [diagnosticFor(WARNING_DOC, 'Utilise the bracket')], {
+      allowInAdmonitions: true,
+    });
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+    expect(result.codes).not.toContain('suppression-refused-in-admonition');
+  });
+
+  it('honours a claim inside a note admonition without the flag', () => {
+    const result = run(NOTE_DOC, [diagnosticFor(NOTE_DOC, 'Utilise the bracket')]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+    expect(result.codes).not.toContain('suppression-refused-in-admonition');
+  });
+
+  it('records every withheld finding with its reason and directive span', () => {
+    const result = run(NEXT_LINE, [diagnosticFor(NEXT_LINE, 'Utilise the bracket')]);
+    expect(result.suppressions).toEqual([
+      {
+        ruleId: 'unapproved-vocabulary',
+        category: 'deterministic-violation',
+        range: {
+          start: NEXT_LINE.indexOf('Utilise the bracket'),
+          end: NEXT_LINE.indexOf('Utilise the bracket') + 'Utilise the bracket'.length,
+        },
+        message: '"Utilise the bracket" is not an approved term.',
+        reason: 'Vendor spelling fixed by contract.',
+        directiveRange: { start: 0, end: NEXT_LINE.indexOf('-->') + 3 },
+      },
+    ]);
+  });
+
+  it('reports how many findings were withheld', () => {
+    const result = run(RANGE, [
+      diagnosticFor(RANGE, 'Utilise the tool'),
+      diagnosticFor(RANGE, 'Utilise the bracket'),
+      diagnosticFor(RANGE, 'Utilise the filter'),
+    ]);
+    const notice = noticeWith(result, 'suppressions-applied');
+    expect(notice?.level).toBe('info');
+    expect(notice?.detail).toEqual({ count: 2 });
+  });
+
+  it('emits no applied notice when nothing was withheld', () => {
+    const text = 'Utilise the bracket.\n';
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.codes).not.toContain('suppressions-applied');
+  });
+
+  it('skips a blank line between the directive and its target prose', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+  });
+
+  it('lets stacked directives claim the same prose line for their own rule ids', () => {
+    const text = [
+      "<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor's API verb. -->",
+      '<!-- ste-ai-ignore-next-line sentence-length-procedural -- Quoted verbatim. -->',
+      'Terminate the session before you remove the module.',
+      '',
+    ].join('\n');
+    const result = run(text, [
+      diagnosticFor(text, 'Terminate'),
+      diagnosticFor(
+        text,
+        'Terminate the session before you remove the module.',
+        'sentence-length-procedural',
+      ),
+    ]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions.map((s) => s.reason)).toEqual([
+      "Vendor's API verb.",
+      'Quoted verbatim.',
+    ]);
+  });
+
+  it('claims a multi-line diagnostic by the line it starts on', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line sentence-length-procedural -- Step retained verbatim. -->',
+      'Utilise the bracket to hold the sensor and then',
+      'tighten the screw to the specified torque value.',
+      'Utilise the filter to remove the particles and then',
+      'close the cover.',
+      '',
+    ].join('\n');
+    const claimed = diagnosticFor(
+      text,
+      'Utilise the bracket',
+      'sentence-length-procedural',
+      'torque value.',
+    );
+    const notClaimed = diagnosticFor(
+      text,
+      'Utilise the filter',
+      'sentence-length-procedural',
+      'close the cover.',
+    );
+    const result = run(text, [claimed, notClaimed]);
+    expect(result.suppressions.map((s) => s.range)).toEqual([claimed.range]);
+    expect(result.diagnostics.map((d) => d.range)).toEqual([notClaimed.range]);
+  });
+
+  it('withholds findings anchored inside the directive comment itself', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Vendor spelling')], { format: 'text' });
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions[0]?.reason).toBe('directive text is not prose');
+  });
+});

--- a/test/unit/suppressions.test.ts
+++ b/test/unit/suppressions.test.ts
@@ -118,6 +118,31 @@ const NOTE_DOC = [
   '',
 ].join('\n');
 
+const SAMPLES = [
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Live directive. -->',
+  'Utilise the bracket.',
+  '',
+  '```markdown',
+  '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Fenced sample. -->',
+  'Utilise the fenced example.',
+  '```',
+  '',
+  'Write `<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Inline sample. -->` in the file.',
+  '',
+  'Indented sample:',
+  '',
+  '    <!-- ste-ai-ignore-next-line unapproved-vocabulary -- Indented sample. -->',
+  '',
+].join('\n');
+
+const QUOTED_STACK = [
+  '> [!NOTE]',
+  "> <!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor's API verb. -->",
+  '> <!-- ste-ai-ignore-next-line sentence-length-procedural -- Quoted verbatim. -->',
+  '> Terminate the session before you remove the module.',
+  '',
+].join('\n');
+
 describe('scanSuppressions', () => {
   it('parses a next-line directive with its rule ids and reason', () => {
     const doc = analyseDocument({ id: 't', format: 'markdown', text: NEXT_LINE });
@@ -147,6 +172,25 @@ describe('scanSuppressions', () => {
       start: RANGE.indexOf('-->') + 3,
       end: RANGE.indexOf('<!-- ste-ai-ignore-end'),
     });
+  });
+
+  it('ignores a directive that a markdown document only shows as a sample', () => {
+    const doc = analyseDocument({ id: 't', format: 'markdown', text: SAMPLES });
+    const { directives } = scanSuppressions(doc);
+    // Documentation about this feature has to be able to quote it. A fenced, inline-code or
+    // indented sample is a picture of a directive, not one.
+    expect(directives.map((d) => d.reason)).toEqual(['Live directive.']);
+  });
+
+  it('reads every comment in a plain-text document, which has no code regions', () => {
+    const doc = analyseDocument({ id: 't', format: 'text', text: SAMPLES });
+    const { directives } = scanSuppressions(doc);
+    expect(directives.map((d) => d.reason)).toEqual([
+      'Live directive.',
+      'Fenced sample.',
+      'Inline sample.',
+      'Indented sample.',
+    ]);
   });
 
   it('reports a comment that starts with the keyword but parses as no known form', () => {
@@ -410,6 +454,28 @@ describe('applySuppressions', () => {
       "Vendor's API verb.",
       'Quoted verbatim.',
     ]);
+  });
+
+  it('lets stacked directives inside a blockquote claim the same prose line', () => {
+    const result = run(QUOTED_STACK, [
+      diagnosticFor(QUOTED_STACK, 'Terminate'),
+      diagnosticFor(
+        QUOTED_STACK,
+        'Terminate the session before you remove the module.',
+        'sentence-length-procedural',
+      ),
+    ]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions.map((s) => s.reason)).toEqual([
+      "Vendor's API verb.",
+      'Quoted verbatim.',
+    ]);
+  });
+
+  it('does not treat a sampled directive comment as directive text', () => {
+    const result = run(SAMPLES, [diagnosticFor(SAMPLES, 'Fenced sample')]);
+    expect(result.suppressions).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it('claims a multi-line diagnostic by the line it starts on', () => {

--- a/test/unit/suppressions.test.ts
+++ b/test/unit/suppressions.test.ts
@@ -294,6 +294,31 @@ describe('applySuppressions', () => {
     expect(noticeWith(result, 'suppression-unused')?.detail?.['line']).toBe(1);
   });
 
+  it('treats a directive named in alreadyClaimed as used', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Reason recorded for the audit. -->',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const doc = analyseDocument({ id: 't', format: 'markdown', text });
+    const { directives } = scanSuppressions(doc);
+    const input = {
+      doc,
+      diagnostics: [] as readonly Diagnostic[],
+      directives,
+      allowInAdmonitions: false,
+      knownRuleIds: KNOWN_RULE_IDS,
+    };
+
+    // Positive control: with nothing claimed the directive really is dead.
+    expect(applySuppressions(input).notices.map((n) => n.code)).toEqual(['suppression-unused']);
+
+    // The caller filtered a candidate against this directive before the diagnostics were built, so
+    // the applier never sees the claim and would otherwise call a live directive dead.
+    const claimed = applySuppressions({ ...input, alreadyClaimed: directives });
+    expect(claimed.notices.map((n) => n.code)).toEqual([]);
+  });
+
   it('refuses a claim inside a warning admonition and keeps the diagnostic', () => {
     const result = run(WARNING_DOC, [diagnosticFor(WARNING_DOC, 'Utilise the bracket')]);
     expect(result.diagnostics).toHaveLength(1);

--- a/test/unit/suppressions.test.ts
+++ b/test/unit/suppressions.test.ts
@@ -646,4 +646,129 @@ describe('applySuppressions', () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.suppressions[0]?.reason).toBe('directive text is not prose');
   });
+
+  it('does not duplicate a refusal notice already reported for the diagnostic’s underlying candidate', () => {
+    const diagnostic = diagnosticFor(WARNING_DOC, 'Utilise the bracket');
+    const doc = analyseDocument({ id: 't', format: 'markdown', text: WARNING_DOC });
+    const scan = scanSuppressions(doc);
+    const applied = applySuppressions({
+      doc,
+      diagnostics: [diagnostic],
+      directives: scan.directives,
+      allowInAdmonitions: false,
+      knownRuleIds: KNOWN_RULE_IDS,
+      alreadyRefused: [{ ruleId: diagnostic.ruleId, range: diagnostic.range }],
+    });
+    // Still kept: only the second, redundant notice is what has to disappear.
+    expect(applied.diagnostics).toHaveLength(1);
+    expect(applied.notices.map((n) => n.code)).not.toContain('suppression-refused-in-admonition');
+  });
+
+  it('rejects an ignore-end that carries trailing arguments and leaves the range open', () => {
+    const text = [
+      '<!-- ste-ai-ignore-start unapproved-vocabulary -- vendor spelling -->',
+      '',
+      'Utilise the bracket.',
+      '',
+      '<!-- ste-ai-ignore-end unapproved-vocabulary -->',
+      '',
+      'Utilise the filter.',
+      '',
+    ].join('\n');
+    const result = run(text, [
+      diagnosticFor(text, 'Utilise the bracket'),
+      diagnosticFor(text, 'Utilise the filter'),
+    ]);
+    expect(result.codes).toContain('suppression-malformed');
+    expect(result.codes).toContain('suppression-unclosed-range');
+    // The safer failure: the malformed comment did not close the range at all, so it is never
+    // read as a stray `ignore-end` either.
+    expect(result.codes).not.toContain('suppression-end-without-start');
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(2);
+  });
+
+  it('claims a note admonition introduced by a GFM alert marker on its own line', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '> [!NOTE]',
+      '> Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+  });
+
+  it('reaches the refusal for a warning admonition introduced by a GFM alert marker, exactly once', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '> [!WARNING]',
+      '> Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.codes.filter((c) => c === 'suppression-refused-in-admonition')).toHaveLength(1);
+  });
+
+  it('claims a note admonition introduced by an RST/MyST directive line', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '.. note::',
+      '',
+      '   Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+  });
+
+  it('claims a note admonition introduced by an mkdocs container line', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '!!! note',
+      '',
+      '   Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+  });
+
+  it('claims a warning admonition introduced by an AsciiDoc block label', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '[WARNING]',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.codes.filter((c) => c === 'suppression-refused-in-admonition')).toHaveLength(1);
+  });
+
+  it('still voids the claim across an indented sample even next to an admonition-free block', () => {
+    // Regression guard for item 7: the admonition-opener allowance must not reopen the gap to
+    // arbitrary skipped content.
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '    <!-- ste-ai-ignore-next-line unapproved-vocabulary -- Sample only. -->',
+      '',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    expect(result.codes).toContain('suppression-unused');
+  });
 });

--- a/test/unit/suppressions.test.ts
+++ b/test/unit/suppressions.test.ts
@@ -268,6 +268,71 @@ describe('applySuppressions', () => {
     expect(result.suppressions).toHaveLength(2);
   });
 
+  it('claims nothing when unclaimable content lies between it and the next block', () => {
+    // An indented sample is entirely protected, so it produces no block of its own. Stepping over
+    // it silently would withhold a finding in a paragraph the author never pointed at.
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '    <!-- ste-ai-ignore-next-line unapproved-vocabulary -- Sample only. -->',
+      '',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    expect(result.codes).toContain('suppression-unused');
+  });
+
+  it('claims nothing across a fenced code block', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '```sh',
+      'utilise --now',
+      '```',
+      '',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.suppressions).toEqual([]);
+    expect(result.codes).toContain('suppression-unused');
+  });
+
+  it('still claims the first item of the list beneath it', () => {
+    // A list bullet is markup introducing the claimed block, not content standing between.
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '1. Utilise the bracket.',
+      '2. Utilise the filter.',
+      '',
+    ].join('\n');
+    const result = run(text, [
+      diagnosticFor(text, 'Utilise the bracket'),
+      diagnosticFor(text, 'Utilise the filter'),
+    ]);
+    expect(result.suppressions.map((s) => s.message)).toEqual([
+      '"Utilise the bracket" is not an approved term.',
+    ]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it('still claims the heading beneath it', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      '# Utilise the bracket',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions).toHaveLength(1);
+  });
+
   it('does not treat a directive comment line as the block it claims in a text document', () => {
     // In `format: 'text'` the comment is not masked, so the directive line is a block of its own.
     const text = [

--- a/test/unit/suppressions.test.ts
+++ b/test/unit/suppressions.test.ts
@@ -77,8 +77,18 @@ function noticeWith(result: RunResult, code: string): RunNotice | undefined {
 const NEXT_LINE = [
   '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling fixed by contract. -->',
   'Utilise the bracket.',
+  '',
   'Utilise the filter.',
   '',
+].join('\n');
+
+/** The same sentence, written as one long line and as three soft-wrapped ones. */
+const UNWRAPPED =
+  'The technician must inspect the assembly and then utilise the bracket to hold the sensor.';
+const WRAPPED = [
+  'The technician must inspect the assembly and then',
+  'utilise the bracket to hold',
+  'the sensor.',
 ].join('\n');
 
 const SCOPED = [
@@ -157,10 +167,10 @@ describe('scanSuppressions', () => {
       start: 0,
       end: NEXT_LINE.indexOf('-->') + 3,
     });
-    // The span is the whole of the following line, terminator included.
+    // The span runs from the end of the directive to the end of the block beneath it.
     expect(directive?.range).toEqual({
-      start: NEXT_LINE.indexOf('Utilise the bracket.'),
-      end: NEXT_LINE.indexOf('Utilise the filter.'),
+      start: NEXT_LINE.indexOf('-->') + 3,
+      end: NEXT_LINE.indexOf('Utilise the bracket.') + 'Utilise the bracket.'.length,
     });
   });
 
@@ -216,7 +226,62 @@ describe('directiveFor', () => {
 });
 
 describe('applySuppressions', () => {
-  it('claims a finding on the following line and not on the line after that', () => {
+  it('claims the same findings whether the paragraph is soft-wrapped or not', () => {
+    // The property that motivates claiming a block rather than a line. Rewrapping a paragraph is
+    // not an edit to its wording, so it must not change what a suppression covers — under
+    // line-claiming, moving the offending word to the second line silently revoked the suppression.
+    for (const [shape, prose] of [
+      ['unwrapped', UNWRAPPED],
+      ['wrapped', WRAPPED],
+    ] as const) {
+      const text = [
+        '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+        prose,
+        '',
+      ].join('\n');
+      const result = run(text, [diagnosticFor(text, 'utilise')]);
+      expect(result.diagnostics, shape).toEqual([]);
+      expect(
+        result.suppressions.map((s) => s.reason),
+        shape,
+      ).toEqual(['Vendor spelling by contract.']);
+      expect(result.codes, shape).not.toContain('suppression-unused');
+    }
+  });
+
+  it('claims every sentence of the block it names, and not the block after it', () => {
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      'Utilise the bracket. Utilise the filter to remove the particles.',
+      '',
+      'Utilise the cover.',
+      '',
+    ].join('\n');
+    const result = run(text, [
+      diagnosticFor(text, 'Utilise the bracket'),
+      diagnosticFor(text, 'Utilise the filter'),
+      diagnosticFor(text, 'Utilise the cover'),
+    ]);
+    expect(result.diagnostics.map((d) => d.message)).toEqual([
+      '"Utilise the cover" is not an approved term.',
+    ]);
+    expect(result.suppressions).toHaveLength(2);
+  });
+
+  it('does not treat a directive comment line as the block it claims in a text document', () => {
+    // In `format: 'text'` the comment is not masked, so the directive line is a block of its own.
+    const text = [
+      '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Vendor spelling by contract. -->',
+      '',
+      'Utilise the bracket.',
+      '',
+    ].join('\n');
+    const result = run(text, [diagnosticFor(text, 'Utilise the bracket')], { format: 'text' });
+    expect(result.diagnostics).toEqual([]);
+    expect(result.suppressions.map((s) => s.reason)).toEqual(['Vendor spelling by contract.']);
+  });
+
+  it('claims the block below it and not the one after that', () => {
     const result = run(NEXT_LINE, [
       diagnosticFor(NEXT_LINE, 'Utilise the bracket'),
       diagnosticFor(NEXT_LINE, 'Utilise the filter'),
@@ -328,6 +393,7 @@ describe('applySuppressions', () => {
     const text = [
       '<!-- ste-ai-ignore-next-line unapproved-vocabulary -- Reason recorded for the audit. -->',
       'The cover is in place.',
+      '',
       'Utilise the bracket.',
       '',
     ].join('\n');
@@ -456,7 +522,7 @@ describe('applySuppressions', () => {
     ]);
   });
 
-  it('lets stacked directives inside a blockquote claim the same prose line', () => {
+  it('lets stacked directives inside a blockquote each claim the paragraph', () => {
     const result = run(QUOTED_STACK, [
       diagnosticFor(QUOTED_STACK, 'Terminate'),
       diagnosticFor(
@@ -478,11 +544,12 @@ describe('applySuppressions', () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it('claims a multi-line diagnostic by the line it starts on', () => {
+  it('claims a multi-line diagnostic by the block it starts in', () => {
     const text = [
       '<!-- ste-ai-ignore-next-line sentence-length-procedural -- Step retained verbatim. -->',
       'Utilise the bracket to hold the sensor and then',
       'tighten the screw to the specified torque value.',
+      '',
       'Utilise the filter to remove the particles and then',
       'close the cover.',
       '',


### PR DESCRIPTION
Closes #10.

## Why this issue

`src/core/runner.ts:50` reads `userConfig.enabled ?? packSpec?.enabled ?? true`. That is the only lever a user has, and it is whole-rule, whole-run. There is no filter-rule path either: `src/textlint/preset.ts:22-36` exports `rules` and `rulesConfig` and no `filters`, and `textlint-filter-rule-*` appears nowhere in `package.json`.

Against the corpus figures recorded in `docs/provisional-rules.md`, that leaves a user two options — accept persistent noise or disable the rule — and both discard the rule's true positives. `docs/extension-roadmap.md:199-206` ranks this step 1 of 7.

Deferring to `textlint-filter-rule-comments` would not do: the CLI and the programmatic API do not pass through textlint's filter pipeline, so two of the three surfaces would stay uncovered, and a suppression the core does not know about cannot be reported in `--json`.

## Syntax

Three keywords, each written inside an HTML comment, honoured in both `markdown` and `text` documents:

| Keyword | Takes | Claims |
| --- | --- | --- |
| `ste-ai-ignore-next-line` | optional rule ids, then a required reason | the next eligible line |
| `ste-ai-ignore-start` | optional rule ids, then a required reason | everything up to the matching end |
| `ste-ai-ignore-end` | nothing | closes the open range |

Rule ids are comma- or space-separated and precede the reason separator, which is a double hyphen with a space on each side. An empty id list means every rule.

The literal comment delimiters are stripped from this description by GitHub, so the exact form to copy is in [`docs/suppression.md`](https://github.com/Jamie-BitFlight/textlint-ASD-ai/blob/claude/repo-issue-assessment-jhkg3w/docs/suppression.md) along with a worked example.

## Decisions taken

Reasoning recorded in `docs/suppression.md`.

- **A reason is required.** A directive without one is inert and reported as `suppression-reason-missing`.
- **A finding is claimed by the line it is reported on** — anchored on the diagnostic's start offset, not on span overlap. A sentence-length diagnostic covers a sentence running over several lines; under an overlap rule a next-line directive anywhere in those lines would claim it.
- **`next-line` skips blank lines and directive-only lines.** A blank line between an HTML comment and the paragraph beneath it is ordinary Markdown formatting. Skipping directive-only lines lets directives stack, each with its own rule id and reason.
- **Suppressions are recorded, never discarded.** A withheld finding leaves `diagnostics` and does not leave the result: `AnalysisResult.suppressions`, the `--json` per-file array, the CLI `suppressed` lines, and a `suppressions-applied` notice. This is the same rule that already forbids an outage from being converted into compliance (`docs/diagnostic-policy.md:29-33`). A `suppression-unused` notice keeps dead directives reviewable.
- **The admonition interaction the issue asked to settle.** A claim inside a `danger`, `warning` or `caution` block is refused by default; the diagnostic is kept and `suppression-refused-in-admonition` is emitted. `suppressions.allowInAdmonitions` permits it. `autofix.allowInAdmonitions` stays `z.literal(false)` and untouched — rewriting the source of a safety notice and withholding a report about one are different acts, and only the second is an operator's decision to take.
- **A suppressed candidate is never sent to the model.** Candidates are filtered before adjudication, so a passage an operator has ruled on is neither paid for nor transmitted.

Known limitation, documented: `info`-level notices do not reach a textlint report (`src/textlint/adapter.ts:215`), so suppressions are audited through the CLI or the programmatic API.

## Commits on this branch

| Commit | Contents | Verified |
| --- | --- | --- |
| `03afc37` | `docs/suppression.md` plus updates to `configuration.md`, `diagnostic-policy.md`, `extension-roadmap.md`, `README.md` | CI success |
| `82bfcf0` | `src/core/suppressions.ts`, the two new types, the `suppressions` config schema, the barrel export, 23 unit tests | CI success |

## Still to land

The wiring: `src/analysis/analyse.ts` (both entry points, plus candidate filtering ahead of model dispatch), the `src/cli/main.ts` `--json` and human-output changes, and the integration and e2e tests. Written test-first.

## Verification

`npm test` was 16 files / 371 tests passing before any change on this branch. At `82bfcf0` it is 17 files / 394 tests passing, with `npm run typecheck` and `eslint` clean.