### PR TITLE
fix: sync package-lock.json's engines.node with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "vitest": "^4.0.0"
       },
       "engines": {
-        "node": ">=20.11"
+        "node": ">=24"
       },
       "peerDependencies": {
         "textlint": ">=13"


### PR DESCRIPTION
One-line fix. PR #38 bumped `package.json`'s `engines.node` to `>=24` but never regenerated `package-lock.json`, which still recorded `>=20.11` in its own root-entry mirror of that field on `main`.

Found via a stop-hook uncommitted-changes check surfacing a stray `npm ci`-generated diff sitting in an already-merged branch's local working tree — traced back to confirm it was real drift on `main` (not local noise) before fixing it properly on its own branch.

Gate clean: typecheck, lint, 491/491 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXVhFQhSfdvdu8n7houDK6)_