### PR TITLE
docs: state the real mission, fix stale reader-architecture status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Working on this repo
+
+## Documentation stays in sync with code — no confirmation needed
+
+Standing pre-approval: whenever a task changes functionality, update the documentation that
+describes it as part of the same task, without asking first. Stale documentation is never
+acceptable output. A task that changes behavior but leaves the docs describing the old behavior is
+an incomplete task, not a finished one with a follow-up.
+
+This covers `README.md`, everything under `docs/`, doc comments on changed code, and any other
+file whose job is to describe current behavior to a human or an agent reading it later. It does not
+require a separate confirmation step, a separate PR, or asking whether documentation should be
+updated — that question is already answered.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # textlint-rule-preset-ste-ai
 
-An auditable Simplified Technical English linter for technical documentation: deterministic textlint
-rules, plus an **optional** semantic-adjudication subsystem that calls a small model served locally by
-llama.cpp. It is meant to run inside a pre-commit hook — Husky, prek, or the Python `pre-commit`
-framework, invoked via `npx` — most often checking documentation an AI agent has just drafted, so the
-agent's vocabulary stays consistent with the project's before the commit lands.
+A linter that lets an AI agent gate the documents it writes for clarity, readability, and vocabulary
+consistency — checked against a checkable, per-project-approved vocabulary, not just a generic style
+guide. "Write following ASD-STE100 guidelines" is already a prompt pattern agents respond well to,
+producing shorter, clearer text; this package turns that pattern into something enforceable and
+gateable instead of a hope. It ships deterministic textlint rules, plus an **optional**
+semantic-adjudication subsystem that calls a small model served locally by llama.cpp for the checks
+that genuinely need judgement. It is meant to run inside a pre-commit hook — Husky, prek, or the
+Python `pre-commit` framework, invoked via `npx` — most often checking documentation an AI agent has
+just drafted, so the agent's vocabulary stays consistent with the project's before the commit lands.
 
 > **This package does not implement ASD-STE100 and makes no claim of conformance with it.** The
-> standard and its dictionary are proprietary and were not available to this repository. Every rule
-> shipped here is an authored plain-English heuristic marked `provisional`. Read
-> [`docs/DISCLAIMER.md`](docs/DISCLAIMER.md) before using this anywhere it matters.
+> standard and its dictionary are proprietary and were not available to this repository. ASD-STE100
+> is referenced here as a known target agents already understand, not as a specification this
+> package reproduces. Every rule shipped here is an authored plain-English heuristic marked
+> `provisional`. Read [`docs/DISCLAIMER.md`](docs/DISCLAIMER.md) before using this anywhere it
+> matters.
 
 ## The idea
 
@@ -19,17 +25,16 @@ schema-validated, threshold-gated, span-anchored and traced.
 
 ```
                     ┌────────────────────────────────┐
-  markdown / text → │ protected regions → blocks →   │ → deterministic rules → violations
-                    │ sentences → words (offsets     │ ↘
-                    │ preserved throughout)          │   candidates → broker → evaluator → verdict
+  markdown / text → │ pluggable document reader →    │ → deterministic rules → violations
+                    │ text units → sentences → words │ ↘
+                    │ (offsets preserved throughout) │   candidates → broker → evaluator → verdict
                     └────────────────────────────────┘        (optional, local, off by default)
 ```
 
-The "protected regions → blocks" step is implemented today by hand-written regex over masked text,
-selected by a `markdown`/`text` format flag. That is being replaced by a pluggable document reader —
-a real parser for Markdown first — feeding the same reader-agnostic rules below; see
-[issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25) and
-[`docs/architecture.md`](docs/architecture.md). It is in progress, not shipped.
+Document structure is read through a real parser (`@textlint/markdown-to-ast` for Markdown today) via
+a pluggable `DocumentReader` interface, not hand-written regex over masked text; see
+[`docs/architecture.md`](docs/architecture.md) for the reasoning and
+[issue #25](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/25) for the history.
 
 ## Install
 


### PR DESCRIPTION
## What

- `README.md`'s opening framing described this as a Simplified Technical English linter with a caveat that the architecture was still in progress. Restated it as what it actually is: a gate for AI-agent-written documents against checkable, project-approved vocabulary, using ASD-STE100 as a known target agents already respond well to ("write following ASD-STE100 guidelines"), not a specification this package implements or claims conformance with.
- Fixed a stale claim: the document-reader rewrite (#25) merged via PR #32 — "in progress, not shipped" and the link to the old repo name (`textlint-ASD-ai`, before the rename to `textlint-rule-preset-ste-ai`) were both wrong. The diagram and prose now describe the pluggable `DocumentReader` as what's actually shipped.
- Added `CLAUDE.md`: standing pre-approval that documentation stays in sync with any functional change, as part of the same task, without asking first.

## Why

Maintainer-directed. Doc-only change, no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXVhFQhSfdvdu8n7houDK6)_