### PR TITLE
Fix the 7 ponytail-audit findings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,12 +234,34 @@ autofix policy, protected terminology) is read from a shared file — see
 file, `shared` override, the rule's own textlint options. Replacing an object wholesale would drop an
 `enabled: false` set by a lower layer; there is a test for that.
 
-## Document reader — design note (pending review, not yet implemented)
+## Document reader — design note (implemented; the async `DocumentReader` interface below since removed)
 
-**Status.** Nothing in this section is built. No code under `src/` or `test/` has changed for it. It
-is written to be read, argued with, and either approved or sent back — see the gate at the end. The
-section above this one already states the motivation (issue #25, issue #11's measured 0/35 result on
-`noun-cluster-candidate`) and is not repeated here.
+**Status.** The note below predates implementation and was never updated once the work landed (PR
+#32, then a follow-on stage that wired the reader into `analysis`) — read it as a historical record
+of the reasoning, not as a description of today's `src/reader/` module. Three things it proposed did
+not survive contact with the constraints §3 and the code itself already state:
+
+- The `DocumentReader` interface and its `read(): AsyncIterable<TextUnit>` method (§1) were built
+  exactly as drafted, on `MarkdownReader`/`PlainTextReader`, but never gained a production caller.
+  `analyseTextDeterministic` documents itself as performing no I/O — a contract existing callers
+  rely on — and `analysis`'s other entry point, `analyseText`, called the reader's own synchronous
+  core (`readMarkdownUnitsSync`/`readPlainTextUnitsSync`, added specifically so a synchronous caller
+  had something to call) rather than `read()`, for no reason particular to it being async; it simply
+  never needed to be. With zero callers actually awaiting the interface, "every caller already
+  awaits" (§1's stated reason for making `read()` async ahead of any reader that needed it) turned
+  out not to hold, so the `DocumentReader` interface and the two wrapper classes were removed
+  (ponytail-audit yagni finding), leaving `readMarkdownUnitsSync`/`readPlainTextUnitsSync` as the
+  real, and only, public reader API. Reintroduce an async seam when a reader that genuinely needs
+  real I/O — docx, a remotely-fetched document — actually lands; at that point `analyseTextDeterministic`'s
+  "no I/O" contract, not this note, is what should drive the interface's shape.
+- §7 lists "`analysis` wired to select a reader by `DocumentFormat` and iterate its units" as in
+  scope; what was actually built has `src/analysis/analyse.ts` call the synchronous functions above
+  directly and build blocks from their output (see that file's own `readerBlocksFor` and its doc
+  comment), not iterate an `AsyncIterable`.
+
+The rest of this section — the parser choice (§2), the module-boundary reasoning (§3), the offset
+contract demonstration (§4) and everything after — is otherwise still accurate: it was implemented as
+described and is not repeated or corrected again below.
 
 ### 1. The `DocumentReader` interface and the text unit
 

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -63,7 +63,6 @@ falls back to the provisional pack silently.
     "sentenceReadabilityFloorWords": 20,
     "maxNounClusterLength": 3,
     "maxSentencesPerProceduralStep": 1,
-    "maxParagraphSentences": 6,
   },
 
   "dictionary": {

--- a/scripts/build-candidate-packets.mjs
+++ b/scripts/build-candidate-packets.mjs
@@ -16,21 +16,33 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
 import { resolveConfig } from '../dist/core/config.js';
 import { analyseDocument } from '../dist/core/document.js';
 import { runDeterministicRules } from '../dist/core/runner.js';
 import { deterministicRules } from '../dist/deterministic/index.js';
 import { resolveRulePack } from '../dist/rule-pack/loader.js';
 
-const args = process.argv.slice(2);
-function flag(name, fallback) {
-  const index = args.indexOf(name);
-  return index === -1 ? fallback : args[index + 1];
+let values;
+try {
+  ({ values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      fixtures: { type: 'string', default: 'fixtures' },
+      split: { type: 'string', default: 'all' },
+      out: { type: 'string' },
+    },
+    strict: true,
+    allowPositionals: false,
+  }));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
 }
 
-const fixturesDir = resolve(flag('--fixtures', 'fixtures'));
-const split = flag('--split', 'all');
-const outDir = flag('--out', undefined);
+const fixturesDir = resolve(values.fixtures);
+const split = values.split;
+const outDir = values.out;
 
 const manifest = JSON.parse(readFileSync(join(fixturesDir, 'manifest.json'), 'utf8'));
 const config = resolveConfig({});

--- a/scripts/evaluate-semantic.mjs
+++ b/scripts/evaluate-semantic.mjs
@@ -14,6 +14,7 @@
 import { existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 if (!existsSync(join(root, 'dist', 'evaluation', 'evaluate.js'))) {
@@ -26,23 +27,37 @@ const { evaluateSemanticEvaluators, formatEvaluationReport } = await import(
 );
 const { LlamaCppClient } = await import(join(root, 'dist', 'model-client', 'llama-client.js'));
 
-const argv = process.argv.slice(2);
-const flag = (name, fallback) => {
-  const i = argv.indexOf(`--${name}`);
-  return i >= 0 && argv[i + 1] !== undefined ? argv[i + 1] : fallback;
-};
-const has = (name) => argv.includes(`--${name}`);
+let values;
+try {
+  ({ values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      split: { type: 'string', default: 'heldout' },
+      endpoint: { type: 'string', default: 'http://127.0.0.1:8080' },
+      model: { type: 'string', default: 'local-ste-adjudicator' },
+      timeout: { type: 'string', default: '30000' },
+      concurrency: { type: 'string', default: '2' },
+      out: { type: 'string' },
+      json: { type: 'boolean', default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  }));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+}
 
-const split = flag('split', 'heldout');
+const split = values.split;
 if (!['dev', 'heldout', 'all'].includes(split)) {
   console.error(`--split must be dev, heldout or all (got "${split}")`);
   process.exit(2);
 }
-const endpoint = flag('endpoint', 'http://127.0.0.1:8080');
-const model = flag('model', 'local-ste-adjudicator');
-const timeout = Number(flag('timeout', '30000'));
-const concurrency = Number(flag('concurrency', '2'));
-const out = flag('out', undefined);
+const endpoint = values.endpoint;
+const model = values.model;
+const timeout = Number(values.timeout);
+const concurrency = Number(values.concurrency);
+const out = values.out;
 
 const transport = new LlamaCppClient({ endpoint, requestTimeoutMs: timeout });
 
@@ -63,7 +78,7 @@ const report = await evaluateSemanticEvaluators({
   },
 });
 
-if (has('json')) {
+if (values.json) {
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 } else {
   process.stdout.write(`${formatEvaluationReport(report)}\n`);

--- a/scripts/merge-candidate-verdicts.mjs
+++ b/scripts/merge-candidate-verdicts.mjs
@@ -27,17 +27,30 @@
 
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
 
-const args = process.argv.slice(2);
-function flag(name, fallback) {
-  const index = args.indexOf(name);
-  return index === -1 ? fallback : args[index + 1];
+let values;
+try {
+  ({ values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      verdicts: { type: 'string', default: 'fixtures/verdicts' },
+      packets: { type: 'string', default: 'fixtures/packets' },
+      fixtures: { type: 'string', default: 'fixtures' },
+      check: { type: 'boolean', default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  }));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
 }
 
-const verdictsDir = resolve(flag('--verdicts', 'fixtures/verdicts'));
-const packetsDir = resolve(flag('--packets', 'fixtures/packets'));
-const fixturesDir = resolve(flag('--fixtures', 'fixtures'));
-const checkOnly = args.includes('--check');
+const verdictsDir = resolve(values.verdicts);
+const packetsDir = resolve(values.packets);
+const fixturesDir = resolve(values.fixtures);
+const checkOnly = values.check;
 
 const jsonFiles = (dir) => readdirSync(dir).filter((f) => f.endsWith('.json'));
 

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -167,11 +167,26 @@ export interface AnalysisResult {
   readonly config: SteAiConfig;
 }
 
-/** Deterministic-only analysis. Never performs I/O beyond reading the rule pack. */
-export function analyseTextDeterministic(
+/**
+ * Shared setup for both production entry points below: resolve config and rule pack, build the
+ * source document, run structural analysis over the reader's blocks, run the deterministic rules,
+ * and filter candidates through any inline suppression directives.
+ *
+ * {@link analyseTextDeterministic} and {@link analyseText} differ only in what they do with the
+ * result — the deterministic path turns leftover candidates into `review-required` diagnostics
+ * itself, while the full path hands them to semantic adjudication — so everything up to and
+ * including `suppressCandidates` is identical between them and lives here once.
+ */
+function prepareRun(
   text: string,
-  options: AnalyseTextOptions = {},
-): AnalysisResult {
+  options: AnalyseTextOptions,
+): {
+  readonly config: SteAiConfig;
+  readonly pack: RulePack;
+  readonly document: AnalysedDocument;
+  readonly run: ReturnType<typeof runDeterministicRules>;
+  readonly pass: CandidateSuppressionPass;
+} {
   const config = resolveConfig(options.config ?? {});
   const pack = resolveRulePack(config.rulePack, options.baseDir ?? process.cwd());
   const format = options.format ?? 'markdown';
@@ -192,8 +207,8 @@ export function analyseTextDeterministic(
     blocks: readerBlocksFor(sourceDoc, structureOptions),
   });
 
-  // Fix conflicts are resolved below instead, once the suppressed findings are out of the list: a
-  // finding nobody will be shown must not be able to veto another finding's fix.
+  // Fix conflicts are resolved by each caller instead, once the suppressed findings are out of the
+  // list: a finding nobody will be shown must not be able to veto another finding's fix.
   const run = runDeterministicRules({
     doc: document,
     rules: deterministicRules,
@@ -203,6 +218,16 @@ export function analyseTextDeterministic(
   });
 
   const pass = suppressCandidates(document, run.candidates, config);
+
+  return { config, pack, document, run, pass };
+}
+
+/** Deterministic-only analysis. Never performs I/O beyond reading the rule pack. */
+export function analyseTextDeterministic(
+  text: string,
+  options: AnalyseTextOptions = {},
+): AnalysisResult {
+  const { config, pack, document, run, pass } = prepareRun(text, options);
 
   // Candidates are passages no deterministic rule could decide. Returning only `run.diagnostics`
   // discarded them, so a document whose only findings needed adjudication reported clean — the
@@ -502,38 +527,10 @@ export async function analyseText(
   text: string,
   options: AnalyseTextOptions = {},
 ): Promise<AnalysisResult> {
-  const config = resolveConfig(options.config ?? {});
-  const pack = resolveRulePack(config.rulePack, options.baseDir ?? process.cwd());
-  const format = options.format ?? 'markdown';
-
-  const sourceDoc: SourceDocument = {
-    id: options.id ?? options.path ?? 'document',
-    format,
-    text,
-    ...(options.path === undefined ? {} : { path: options.path }),
-  };
-  const structureOptions = structureOptionsFor(format, config);
-  const document = analyseDocument(sourceDoc, {
-    protectedRegions: {
-      approvedTerms: [...config.approvedTerms, ...pack.approvedTechnicalTerms],
-      extraPatterns: config.extraProtectedPatterns,
-    },
-    structure: structureOptions,
-    blocks: readerBlocksFor(sourceDoc, structureOptions),
-  });
+  const { config, pack, document, run, pass } = prepareRun(text, options);
 
   // Overlap resolution is deferred to the merged, post-suppression list below. It has to see the
   // semantic fixes anyway, and a withheld finding must not veto a surviving finding's fix.
-  const run = runDeterministicRules({
-    doc: document,
-    rules: deterministicRules,
-    config,
-    pack,
-    resolveFixes: false,
-  });
-
-  const pass = suppressCandidates(document, run.candidates, config);
-
   const transport: ModelTransport =
     options.transport ??
     new LlamaCppClient({

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { parseArgs as parseArgsNode, type ParseArgsOptionsConfig } from 'node:util';
 import { analyseText, analyseTextDeterministic } from '../analysis/analyse.js';
 import type { SteAiConfigInput } from '../core/config.js';
 import type { AnalysedDocument, Diagnostic, RunNotice, SuppressionRecord } from '../core/types.js';
@@ -44,20 +45,6 @@ interface Args {
   readonly flags: Map<string, string | boolean>;
 }
 
-/**
- * Recognised boolean options. An unknown `--flag` is a usage error rather than an ignored token:
- * a typo such as `--semantci` used to fall through silently to deterministic-only mode, producing
- * a clean-looking report for a run the operator believed was using a model.
- */
-const BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
-  'json',
-  'deterministic-only',
-  'semantic',
-  'trace',
-  'fail-on-review',
-  'help',
-]);
-
 export class UsageError extends Error {
   constructor(message: string) {
     super(message);
@@ -65,37 +52,49 @@ export class UsageError extends Error {
   }
 }
 
-function parseArgs(argv: readonly string[]): Args {
-  const flags = new Map<string, string | boolean>();
-  const files: string[] = [];
-  let command = '';
-  const valued = new Set(['endpoint', 'model', 'config', 'format', 'min-severity']);
+/**
+ * Recognised options. An unknown `--flag` is a usage error rather than an ignored token: a typo such
+ * as `--semantci` used to fall through silently to deterministic-only mode, producing a clean-looking
+ * report for a run the operator believed was using a model. `strict: true` below (`node:util`'s own
+ * default) is what still enforces that, now via the standard library instead of a hand-rolled set
+ * membership check.
+ */
+const OPTIONS: ParseArgsOptionsConfig = {
+  json: { type: 'boolean' },
+  'deterministic-only': { type: 'boolean' },
+  semantic: { type: 'boolean' },
+  trace: { type: 'boolean' },
+  'fail-on-review': { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+  endpoint: { type: 'string' },
+  model: { type: 'string' },
+  config: { type: 'string' },
+  format: { type: 'string' },
+  'min-severity': { type: 'string' },
+};
 
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === undefined) continue;
-    if (arg === '-h' || arg === '--help') {
-      flags.set('help', true);
-      continue;
-    }
-    if (arg.startsWith('--')) {
-      const name = arg.slice(2);
-      if (valued.has(name)) {
-        const value = argv[i + 1];
-        if (value === undefined) throw new UsageError(`--${name} needs a value`);
-        flags.set(name, value);
-        i += 1;
-      } else {
-        if (!BOOLEAN_FLAGS.has(name)) {
-          throw new UsageError(`Unknown option --${name}`);
-        }
-        flags.set(name, true);
-      }
-      continue;
-    }
-    if (command === '') command = arg;
-    else files.push(arg);
+function parseArgs(argv: readonly string[]): Args {
+  let parsed: ReturnType<typeof parseArgsNode>;
+  try {
+    parsed = parseArgsNode({
+      args: [...argv],
+      options: OPTIONS,
+      strict: true,
+      allowPositionals: true,
+    });
+  } catch (error) {
+    // `node:util.parseArgs` throws a `TypeError` (`ERR_PARSE_ARGS_UNKNOWN_OPTION`,
+    // `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`, …) for exactly the same input shapes the previous
+    // hand-rolled parser rejected: an unknown `--flag`, or a valued flag given no value. Recast as
+    // `UsageError` so `main()`'s existing catch — print `USAGE`, exit 2 — still fires unchanged.
+    throw new UsageError(error instanceof Error ? error.message : String(error));
   }
+
+  const flags = new Map<string, string | boolean>();
+  for (const [name, value] of Object.entries(parsed.values)) {
+    if (typeof value === 'string' || typeof value === 'boolean') flags.set(name, value);
+  }
+  const [command = '', ...files] = parsed.positionals;
   return { command, files, flags };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import type { DiagnosticCategory, Severity } from './types.js';
 
 export const severitySchema = z.enum(['info', 'warning', 'error']);
 
@@ -150,8 +149,4 @@ export type SteAiConfigInput = z.input<typeof steAiConfigSchema>;
 
 export function resolveConfig(input: unknown): SteAiConfig {
   return steAiConfigSchema.parse(input ?? {});
-}
-
-export function severityFor(policy: DiagnosticPolicy, category: DiagnosticCategory): Severity {
-  return policy.severity[category];
 }

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -122,11 +122,6 @@ export function tokenizeWords(masked: string, offset = 0): Word[] {
   return out;
 }
 
-/** Count words, which is what every sentence-length limit is expressed in. */
-export function countWords(words: readonly Word[]): number {
-  return words.length;
-}
-
 /** Trim a range so it excludes leading/trailing whitespace in `text`. */
 export function trimRange(text: string, range: SourceRange): SourceRange {
   let { start, end } = range;

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { SourcePosition, SourceRange, Word } from './types.js';
 
 /** The character opaque protected regions are masked with. Never appears in real prose. */
@@ -130,17 +132,20 @@ export function trimRange(text: string, range: SourceRange): SourceRange {
   return { start, end };
 }
 
-/** Stable content hash (FNV-1a 64-bit, hex). Deterministic across processes and platforms. */
+/**
+ * Stable content hash (SHA-256, hex). Deterministic across processes and platforms.
+ *
+ * Used only as a cache/dedup key (`SemanticTrace.contentHash`, `SemanticBroker`'s request cache,
+ * `textlint/adapter.ts`'s config-fingerprint) — an opaque, collision-resistant string, never parsed
+ * or compared to a fixed length by any caller. Each part is hashed with a trailing separator so
+ * `contentHash('ab', 'c')` and `contentHash('a', 'bc')` cannot collide by concatenation alone, the
+ * same property the previous FNV-1a implementation preserved by mixing a delimiter after every part.
+ */
 export function contentHash(...parts: readonly string[]): string {
-  let hash = 0xcbf29ce484222325n;
-  const prime = 0x100000001b3n;
-  const mask = 0xffffffffffffffffn;
-  const encoder = new TextEncoder();
+  const hash = createHash('sha256');
   for (const part of parts) {
-    for (const byte of encoder.encode(part)) {
-      hash = ((hash ^ BigInt(byte)) * prime) & mask;
-    }
-    hash = ((hash ^ 0x1fn) * prime) & mask;
+    hash.update(part);
+    hash.update('\x1f');
   }
-  return hash.toString(16).padStart(16, '0');
+  return hash.digest('hex');
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -460,7 +460,6 @@ export interface RulePackLimits {
   readonly sentenceReadabilityFloorWords: number;
   readonly maxNounClusterLength: number;
   readonly maxSentencesPerProceduralStep: number;
-  readonly maxParagraphSentences: number;
 }
 
 export interface RulePackRuleSpec {

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -200,11 +200,6 @@ export function isFunctionWord(word: Word): boolean {
   return FUNCTION_WORDS.has(word.lower);
 }
 
-/** Blocks indexed by id. */
-export function indexBlocks(blocks: readonly TextBlock[]): Map<string, TextBlock> {
-  return new Map(blocks.map((b) => [b.id, b]));
-}
-
 /** Sibling list items: same depth, contiguous in document order, all `list-item`. */
 export function groupSiblingListItems(blocks: readonly TextBlock[]): TextBlock[][] {
   const groups: TextBlock[][] = [];

--- a/src/reader/index.ts
+++ b/src/reader/index.ts
@@ -1,3 +1,3 @@
-export type { DocumentReader, TextUnit } from './types.js';
-export { MarkdownReader, readMarkdownUnitsSync } from './markdown-reader.js';
-export { PlainTextReader, readPlainTextUnitsSync } from './plain-text-reader.js';
+export type { TextUnit } from './types.js';
+export { readMarkdownUnitsSync } from './markdown-reader.js';
+export { readPlainTextUnitsSync } from './plain-text-reader.js';

--- a/src/reader/markdown-reader.ts
+++ b/src/reader/markdown-reader.ts
@@ -19,7 +19,7 @@ import {
   isBareAdmonitionOpener,
 } from '../core/structure.js';
 import type { AdmonitionKind, SourceDocument, SourceRange, TextMode } from '../core/types.js';
-import type { DocumentReader, TextUnit } from './types.js';
+import type { TextUnit } from './types.js';
 
 /**
  * Reads Markdown through a real parser (`@textlint/markdown-to-ast`) instead of the regex-driven
@@ -32,25 +32,15 @@ import type { DocumentReader, TextUnit } from './types.js';
  * parsed node's own `range`, or derived from its children's ranges (see {@link contentRange}). The
  * offset contract holds by construction: nothing here re-slices, re-indexes or otherwise
  * reconstructs a position, so every range is already a valid offset into the source the parser saw.
+ *
+ * Synchronous, not behind an async `DocumentReader` interface: `src/analysis/analyse.ts` is the one
+ * production caller, `analyseTextDeterministic` documents itself as performing no I/O (a contract
+ * existing callers rely on), and nothing here actually needs an event-loop turn — `parse()` and the
+ * tree walk are both synchronous underneath. An earlier async `DocumentReader.read()` wrapper around
+ * this function was removed (ponytail-audit yagni finding) once it turned out to have no caller of
+ * its own; see `docs/architecture.md`, "Document reader", for the full history. Reintroduce an async
+ * seam if and when a reader that genuinely needs real I/O (docx, a remotely-fetched document) lands.
  */
-export class MarkdownReader implements DocumentReader {
-  readonly mediaType = 'markdown' as const;
-
-  /**
-   * `async` to satisfy {@link DocumentReader}, but a thin wrapper: every step underneath —
-   * `parse()`, the tree walk — is synchronous. `readMarkdownUnitsSync` is the real implementation,
-   * exported separately for callers (`src/core/document.ts` via `src/analysis/analyse.ts`) that
-   * cannot themselves become async: `core` must never import `reader` at all (module boundary), and
-   * `analyseTextDeterministic` documents itself as performing no I/O, a contract existing callers
-   * rely on. Nothing here actually needs an event-loop turn, so nothing is lost by also offering it
-   * synchronously.
-   */
-  async *read(doc: SourceDocument): AsyncIterable<TextUnit> {
-    for (const unit of readMarkdownUnitsSync(doc)) yield unit;
-  }
-}
-
-/** The synchronous core `MarkdownReader.read()` wraps. See the class doc for why this exists. */
 export function readMarkdownUnitsSync(doc: SourceDocument): TextUnit[] {
   const ast = parse(doc.text);
   const counter = new Counter();

--- a/src/reader/plain-text-reader.ts
+++ b/src/reader/plain-text-reader.ts
@@ -1,25 +1,17 @@
 import { defaultStructureOptions, detectMode } from '../core/structure.js';
 import { computeLineStarts, trimRange } from '../core/text.js';
 import type { SourceDocument } from '../core/types.js';
-import type { DocumentReader, TextUnit } from './types.js';
+import type { TextUnit } from './types.js';
 
 /**
- * The simplest reader that satisfies {@link DocumentReader}: `format: 'text'` has no structure
- * beyond blank-line-separated paragraphs, which is exactly what `src/core/structure.ts`'s
- * `format === 'text'` branch already does. No parser dependency, because plain text has nothing
- * for a parser to recover that a blank-line scan does not already give exactly.
+ * The simplest reader for `format: 'text'`, which has no structure beyond blank-line-separated
+ * paragraphs — exactly what `src/core/structure.ts`'s `format === 'text'` branch already does. No
+ * parser dependency, because plain text has nothing for a parser to recover that a blank-line scan
+ * does not already give exactly.
+ *
+ * Synchronous — see `readMarkdownUnitsSync`'s doc comment (`src/reader/markdown-reader.ts`) for why
+ * this reader has no async wrapper.
  */
-export class PlainTextReader implements DocumentReader {
-  readonly mediaType = 'text' as const;
-
-  /** `async` to satisfy {@link DocumentReader}; the blank-line scan underneath is synchronous. See
-   * `MarkdownReader.read()`'s doc for why a synchronous core is exported alongside this. */
-  async *read(doc: SourceDocument): AsyncIterable<TextUnit> {
-    for (const unit of readPlainTextUnitsSync(doc)) yield unit;
-  }
-}
-
-/** The synchronous core `PlainTextReader.read()` wraps. */
 export function readPlainTextUnitsSync(doc: SourceDocument): TextUnit[] {
   return splitParagraphs(doc.text);
 }

--- a/src/reader/types.ts
+++ b/src/reader/types.ts
@@ -1,10 +1,4 @@
-import type {
-  AdmonitionKind,
-  DocumentFormat,
-  SourceDocument,
-  SourceRange,
-  TextMode,
-} from '../core/types.js';
+import type { AdmonitionKind, SourceRange, TextMode } from '../core/types.js';
 
 /**
  * One reader-recognised span of the document that the checker treats as a unit of judgement.
@@ -43,14 +37,4 @@ export interface TextUnit {
   /** 1-based, the number actually written for this item in an ordered list. Same meaning as
    * `TextBlock.listOrdinal`; `undefined` for anything that is not an ordered list's item. */
   readonly listOrdinal?: number;
-}
-
-export interface DocumentReader {
-  readonly mediaType: DocumentFormat;
-  /**
-   * Async even though every reader today is synchronous underneath. A reader for docx, or one
-   * backed by a remotely-fetched document, may need real I/O to produce its next unit, and there
-   * must be no second interface for that later — every caller already awaits.
-   */
-  read(doc: SourceDocument): AsyncIterable<TextUnit>;
 }

--- a/src/rule-pack/provisional-pack.ts
+++ b/src/rule-pack/provisional-pack.ts
@@ -51,7 +51,6 @@ export const provisionalRulePack: RulePack = {
     // description at the same length.
     maxNounClusterLength: 3,
     maxSentencesPerProceduralStep: 1,
-    maxParagraphSentences: 6,
   },
 
   dictionary: {

--- a/src/rule-pack/schema.ts
+++ b/src/rule-pack/schema.ts
@@ -74,7 +74,6 @@ export const rulePackLimitsSchema = z.object({
   sentenceReadabilityFloorWords: z.number().int().min(1).max(200),
   maxNounClusterLength: z.number().int().min(2).max(10),
   maxSentencesPerProceduralStep: z.number().int().min(1).max(10),
-  maxParagraphSentences: z.number().int().min(1).max(50),
 });
 
 export const rulePackRuleSpecSchema = z.object({

--- a/src/semantic/broker.ts
+++ b/src/semantic/broker.ts
@@ -14,12 +14,12 @@ import {
 } from '../model-client/cache.js';
 import { TransportError, type ChatMessage, type ModelTransport } from '../model-client/types.js';
 import { buildEvaluatorRequest, type EvaluatorRequest } from './evaluators.js';
-import { FilePromptProvider, type PromptProvider } from './prompt-loader.js';
+import { FilePromptProvider } from './prompt-loader.js';
 import { semanticVerdictJsonSchema, validateSemanticResponse } from './response-schema.js';
 
 export interface SemanticBrokerDeps {
   readonly transport: ModelTransport;
-  readonly promptProvider?: PromptProvider;
+  readonly promptProvider?: FilePromptProvider;
   readonly cache?: SemanticCache<SemanticVerdict>;
   /** Injectable clock for deterministic duration assertions in tests. */
   readonly now?: () => number;
@@ -46,7 +46,7 @@ export interface BrokerStats {
 export class SemanticBroker {
   readonly #config: SemanticConfig;
   readonly #transport: ModelTransport;
-  readonly #prompts: PromptProvider;
+  readonly #prompts: FilePromptProvider;
   readonly #cache: SemanticCache<SemanticVerdict>;
   readonly #now: () => number;
   readonly #trace?: (trace: SemanticTrace & { readonly detail?: string }) => void;

--- a/src/semantic/evaluators.ts
+++ b/src/semantic/evaluators.ts
@@ -2,7 +2,7 @@ import type { SemanticConfig } from '../core/config.js';
 import { contentHash } from '../core/text.js';
 import type { CandidatePassage, SemanticEvaluatorId } from '../core/types.js';
 import type { ChatMessage } from '../model-client/types.js';
-import { formatValue, renderTemplate, type PromptProvider } from './prompt-loader.js';
+import { formatValue, renderTemplate, type FilePromptProvider } from './prompt-loader.js';
 
 /**
  * Evaluator definitions.
@@ -121,7 +121,7 @@ export class EvaluatorError extends Error {
 export function buildEvaluatorRequest(
   candidate: CandidatePassage,
   config: SemanticConfig,
-  prompts: PromptProvider,
+  prompts: FilePromptProvider,
 ): EvaluatorRequest {
   const definition = findEvaluator(candidate.evaluatorId);
   if (definition === undefined) {

--- a/src/semantic/prompt-loader.ts
+++ b/src/semantic/prompt-loader.ts
@@ -26,10 +26,6 @@ export interface PromptTemplate {
   readonly variables: readonly string[];
 }
 
-export interface PromptProvider {
-  get(version: string, evaluatorId: string): PromptTemplate;
-}
-
 export class PromptError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
@@ -72,7 +68,7 @@ export function parsePromptFile(text: string, origin: string): PromptTemplate {
   return { id, version, system, user, meta, variables };
 }
 
-export class FilePromptProvider implements PromptProvider {
+export class FilePromptProvider {
   readonly #root: string;
   readonly #cache = new Map<string, PromptTemplate>();
 

--- a/test/unit/broker.test.ts
+++ b/test/unit/broker.test.ts
@@ -249,7 +249,7 @@ describe('SemanticBroker — evaluator selection and tracing', () => {
     const [outcome] = await broker.adjudicate([candidate('a')]);
     expect(outcome?.trace.promptVersion).toBe('v1');
     expect(outcome?.trace.modelId).toBe('m1');
-    expect(outcome?.trace.contentHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(outcome?.trace.contentHash).toMatch(/^[0-9a-f]{64}$/);
     expect(traces).toHaveLength(1);
   });
 

--- a/test/unit/prompts.test.ts
+++ b/test/unit/prompts.test.ts
@@ -149,7 +149,7 @@ describe('request construction', () => {
       expect(request.messages[1]?.role).toBe('user');
       expect(request.evaluatorId).toBe(definition.id);
       expect(request.promptVersion).toBe('v1');
-      expect(request.contentHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(request.contentHash).toMatch(/^[0-9a-f]{64}$/);
     }
   });
 

--- a/test/unit/reader/markdown-reader.test.ts
+++ b/test/unit/reader/markdown-reader.test.ts
@@ -1,23 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { MarkdownReader, readMarkdownUnitsSync } from '../../../src/reader/markdown-reader.js';
+import { readMarkdownUnitsSync } from '../../../src/reader/markdown-reader.js';
 import type { TextUnit } from '../../../src/reader/types.js';
 
 /**
- * `MarkdownReader` against the real parser.
+ * `readMarkdownUnitsSync` against the real parser.
  *
  * Every test proves the offset contract directly rather than trusting it: `text.slice(range.start,
  * range.end) === unit.text` is asserted for every unit produced, because a reader whose offsets
  * don't round-trip into the original source is exactly the defect this whole feature exists to fix.
  */
 
-const reader = new MarkdownReader();
-
-async function read(text: string): Promise<TextUnit[]> {
-  const units: TextUnit[] = [];
-  for await (const unit of reader.read({ id: 't', format: 'markdown', text })) {
-    units.push(unit);
-  }
-  return units;
+function read(text: string): TextUnit[] {
+  return readMarkdownUnitsSync({ id: 't', format: 'markdown', text });
 }
 
 function assertRoundTrips(text: string, units: readonly TextUnit[]): void {
@@ -26,81 +20,77 @@ function assertRoundTrips(text: string, units: readonly TextUnit[]): void {
   }
 }
 
-describe('MarkdownReader', () => {
-  it('reports the mediaType it reads', () => {
-    expect(reader.mediaType).toBe('markdown');
-  });
-
-  it('yields one unit for a single paragraph, with a real offset', async () => {
+describe('readMarkdownUnitsSync', () => {
+  it('yields one unit for a single paragraph, with a real offset', () => {
     const text = 'Prior to installation, remove the bracket.\n';
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units).toHaveLength(1);
     expect(units[0]?.kind).toBe('paragraph');
     expect(units[0]?.text).toBe('Prior to installation, remove the bracket.');
   });
 
-  it('excludes the heading marker from the unit range', async () => {
+  it('excludes the heading marker from the unit range', () => {
     const text = '# Setup\n\nProse follows.\n';
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     const heading = units.find((u) => u.kind === 'heading');
     expect(heading?.text).toBe('Setup');
     expect(heading?.depth).toBe(1);
   });
 
-  it('excludes the list marker from a list-item unit', async () => {
+  it('excludes the list marker from a list-item unit', () => {
     const text = ['1. First item', '2. Second item', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units.map((u) => u.kind)).toEqual(['list-item', 'list-item']);
     expect(units.map((u) => u.text)).toEqual(['First item', 'Second item']);
   });
 
-  it('carries the written ordinal of each item in an ordered list', async () => {
+  it('carries the written ordinal of each item in an ordered list', () => {
     // `structure-rules.ts`'s numbered-step-length check reports its message by ordinal
     // (`block.listOrdinal`) — a reader that dropped this would silently break that report.
     const text = ['5. Fifth item', '6. Sixth item', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(units.map((u) => u.listOrdinal)).toEqual([5, 6]);
   });
 
-  it('leaves listOrdinal undefined for an unordered list', async () => {
+  it('leaves listOrdinal undefined for an unordered list', () => {
     const text = ['- First item', '- Second item', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(units.every((u) => u.listOrdinal === undefined)).toBe(true);
   });
 
-  it('gives a top-level list depth 0, matching scanBlocks’s convention', async () => {
+  it('gives a top-level list depth 0, matching scanBlocks’s convention', () => {
     // scanBlocks computes list depth from indentation width (`Math.floor(markerIndent / 2)`), which
     // is 0 for an unindented top-level list. A reader that disagreed here would silently change
     // which rules a numbered step is subject to, since depth is part of a block's own identity.
     const text = ['1. First item', '2. Second item', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(units.every((u) => u.depth === 0)).toBe(true);
   });
 
-  it('increments list depth only for genuine nesting, not for the outermost list', async () => {
+  it('increments list depth only for genuine nesting, not for the outermost list', () => {
     const text = ['1. Outer item', '   1. Inner item', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     const outer = units.find((u) => u.text === 'Outer item');
     const inner = units.find((u) => u.text === 'Inner item');
     expect(outer?.depth).toBe(0);
     expect(inner?.depth).toBeGreaterThan(0);
   });
 
-  it('forces a heading to descriptive mode regardless of its wording', async () => {
+  it('forces a heading to descriptive mode regardless of its wording', () => {
     // scanBlocks forces every heading to `descriptive`, unconditionally — `push()`'s
     // `kind === 'heading' ? 'descriptive' : detectMode(...)` never runs `detectMode` on a heading at
     // all. An imperative-sounding heading must not become `procedural` just because a reader
     // classifies it the same way it classifies a paragraph.
     const text = '# Remove the bracket\n\nProse follows.\n';
-    const units = await read(text);
+    const units = read(text);
     const heading = units.find((u) => u.kind === 'heading');
     expect(heading?.mode).toBe('descriptive');
   });
 
-  it('carries a pending admonition across a nested walk into the block that actually consumes it', async () => {
+  it('carries a pending admonition across a nested walk into the block that actually consumes it', () => {
     // `pendingAdmonition` must survive a recursive call, not merely a sibling loop: an opener
     // immediately followed by a LIST has to reach the list's own first item, not be lost at the
     // recursion boundary — and, once consumed, must not still be sitting unconsumed in the outer
@@ -114,7 +104,7 @@ describe('MarkdownReader', () => {
       'Ordinary paragraph after the list.',
       '',
     ].join('\n');
-    const units = await read(text);
+    const units = read(text);
     const first = units.find((u) => u.text === 'First item.');
     const second = units.find((u) => u.text === 'Second item.');
     const after = units.find((u) => u.text === 'Ordinary paragraph after the list.');
@@ -123,13 +113,13 @@ describe('MarkdownReader', () => {
     expect(after?.admonition).toBe('none');
   });
 
-  it('carries a pending admonition into the first paragraph of a blockquote it opens', async () => {
+  it('carries a pending admonition into the first paragraph of a blockquote it opens', () => {
     const text = ['[WARNING]', '', '> Quoted prose here.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(units[0]?.admonition).toBe('warning');
   });
 
-  it('splits a bare opener from the body it merges with when no blank line separates them', async () => {
+  it('splits a bare opener from the body it merges with when no blank line separates them', () => {
     // Found via the fixture corpus after wiring, not anticipated in isolation: without a blank
     // line, commonmark merges the opener and the following prose into ONE Paragraph node —
     // scanBlocks, a line-by-line scanner, never merges an opener line with what follows it, blank
@@ -137,23 +127,23 @@ describe('MarkdownReader', () => {
     // isolation, so run against the whole merged blob they see the opener followed by real content
     // and no longer recognise it as "only" an opener — the marker is lost, and so is the register.
     const text = ['[WARNING]', 'The cover is opened by the operator.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     // The opener carries no prose of its own: it must not become a unit.
     expect(units.map((u) => u.text)).toEqual(['The cover is opened by the operator.']);
     expect(units[0]?.admonition).toBe('warning');
   });
 
-  it('keeps the combined-node GFM alert convention inside a blockquote unaffected by the split', async () => {
+  it('keeps the combined-node GFM alert convention inside a blockquote unaffected by the split', () => {
     // Regression guard: the new split logic must not fire inside a blockquote, where a GFM alert's
     // marker-and-body merging into one unit, with the marker's admonition applied directly to it,
     // is deliberate — a different convention from the bare-opener forms, not an oversight to unify.
     const text = ['> [!WARNING]', '> Do not touch the busbar.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(units).toHaveLength(1);
     expect(units[0]?.admonition).toBe('warning');
   });
 
-  it('propagates a GFM alert marker split into its own node by an embedded HTML comment', async () => {
+  it('propagates a GFM alert marker split into its own node by an embedded HTML comment', () => {
     // Found through the full suite, not anticipated in isolation: an HTML comment on its own line
     // inside a blockquote (the shape a suppression directive takes) makes the parser split the
     // blockquote into separate Paragraph nodes around the comment, instead of merging marker and
@@ -168,13 +158,13 @@ describe('MarkdownReader', () => {
       '> The bracket is removed by the technician.',
       '',
     ].join('\n');
-    const units = await read(text);
+    const units = read(text);
     // The marker line must not become a unit of its own — it carries no prose.
     expect(units.map((u) => u.text)).toEqual(['The bracket is removed by the technician.']);
     expect(units[0]?.admonition).toBe('warning');
   });
 
-  it('scopes a GFM alert container’s admonition to every paragraph inside it, not just the first', async () => {
+  it('scopes a GFM alert container’s admonition to every paragraph inside it, not just the first', () => {
     // Regression for the reviewer-found bug: `[!WARNING]` and its two quoted paragraphs parse as
     // THREE separate Paragraph nodes (blank `>` lines split them), all children of the same
     // BlockQuote. The marker's register must scope the whole container, not lapse after the first
@@ -183,7 +173,7 @@ describe('MarkdownReader', () => {
     const text = ['> [!WARNING]', '>', '> First paragraph.', '>', '> Second paragraph.', ''].join(
       '\n',
     );
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     const first = units.find((u) => u.text === 'First paragraph.');
     const second = units.find((u) => u.text === 'Second paragraph.');
@@ -191,44 +181,44 @@ describe('MarkdownReader', () => {
     expect(second?.admonition).toBe('warning');
   });
 
-  it('reads an MkDocs indented admonition body as prose, not a dropped code block', async () => {
+  it('reads an MkDocs indented admonition body as prose, not a dropped code block', () => {
     // Regression for the reviewer-found bug: CommonMark represents `!!! warning`'s four-space
     // indented body as a CodeBlock node, which the reader's default branch used to drop entirely —
     // producing zero units for it and leaving the pending warning to attach to unrelated prose
     // that followed instead.
     const text = '!!! warning\n\n    This is the body text.\n';
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     const body = units.find((u) => u.text === 'This is the body text.');
     expect(body).toBeDefined();
     expect(body?.admonition).toBe('warning');
   });
 
-  it('still drops a legitimate indented code block with no preceding admonition opener', async () => {
+  it('still drops a legitimate indented code block with no preceding admonition opener', () => {
     const text = 'Some prose.\n\n    var x = 1;\n';
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units.map((u) => u.text)).toEqual(['Some prose.']);
   });
 
-  it('does not hijack a fenced code block that follows a pending admonition opener', async () => {
+  it('does not hijack a fenced code block that follows a pending admonition opener', () => {
     // A fenced block is a deliberate code sample, even inside an admonition — only the ambiguous
     // indented-code shape is MkDocs's own body convention.
     const text = ['!!! note', '', '```python', 'x = 1', '```', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units).toHaveLength(0);
   });
 
-  it('excludes the table markup from a table-cell unit', async () => {
+  it('excludes the table markup from a table-cell unit', () => {
     const text = ['| Step | Action |', '| --- | --- |', '| 1 | Utilise the tool |', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     const cells = units.filter((u) => u.kind === 'table-cell');
     expect(cells.map((c) => c.text)).toEqual(['Step', 'Action', '1', 'Utilise the tool']);
   });
 
-  it('recovers the exact defect class issue #11 named: a table cell and a link', async () => {
+  it('recovers the exact defect class issue #11 named: a table cell and a link', () => {
     const text = [
       '| Step | Action |',
       '| --- | --- |',
@@ -237,7 +227,7 @@ describe('MarkdownReader', () => {
       'See [the guide](./guide.md) before you continue.',
       '',
     ].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     const cell = units.find((u) => u.kind === 'table-cell' && u.text === 'Utilise the tool');
     expect(cell).toBeDefined();
@@ -251,9 +241,9 @@ describe('MarkdownReader', () => {
     expect(paragraph?.text.endsWith('before you continue.')).toBe(true);
   });
 
-  it('produces a blockquote unit for quoted prose', async () => {
+  it('produces a blockquote unit for quoted prose', () => {
     const text = ['> Quoted prose here.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units).toHaveLength(1);
     expect(units[0]?.kind).toBe('blockquote');
@@ -261,26 +251,26 @@ describe('MarkdownReader', () => {
     expect(units[0]?.depth).toBeGreaterThan(0);
   });
 
-  it('keeps a continuation line’s own marker in text, verbatim, for a human-facing report', async () => {
+  it('keeps a continuation line’s own marker in text, verbatim, for a human-facing report', () => {
     // The parser gives the whole quoted paragraph one node, and only the FIRST line's leading `>` is
     // excluded from it — a continuation line's own `>` sits mid-string. `text` is the exact source
     // slice (the round-trip invariant `assertRoundTrips` checks everywhere), so it is not this
     // reader's place to alter it — a report showing a reader what they actually wrote must show the
     // `>` they actually wrote.
     const text = ['> First line of the quote.', '> Second line of the quote.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units).toHaveLength(1);
     expect(units[0]?.text).toBe('First line of the quote.\n> Second line of the quote.');
   });
 
-  it('masks a continuation line’s marker in `masked`, at the same length, never strips it', async () => {
+  it('masks a continuation line’s marker in `masked`, at the same length, never strips it', () => {
     // This is the actual fix for the gap found while building stage 1: `>` is markup, not prose, and
     // a checker reading `masked` must not see it as if the author wrote it as a sentence-initial
     // capital-less word. Masking — not stripping — is what keeps `masked` the same length as `text`
     // and therefore offset-compatible with `range`, exactly like `Sentence.masked` elsewhere in core.
     const text = ['> First line of the quote.', '> Second line of the quote.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     const unit = units[0];
     expect(unit?.masked.length).toBe(unit?.text.length);
     expect(unit?.masked).toBe('First line of the quote.\n� Second line of the quote.');
@@ -288,50 +278,44 @@ describe('MarkdownReader', () => {
     expect(text.slice(unit?.range.start ?? 0, unit?.range.end ?? 0)).toBe(unit?.text);
   });
 
-  it('leaves `masked` equal to `text` when there is no embedded marker to mask', async () => {
+  it('leaves `masked` equal to `text` when there is no embedded marker to mask', () => {
     const text = 'Prior to installation, remove the bracket.\n';
-    const units = await read(text);
+    const units = read(text);
     expect(units[0]?.masked).toBe(units[0]?.text);
   });
 
-  it('detects a GFM alert admonition on the blockquote unit it opens', async () => {
+  it('detects a GFM alert admonition on the blockquote unit it opens', () => {
     const text = ['> [!WARNING]', '> Do not touch the busbar.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units).toHaveLength(1);
     expect(units[0]?.admonition).toBe('warning');
   });
 
-  it('leaves an ordinary blockquote at admonition none', async () => {
+  it('leaves an ordinary blockquote at admonition none', () => {
     const text = ['> Quoted prose here.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(units[0]?.admonition).toBe('none');
   });
 
-  it('classifies an imperative sentence as procedural and a descriptive one as descriptive', async () => {
+  it('classifies an imperative sentence as procedural and a descriptive one as descriptive', () => {
     const text = ['Remove the bracket.', '', 'The bracket is removed by the technician.', ''].join(
       '\n',
     );
-    const units = await read(text);
+    const units = read(text);
     expect(units[0]?.mode).toBe('procedural');
     expect(units[1]?.mode).toBe('descriptive');
   });
 
-  it('gives every unit a stable, distinct id within one read', async () => {
+  it('gives every unit a stable, distinct id within one read', () => {
     const text = ['# Setup', '', 'First paragraph.', '', 'Second paragraph.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     const ids = units.map((u) => u.id);
     expect(new Set(ids).size).toBe(ids.length);
     for (const id of ids) expect(id.length).toBeGreaterThan(0);
   });
 
-  it('is async-iterable, not merely array-returning', () => {
-    const text = 'Prose.\n';
-    const iterable = reader.read({ id: 't', format: 'markdown', text });
-    expect(typeof iterable[Symbol.asyncIterator]).toBe('function');
-  });
-
-  it('produces byte-identical units across two reads of the same text', async () => {
+  it('produces byte-identical units across two reads of the same text', () => {
     const text = [
       '# Setup',
       '',
@@ -342,30 +326,8 @@ describe('MarkdownReader', () => {
       'See [the guide](./guide.md) before you continue.',
       '',
     ].join('\n');
-    const a = await read(text);
-    const b = await read(text);
+    const a = read(text);
+    const b = read(text);
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
-  });
-
-  it('exposes a synchronous core the async `read()` is a thin wrapper over', async () => {
-    // `analyseDocument` (`src/core/document.ts`) is called synchronously by every existing caller,
-    // and `analyseTextDeterministic` documents itself as performing no I/O — a contract dozens of
-    // call sites rely on. `core` also may never import `reader` (module boundary). Wiring the reader
-    // into `analysis` without breaking either of those requires a genuinely synchronous entry point
-    // this reader can offer, since nothing here actually needs to be async — `parse()` and the tree
-    // walk are both synchronous underneath the `AsyncIterable` the interface promises.
-    const text = [
-      '# Setup',
-      '',
-      '| Step | Action |',
-      '| --- | --- |',
-      '| 1 | Utilise the tool |',
-      '',
-      'See [the guide](./guide.md) before you continue.',
-      '',
-    ].join('\n');
-    const sync = readMarkdownUnitsSync({ id: 't', format: 'markdown', text });
-    const asynchronous = await read(text);
-    expect(JSON.stringify(sync)).toBe(JSON.stringify(asynchronous));
   });
 });

--- a/test/unit/reader/plain-text-reader.test.ts
+++ b/test/unit/reader/plain-text-reader.test.ts
@@ -1,21 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { PlainTextReader, readPlainTextUnitsSync } from '../../../src/reader/plain-text-reader.js';
+import { readPlainTextUnitsSync } from '../../../src/reader/plain-text-reader.js';
 import type { TextUnit } from '../../../src/reader/types.js';
 
 /**
- * `PlainTextReader` — the "simplest reader that satisfies the interface", per the design note.
- * No parser: `format: 'text'` has no structure beyond blank-line-separated paragraphs, which is
- * exactly what `src/core/structure.ts`'s `format === 'text'` branch already does.
+ * `readPlainTextUnitsSync` — the simplest reader for `format: 'text'`. No parser: `format: 'text'`
+ * has no structure beyond blank-line-separated paragraphs, which is exactly what
+ * `src/core/structure.ts`'s `format === 'text'` branch already does.
  */
 
-const reader = new PlainTextReader();
-
-async function read(text: string): Promise<TextUnit[]> {
-  const units: TextUnit[] = [];
-  for await (const unit of reader.read({ id: 't', format: 'text', text })) {
-    units.push(unit);
-  }
-  return units;
+function read(text: string): TextUnit[] {
+  return readPlainTextUnitsSync({ id: 't', format: 'text', text });
 }
 
 function assertRoundTrips(text: string, units: readonly TextUnit[]): void {
@@ -24,14 +18,10 @@ function assertRoundTrips(text: string, units: readonly TextUnit[]): void {
   }
 }
 
-describe('PlainTextReader', () => {
-  it('reports the mediaType it reads', () => {
-    expect(reader.mediaType).toBe('text');
-  });
-
-  it('yields one unit for a single paragraph', async () => {
+describe('readPlainTextUnitsSync', () => {
+  it('yields one unit for a single paragraph', () => {
     const text = 'Prior to installation, remove the bracket.\n';
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units).toHaveLength(1);
     expect(units[0]?.kind).toBe('paragraph');
@@ -40,56 +30,44 @@ describe('PlainTextReader', () => {
     expect(units[0]?.admonition).toBe('none');
   });
 
-  it('splits on a blank line into two units with real offsets', async () => {
+  it('splits on a blank line into two units with real offsets', () => {
     const text = ['First paragraph.', '', 'Second paragraph.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units.map((u) => u.text)).toEqual(['First paragraph.', 'Second paragraph.']);
     expect(units[1]?.range.start).toBe(text.indexOf('Second paragraph.'));
   });
 
-  it('skips multiple consecutive blank lines without producing an empty unit', async () => {
+  it('skips multiple consecutive blank lines without producing an empty unit', () => {
     const text = ['First paragraph.', '', '', '', 'Second paragraph.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     assertRoundTrips(text, units);
     expect(units.map((u) => u.text)).toEqual(['First paragraph.', 'Second paragraph.']);
   });
 
-  it('classifies mode the same way the markdown reader does', async () => {
+  it('classifies mode the same way the markdown reader does', () => {
     const text = ['Remove the bracket.', '', 'The bracket is removed by the technician.', ''].join(
       '\n',
     );
-    const units = await read(text);
+    const units = read(text);
     expect(units[0]?.mode).toBe('procedural');
     expect(units[1]?.mode).toBe('descriptive');
   });
 
-  it('gives every unit a distinct id', async () => {
+  it('gives every unit a distinct id', () => {
     const text = ['One.', '', 'Two.', '', 'Three.', ''].join('\n');
-    const units = await read(text);
+    const units = read(text);
     expect(new Set(units.map((u) => u.id)).size).toBe(units.length);
   });
 
-  it('is async-iterable', () => {
-    const iterable = reader.read({ id: 't', format: 'text', text: 'Prose.\n' });
-    expect(typeof iterable[Symbol.asyncIterator]).toBe('function');
-  });
-
-  it('produces nothing for a blank document', async () => {
-    const units = await read('\n\n\n');
+  it('produces nothing for a blank document', () => {
+    const units = read('\n\n\n');
     expect(units).toEqual([]);
   });
 
-  it('has `masked` equal to `text`: plain text has no per-line markup to mask', async () => {
+  it('has `masked` equal to `text`: plain text has no per-line markup to mask', () => {
     const text = 'Prose.\n';
-    const units = await read(text);
+    const units = read(text);
     expect(units[0]?.masked).toBe(units[0]?.text);
-  });
-
-  it('exposes a synchronous core the async `read()` is a thin wrapper over', async () => {
-    const text = ['First paragraph.', '', 'Second paragraph.', ''].join('\n');
-    const sync = readPlainTextUnitsSync({ id: 't', format: 'text', text });
-    const asynchronous = await read(text);
-    expect(JSON.stringify(sync)).toBe(JSON.stringify(asynchronous));
   });
 });


### PR DESCRIPTION
## What

Fixes all 7 findings from a `ponytail-audit` scan of `src/`/`scripts/` (independently spot-checked before this branch started — `countWords`/`severityFor`/`indexBlocks`/`maxParagraphSentences`/`DocumentReader.read()` production-caller claims all confirmed via direct grep):

1. **`shrink:`** Extracted `prepareRun()` — the ~28-line setup block duplicated verbatim between `analyseTextDeterministic`/`analyseText` in `src/analysis/analyse.ts`.
2. **`stdlib:`** Replaced the hand-rolled CLI flag parser (`src/cli/main.ts`) and three near-identical `flag()` helpers (`scripts/*.mjs`) with `node:util.parseArgs`. Documented exit-code/error behavior preserved (verified live: unknown flag → exit 2). Two disclosed incidental improvements: `--flag=value` syntax now works, and `--flag --otherflag` (previously silently swallowing the next flag as a value) now errors instead of misparsing.
3. **`delete:`** Removed 3 fully unused exports — `countWords()`, `severityFor()`, `indexBlocks()`.
4. **`stdlib:`** Replaced hand-rolled FNV-1a hashing with `node:crypto`'s `createHash('sha256')`, already used elsewhere in this codebase for the same purpose. Checked every call site treats the digest as an opaque string before confirming the length change (16→64 hex chars) was a safe drop-in.
5. **`yagni:`** Removed the unused async `DocumentReader` interface and its two wrapper classes (`MarkdownReader`, `PlainTextReader`) — no production caller ever used `.read()`; `analysis` always called the sync functions directly. Read `docs/architecture.md`'s original design note first: the stated reason for making `.read()` async ("no second interface for that later") never held, since a sync interface existed from day one specifically because `analyseTextDeterministic` documents itself as I/O-free and `core` may never import `reader`. Updated the design note with a status correction rather than leaving it describing removed code.
6. **`yagni:`** Collapsed the single-implementation `PromptProvider` interface to a concrete `FilePromptProvider` reference.
7. **`delete:`** Removed `RulePackLimits.maxParagraphSentences`, read by no rule, from schema/type/pack/docs.

## Verification

Independently re-verified beyond the implementing agent's own report: full gate clean (typecheck, lint, 485/485 tests) re-run myself in a separate worktree; live-tested the built CLI's unknown-flag behavior (`exit 2`, confirmed); re-grepped for zero remaining references to every deleted export; confirmed `scripts/ci/check-candidate-ground-truth.sh` passes (123 candidates, 0 problems, correct for this branch's `main`-only lineage).

Correctness, security, and performance were explicitly out of scope for the audit itself, per its own stated boundaries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXVhFQhSfdvdu8n7houDK6)_