### PR TITLE
chore: fix QA tooling gaps — dependency currency, strictTypeChecked, eslint-plugin-n, coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,13 @@ jobs:
 
       # The default suite must never need a model service. If this step starts requiring network
       # access, that is a regression in the deterministic-only guarantee.
-      - name: Unit, integration, fixture and e2e tests
-        run: npm test
+      #
+      # Runs `test:coverage`, not plain `test`: vitest.config.ts's coverage `thresholds` are only
+      # evaluated when coverage collection is enabled (`--coverage`), so this is the step that
+      # actually enforces them — running the plain suite here would let a coverage regression pass
+      # CI silently despite the thresholds existing in config.
+      - name: Unit, integration, fixture and e2e tests (with coverage enforcement)
+        run: npm run test:coverage
 
       - name: Fixture provenance and corpus integrity
         run: node scripts/validate-fixtures.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,26 +9,29 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "^15.7.1",
-        "@textlint/markdown-to-ast": "^15.7.1",
+        "@textlint/ast-node-types": "^15.8.0",
+        "@textlint/markdown-to-ast": "^15.8.0",
         "sentence-splitter": "^5.0.1",
         "text-readability": "^1.1.1",
-        "zod": "^4.1.10"
+        "zod": "^4.4.3"
       },
       "bin": {
         "ste-ai": "dist/cli/main.js"
       },
       "devDependencies": {
-        "@textlint/types": "^15.7.1",
+        "@textlint/kernel": "^15.8.0",
+        "@textlint/textlint-plugin-markdown": "^15.8.0",
+        "@textlint/textlint-plugin-text": "^15.8.0",
+        "@textlint/types": "^15.8.0",
         "@types/node": "^26.1.2",
-        "@vitest/coverage-v8": "^4.0.0",
+        "@vitest/coverage-v8": "^4.1.10",
         "oxlint": "^1.76.0",
         "oxlint-tsgolint": "^7.0.2001",
-        "prettier": "^3.6.2",
-        "textlint": "^15.7.1",
-        "textlint-tester": "^15.7.1",
+        "prettier": "^3.9.6",
+        "textlint": "^15.8.0",
+        "textlint-tester": "^15.8.0",
         "typescript": "^7.0.2",
-        "vitest": "^4.0.0"
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=24"
@@ -236,19 +239,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -284,70 +274,32 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+        "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+      "engines": {
+        "node": ">=20"
       }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1057,122 +1009,126 @@
       "license": "MIT"
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
-      "integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.8.0.tgz",
+      "integrity": "sha512-5CiH9COYmovWmExQgs7763DzX6Gy9zjkjJ7JxCC95wyTcjwQn/8poNF6fv3qzRlmx8CRRde8DHr9FcgAAiPzgw==",
       "license": "MIT"
     },
     "node_modules/@textlint/ast-tester": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-15.7.1.tgz",
-      "integrity": "sha512-0CZWFKB7D21y8LA4Dv5irOX1/iGDGwM4OTaW7PxJpfRhXCL40uMOhS+P+1bjFmpSkM/DF/5HPRph0E744iJobw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-15.8.0.tgz",
+      "integrity": "sha512-EoNPm/Xpv59BYQimlUcEsD8iHWVLMiyA/U66ATQCiZQTrvS93C67q3V630fhCJWeSuSR660BGadHGX1jv+IeTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1",
+        "@textlint/ast-node-types": "15.8.0",
         "debug": "^4.4.3"
       }
     },
     "node_modules/@textlint/ast-traverse": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-15.7.1.tgz",
-      "integrity": "sha512-tFgFiSbh6fdQo7MF4FYQoQBHqM8BoTEfvubGXm7Xi65QRYefNz+iuXYaoyto6OlMj5M95u9Gk/Ni7577rZ8uow==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-15.8.0.tgz",
+      "integrity": "sha512-N/FhYDJLXUFOIlsRAuyx78ll2/O2SCU5mZBB1jWQhX71653YcrJvFf6r+EavnKlxNie0mcaTt0hrCnX2q0SdLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1"
+        "@textlint/ast-node-types": "15.8.0"
       }
     },
     "node_modules/@textlint/config-loader": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-15.7.1.tgz",
-      "integrity": "sha512-K5KTpQFclHn0zby48wvckhOzUg2gXJyFXeagYt9mFgYOnCgMzTYL/P/TIE6ljhtZ0arhK1aH0e1uFZYasGbXog==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-15.8.0.tgz",
+      "integrity": "sha512-iJjgkZxURc7YAIRwNkhjsD2d0j3zKzlyRAw5EAmX/Rxr1/jBXPm2taaLOX1yMaaeZxVpWZ+7mauU5B96qjfQpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/kernel": "15.7.1",
-        "@textlint/module-interop": "15.7.1",
-        "@textlint/resolver": "15.7.1",
-        "@textlint/types": "15.7.1",
-        "@textlint/utils": "15.7.1",
+        "@textlint/kernel": "15.8.0",
+        "@textlint/module-interop": "15.8.0",
+        "@textlint/resolver": "15.8.0",
+        "@textlint/types": "15.8.0",
+        "@textlint/utils": "15.8.0",
         "debug": "^4.4.3",
         "rc-config-loader": "^4.1.4"
       }
     },
     "node_modules/@textlint/feature-flag": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-15.7.1.tgz",
-      "integrity": "sha512-ZFIJ2edV7K04UJ7/7ptvL61vs54MHYzDaIfTW+vaXwq5KDeCD2QyjsKt+TbOHQ8n8sW6fO171n4p0gwRo01Ojg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-15.8.0.tgz",
+      "integrity": "sha512-qvk6DV9lazH9EVHGLglvO9LwJbi22yy2LdZDQNH4EvlGk5+cNxbV1yZzuLdk+7elOuK2Lb9l5geMpZPa/j11XQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/fixer-formatter": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-15.7.1.tgz",
-      "integrity": "sha512-vqF17A1aUJeIulvWQUWX4SX0tYWT6Burx8L1qPHbf8ZlpUAHSXPVzorwmZyw6bAkKl6cODHj2EtK2HrnqjV1Ow==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-15.8.0.tgz",
+      "integrity": "sha512-/Lwo9E6Kvltb/cYsOCKvBwVRz4GZ8CLgOVNTDRdyYVtXE6EGk5utCPCdzjEm1h3C6bdXcnoArGvgyhlFw7AsUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/module-interop": "15.7.1",
-        "@textlint/resolver": "15.7.1",
-        "@textlint/types": "15.7.1",
-        "chalk": "^4.1.2",
+        "@textlint/module-interop": "15.8.0",
+        "@textlint/resolver": "15.8.0",
+        "@textlint/types": "15.8.0",
         "debug": "^4.4.3",
         "diff": "^8.0.4",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@textlint/kernel": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-15.7.1.tgz",
-      "integrity": "sha512-OGghiMbXLD3ULHedZYP1B+A8Bj4snlCatzsOdz0M8q0v4I79NdcamWt/5GYmbp6AOQg3HBQG8+9V+0H+do19mw==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-15.8.0.tgz",
+      "integrity": "sha512-Wc2Z2Oq95v+IXj+G4j3cKpfQ1t2YRgubxHHj8i93Nu+R2F/GvszRC7pYBHYBH9HMmlJyTBq8jcjBOYG/b52CUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1",
-        "@textlint/ast-tester": "15.7.1",
-        "@textlint/ast-traverse": "15.7.1",
-        "@textlint/feature-flag": "15.7.1",
-        "@textlint/source-code-fixer": "15.7.1",
-        "@textlint/types": "15.7.1",
-        "@textlint/utils": "15.7.1",
+        "@textlint/ast-node-types": "15.8.0",
+        "@textlint/ast-tester": "15.8.0",
+        "@textlint/ast-traverse": "15.8.0",
+        "@textlint/feature-flag": "15.8.0",
+        "@textlint/source-code-fixer": "15.8.0",
+        "@textlint/types": "15.8.0",
+        "@textlint/utils": "15.8.0",
         "debug": "^4.4.3",
         "fast-equals": "^4.0.3",
         "structured-source": "^4.0.0"
       }
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
-      "integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.8.0.tgz",
+      "integrity": "sha512-+oU3A235NATv6Lzi4xa4kJ65PuNJlIxesaO4AvDhDWA9FWm7y4XKWaoQCW1esgaQQ6dwnUiFKArQ8TcJ86mC4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.7.1",
-        "@textlint/resolver": "15.7.1",
-        "@textlint/types": "15.7.1",
-        "chalk": "^4.1.2",
+        "@textlint/module-interop": "15.8.0",
+        "@textlint/resolver": "15.8.0",
+        "@textlint/types": "15.8.0",
         "debug": "^4.4.3",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "lodash": "^4.18.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "table": "^6.9.0",
         "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@textlint/markdown-to-ast": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-15.7.1.tgz",
-      "integrity": "sha512-9DLSah7g6mYNHvO6pssLdFvFPAl3HHyEIm4RE5of/1QN9FXJXDgdOcVV3YpQmbYT/YntuIvOQiqOndCSPWTW2A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-15.8.0.tgz",
+      "integrity": "sha512-gWOcd2+UCqODMLGIIY5WiPE9zmR9L4aut3FIkxH8gSCiZ6EVkBaU2mgm+8KiGOjJqdtT98xkWocCwDtQ1kypOQ==",
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1",
+        "@textlint/ast-node-types": "15.8.0",
         "debug": "^4.4.3",
         "mdast-util-gfm-autolink-literal": "^0.1.3",
         "neotraverse": "^0.6.18",
@@ -1185,76 +1141,76 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
-      "integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.8.0.tgz",
+      "integrity": "sha512-rt+OR1WYGoLOY8HkA/aBPrqufF6yUUEsKEAh7XohTsT3lp9IyZFT6zOIbjul9P4FAzsmSPkcrYjVx3Bz/IUfkg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/resolver": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
-      "integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.8.0.tgz",
+      "integrity": "sha512-E88tzfX3K8Jykk+38aJ9cy8RquD8ABVOPTO2rFEESq0wcg8x6/ypdAS8ZgR7OKiGqlRF0hkO/m5PbQwVfKM3VA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/source-code-fixer": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-15.7.1.tgz",
-      "integrity": "sha512-Z8ZfQQbVH2GIUMzSGEQWKKnAFCH+mbQtw5ipigFHExUImx2RC2ppaR1m8ZAy7SYgbXGhvfkPKZ4ndEmVWTs5Mg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-15.8.0.tgz",
+      "integrity": "sha512-oWEBXLRzvv9bMu7/8NFMDM6GXil6iPXbNdiopQfxmrEVduc7mZ5gPoKr77gwrUO05jLS5ycfxE7kwPUu5sXP8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/types": "15.7.1",
+        "@textlint/types": "15.8.0",
         "debug": "^4.4.3"
       }
     },
     "node_modules/@textlint/text-to-ast": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-15.7.1.tgz",
-      "integrity": "sha512-W6AYCOcEAtw9hs0u69+Tte8hmWaLKYGdo3yBxgOpl20Q6AOkxxEaG305Nr5rgbO6caWJWkR/t2WxBkZzm3KG0A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-15.8.0.tgz",
+      "integrity": "sha512-Mmhy0tW9fOhekLNMouyy93WEQR9xVrbigKtgCA+jyoqrs5vqSC6x06f/KeZZSvDXQ6hy2gA25m36Swfcg35BPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1"
+        "@textlint/ast-node-types": "15.8.0"
       }
     },
     "node_modules/@textlint/textlint-plugin-markdown": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-15.7.1.tgz",
-      "integrity": "sha512-vnTU1/0ZLEC0cSBK5bBfR3aXYJbn3rMFR455y848Df6DHI4gLc1L2uNXDkYYPh84KvzIs7RfEUHZyHSwSISFLg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-15.8.0.tgz",
+      "integrity": "sha512-susQtSt0omGIkQmb3vNXx3CQS92OViTHD7Qe79quSMxYv0jgN/bCZUa8ej96qOOqPeuoSDDDpMdEZ4D+B6Lb+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/markdown-to-ast": "15.7.1",
-        "@textlint/types": "15.7.1"
+        "@textlint/markdown-to-ast": "15.8.0",
+        "@textlint/types": "15.8.0"
       }
     },
     "node_modules/@textlint/textlint-plugin-text": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-15.7.1.tgz",
-      "integrity": "sha512-krU0KiDmG2LrESF3LchgfbSwclB/8I2itA4uzSY9Tln3miaWGKzUpLu00bQtvua0f2Ux7tsLnSmwAgGFf9gERA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-15.8.0.tgz",
+      "integrity": "sha512-oz+tip3nSEkzPv5h4WVtXngLorBtJe97Sc1o3EddbcpIvI57jj5cCM7tNMQVGpgpQnGYplfzJt4M1EyFPopfCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/text-to-ast": "15.7.1",
-        "@textlint/types": "15.7.1"
+        "@textlint/text-to-ast": "15.8.0",
+        "@textlint/types": "15.8.0"
       }
     },
     "node_modules/@textlint/types": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
-      "integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.8.0.tgz",
+      "integrity": "sha512-Anhc6y5736YIsvqae0U6k0YmB2M/QVHkEeOv2aydAn/WIkdI69dCOiDbe3/+RagS3qstFTSFWJzNRA2lUjv19w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1"
+        "@textlint/ast-node-types": "15.8.0"
       }
     },
     "node_modules/@textlint/utils": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-15.7.1.tgz",
-      "integrity": "sha512-+q5Z5fsNk/ixDY5D70ZCQungr7ppzBAAhmi207qDBzSBFeA5MM2ASGwMjPc5aMJ/3DvonI/01B3UIgbpVgIXVA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-15.8.0.tgz",
+      "integrity": "sha512-waINJCI7sBVs1A3K05UFKe8QoNAsdJFCXr3PJ1QsgAf0BeEgCtyrLVcZUdbOtKxRkF4QB4NuClB0By1Ty4znpQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1816,39 +1772,7 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
+    "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
@@ -1864,13 +1788,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -1957,45 +1874,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/boundary": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
@@ -2013,16 +1891,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/cacheable": {
@@ -2049,37 +1917,6 @@
         "@keyv/serialize": "^1.1.1"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ccount": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
@@ -2098,23 +1935,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -2177,89 +1997,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -2295,16 +2038,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2325,28 +2058,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2354,60 +2065,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
     },
@@ -2433,39 +2094,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2474,70 +2102,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -2568,9 +2132,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2615,28 +2179,6 @@
         }
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/find-up-simple": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
@@ -2665,26 +2207,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2698,55 +2220,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2767,19 +2240,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2788,19 +2248,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hashery": {
@@ -2814,29 +2261,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/hookified": {
@@ -2873,44 +2297,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/index-to-position": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
@@ -2922,33 +2308,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
-      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -3021,20 +2380,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -3074,16 +2419,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jose": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
-      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -3092,9 +2427,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3114,12 +2449,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3494,16 +2829,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -3675,33 +3000,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/media-typer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
-      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/micromark": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
@@ -3828,33 +3126,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -3906,16 +3177,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/neotraverse": {
       "version": "0.6.18",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
@@ -3946,29 +3207,6 @@
       "integrity": "sha512-fARPRdTwmrQDLYhmeh7j/eZwrCP6WzxD6uKOdK/hT/uKACAE9AG2Bc2dgqOZLkfmmctHpfcJ9w3AQnfLgg3GYg==",
       "license": "MIT"
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -3981,29 +3219,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -4127,26 +3342,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -4170,17 +3365,6 @@
       "integrity": "sha512-tmciSlVyHnX0LC86+zSr+0LURw9rDPw8ilhXcmTpVUOnI6OsKdCzXQs5fTG10Bjz26IBdnKL3XIaP+QvGsk5YQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4207,16 +3391,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/pluralize": {
@@ -4281,20 +3455,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/qified": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
@@ -4314,53 +3474,6 @@
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
-      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/rc-config-loader": {
       "version": "4.1.4",
@@ -4521,30 +3634,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -4556,33 +3645,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/sentence-splitter": {
@@ -4600,132 +3662,6 @@
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
       "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
       "license": "MIT"
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4804,16 +3740,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "4.2.0",
@@ -4916,30 +3842,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/text-readability": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/text-readability/-/text-readability-1.1.1.tgz",
@@ -4967,26 +3869,26 @@
       "license": "MIT"
     },
     "node_modules/textlint": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.7.1.tgz",
-      "integrity": "sha512-T6WRImq6XBnf7kRUE401/gz4USDcrsr9ksDfpwspPAHcvlptsTmd5CrRuPc2brd6t93Z6xSGIGlvV4QAMUHx+A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.8.0.tgz",
+      "integrity": "sha512-3xE8MknztkpEC5MYDO1lXhUDXx+uq45gdvZB16Xh80rX148NgUehSyWCc5ir2SBW0KVpzRRgU3EWAJZqsBfqtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@textlint/ast-node-types": "15.7.1",
-        "@textlint/ast-traverse": "15.7.1",
-        "@textlint/config-loader": "15.7.1",
-        "@textlint/feature-flag": "15.7.1",
-        "@textlint/fixer-formatter": "15.7.1",
-        "@textlint/kernel": "15.7.1",
-        "@textlint/linter-formatter": "15.7.1",
-        "@textlint/module-interop": "15.7.1",
-        "@textlint/resolver": "15.7.1",
-        "@textlint/textlint-plugin-markdown": "15.7.1",
-        "@textlint/textlint-plugin-text": "15.7.1",
-        "@textlint/types": "15.7.1",
-        "@textlint/utils": "15.7.1",
+        "@modelcontextprotocol/server": "^2.0.0",
+        "@textlint/ast-node-types": "15.8.0",
+        "@textlint/ast-traverse": "15.8.0",
+        "@textlint/config-loader": "15.8.0",
+        "@textlint/feature-flag": "15.8.0",
+        "@textlint/fixer-formatter": "15.8.0",
+        "@textlint/kernel": "15.8.0",
+        "@textlint/linter-formatter": "15.8.0",
+        "@textlint/module-interop": "15.8.0",
+        "@textlint/resolver": "15.8.0",
+        "@textlint/textlint-plugin-markdown": "15.8.0",
+        "@textlint/textlint-plugin-text": "15.8.0",
+        "@textlint/types": "15.8.0",
+        "@textlint/utils": "15.8.0",
         "debug": "^4.4.3",
         "file-entry-cache": "^10.1.4",
         "glob": "^13.0.6",
@@ -4996,28 +3898,28 @@
         "rc-config-loader": "^4.1.4",
         "read-package-up": "^11.0.0",
         "structured-source": "^4.0.0",
-        "zod": "^3.25.76"
+        "zod": "^4.2.0"
       },
       "bin": {
         "textlint": "bin/textlint.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.18.0"
       }
     },
     "node_modules/textlint-tester": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/textlint-tester/-/textlint-tester-15.7.1.tgz",
-      "integrity": "sha512-draiL8fu67oWJcY7vsA6wRqJOLydLZKxCxB5m7zMr0ba/41L0ITiU4IuQP1qwaSvoqwaPnzeOIei2GbC2jFv7w==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/textlint-tester/-/textlint-tester-15.8.0.tgz",
+      "integrity": "sha512-nN8jtwBNJJNoetwMY2jEA6P20MJtInQgS8azQ1UeyLaYpv+N/qINaqp35oqV4tI6DxzHzNJQlRb6qGof79p0aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.7.1",
-        "@textlint/feature-flag": "15.7.1",
-        "@textlint/kernel": "15.7.1",
-        "@textlint/textlint-plugin-markdown": "15.7.1",
-        "@textlint/textlint-plugin-text": "15.7.1",
-        "@textlint/types": "15.7.1"
+        "@textlint/ast-node-types": "15.8.0",
+        "@textlint/feature-flag": "15.8.0",
+        "@textlint/kernel": "15.8.0",
+        "@textlint/textlint-plugin-markdown": "15.8.0",
+        "@textlint/textlint-plugin-text": "15.8.0",
+        "@textlint/types": "15.8.0"
       }
     },
     "node_modules/textlint/node_modules/file-entry-cache": {
@@ -5040,16 +3942,6 @@
         "cacheable": "^2.5.0",
         "flatted": "^3.4.2",
         "hookified": "^1.15.0"
-      }
-    },
-    "node_modules/textlint/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/tinybench": {
@@ -5096,16 +3988,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -5148,39 +4030,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -5316,16 +4165,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -5335,16 +4174,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -5568,22 +4397,6 @@
         }
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5611,13 +4424,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -5625,16 +4431,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -100,22 +100,25 @@
     }
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^15.7.1",
-    "@textlint/markdown-to-ast": "^15.7.1",
+    "@textlint/ast-node-types": "^15.8.0",
+    "@textlint/markdown-to-ast": "^15.8.0",
     "sentence-splitter": "^5.0.1",
     "text-readability": "^1.1.1",
-    "zod": "^4.1.10"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@textlint/types": "^15.7.1",
+    "@textlint/kernel": "^15.8.0",
+    "@textlint/textlint-plugin-markdown": "^15.8.0",
+    "@textlint/textlint-plugin-text": "^15.8.0",
+    "@textlint/types": "^15.8.0",
     "@types/node": "^26.1.2",
-    "@vitest/coverage-v8": "^4.0.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "oxlint": "^1.76.0",
     "oxlint-tsgolint": "^7.0.2001",
-    "prettier": "^3.6.2",
-    "textlint": "^15.7.1",
-    "textlint-tester": "^15.7.1",
+    "prettier": "^3.9.6",
+    "textlint": "^15.8.0",
+    "textlint-tester": "^15.8.0",
     "typescript": "^7.0.2",
-    "vitest": "^4.0.0"
+    "vitest": "^4.1.10"
   }
 }

--- a/scripts/build-candidate-packets.mjs
+++ b/scripts/build-candidate-packets.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Build reviewer packets for heuristic candidate passages.
  *

--- a/scripts/build-candidate-packets.mjs
+++ b/scripts/build-candidate-packets.mjs
@@ -14,92 +14,114 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
-import { resolveConfig } from '../dist/core/config.js';
-import { analyseDocument } from '../dist/core/document.js';
-import { runDeterministicRules } from '../dist/core/runner.js';
-import { deterministicRules } from '../dist/deterministic/index.js';
-import { resolveRulePack } from '../dist/rule-pack/loader.js';
 
-let values;
-try {
-  ({ values } = parseArgs({
-    args: process.argv.slice(2),
-    options: {
-      fixtures: { type: 'string', default: 'fixtures' },
-      split: { type: 'string', default: 'all' },
-      out: { type: 'string' },
-    },
-    strict: true,
-    allowPositionals: false,
-  }));
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(2);
-}
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const fixturesDir = resolve(values.fixtures);
-const split = values.split;
-const outDir = values.out;
-
-const manifest = JSON.parse(readFileSync(join(fixturesDir, 'manifest.json'), 'utf8'));
-const config = resolveConfig({});
-const pack = resolveRulePack(config.rulePack);
-
-/** Characters of surrounding source shown to the reviewer on each side of the candidate. */
-const CONTEXT = 320;
-
-const packets = [];
-for (const fixture of manifest.fixtures) {
-  if (split !== 'all' && fixture.split !== split) continue;
-  const originalPath = join(fixturesDir, fixture.originalPath);
-  const text = readFileSync(originalPath, 'utf8');
-  const doc = analyseDocument(
-    { id: fixture.id, format: 'markdown', text, path: originalPath },
-    {
-      protectedRegions: {
-        approvedTerms: [...config.approvedTerms, ...pack.approvedTechnicalTerms],
-        extraPatterns: config.extraProtectedPatterns,
-      },
-      structure: { extraImperativeVerbs: config.extraImperativeVerbs },
-    },
-  );
-  const run = runDeterministicRules({ doc, rules: deterministicRules, config, pack });
-  if (run.candidates.length === 0) continue;
-
-  packets.push({
-    fixtureId: fixture.id,
-    split: fixture.split,
-    category: fixture.category,
-    sourceOrganisation: fixture.sourceOrganisation,
-    originalPath: fixture.originalPath,
-    candidates: run.candidates.map((candidate) => ({
-      passageId: candidate.id,
-      ruleId: candidate.ruleId,
-      evaluatorId: candidate.evaluatorId,
-      span: { start: candidate.range.start, end: candidate.range.end },
-      quote: text.slice(candidate.range.start, candidate.range.end),
-      mode: candidate.mode,
-      admonition: candidate.admonition,
-      heuristicReason: candidate.reason,
-      payload: candidate.payload,
-      context: text.slice(
-        Math.max(0, candidate.range.start - CONTEXT),
-        Math.min(text.length, candidate.range.end + CONTEXT),
-      ),
-    })),
-  });
-}
-
-const total = packets.reduce((sum, p) => sum + p.candidates.length, 0);
-if (outDir === undefined) {
-  process.stdout.write(`${JSON.stringify({ total, packets }, null, 2)}\n`);
-} else {
-  const dir = resolve(outDir);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  for (const packet of packets) {
-    writeFileSync(join(dir, `${packet.fixtureId}.json`), `${JSON.stringify(packet, null, 2)}\n`);
+// Statically importing from `../dist/...` (as this file used to) only resolves once `npm run
+// build` has produced it, and CI's own lint step runs before its build step (see
+// `.github/workflows/ci.yml`), so a static import here is unresolvable at lint time even though it
+// always resolves at the point this script actually runs. `existsSync` + dynamic `import()`
+// matches the same guarded pattern `scripts/validate-fixtures.mjs` and
+// `scripts/evaluate-semantic.mjs` already use for the same reason, and gives a clear message
+// instead of a raw "Cannot find module" if `npm run build` really has not been run yet.
+async function main() {
+  if (!existsSync(join(root, 'dist', 'core', 'config.js'))) {
+    console.error('dist/ is missing. Run "npm run build" first.');
+    process.exitCode = 2;
+    return;
   }
-  process.stderr.write(`${packets.length} packets, ${total} candidates written to ${dir}\n`);
+
+  const { resolveConfig } = await import(join(root, 'dist', 'core', 'config.js'));
+  const { analyseDocument } = await import(join(root, 'dist', 'core', 'document.js'));
+  const { runDeterministicRules } = await import(join(root, 'dist', 'core', 'runner.js'));
+  const { deterministicRules } = await import(join(root, 'dist', 'deterministic', 'index.js'));
+  const { resolveRulePack } = await import(join(root, 'dist', 'rule-pack', 'loader.js'));
+
+  let values;
+  try {
+    ({ values } = parseArgs({
+      args: process.argv.slice(2),
+      options: {
+        fixtures: { type: 'string', default: 'fixtures' },
+        split: { type: 'string', default: 'all' },
+        out: { type: 'string' },
+      },
+      strict: true,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
+  }
+
+  const fixturesDir = resolve(values.fixtures);
+  const split = values.split;
+  const outDir = values.out;
+
+  const manifest = JSON.parse(readFileSync(join(fixturesDir, 'manifest.json'), 'utf8'));
+  const config = resolveConfig({});
+  const pack = resolveRulePack(config.rulePack);
+
+  /** Characters of surrounding source shown to the reviewer on each side of the candidate. */
+  const CONTEXT = 320;
+
+  const packets = [];
+  for (const fixture of manifest.fixtures) {
+    if (split !== 'all' && fixture.split !== split) continue;
+    const originalPath = join(fixturesDir, fixture.originalPath);
+    const text = readFileSync(originalPath, 'utf8');
+    const doc = analyseDocument(
+      { id: fixture.id, format: 'markdown', text, path: originalPath },
+      {
+        protectedRegions: {
+          approvedTerms: [...config.approvedTerms, ...pack.approvedTechnicalTerms],
+          extraPatterns: config.extraProtectedPatterns,
+        },
+        structure: { extraImperativeVerbs: config.extraImperativeVerbs },
+      },
+    );
+    const run = runDeterministicRules({ doc, rules: deterministicRules, config, pack });
+    if (run.candidates.length === 0) continue;
+
+    packets.push({
+      fixtureId: fixture.id,
+      split: fixture.split,
+      category: fixture.category,
+      sourceOrganisation: fixture.sourceOrganisation,
+      originalPath: fixture.originalPath,
+      candidates: run.candidates.map((candidate) => ({
+        passageId: candidate.id,
+        ruleId: candidate.ruleId,
+        evaluatorId: candidate.evaluatorId,
+        span: { start: candidate.range.start, end: candidate.range.end },
+        quote: text.slice(candidate.range.start, candidate.range.end),
+        mode: candidate.mode,
+        admonition: candidate.admonition,
+        heuristicReason: candidate.reason,
+        payload: candidate.payload,
+        context: text.slice(
+          Math.max(0, candidate.range.start - CONTEXT),
+          Math.min(text.length, candidate.range.end + CONTEXT),
+        ),
+      })),
+    });
+  }
+
+  const total = packets.reduce((sum, p) => sum + p.candidates.length, 0);
+  if (outDir === undefined) {
+    process.stdout.write(`${JSON.stringify({ total, packets }, null, 2)}\n`);
+  } else {
+    const dir = resolve(outDir);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    for (const packet of packets) {
+      writeFileSync(join(dir, `${packet.fixtureId}.json`), `${JSON.stringify(packet, null, 2)}\n`);
+    }
+    process.stderr.write(`${packets.length} packets, ${total} candidates written to ${dir}\n`);
+  }
 }
+
+await main();

--- a/scripts/build-candidate-packets.mjs
+++ b/scripts/build-candidate-packets.mjs
@@ -15,10 +15,20 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * A filesystem path is not a URL: on Windows, `join(root, 'dist', ...)` produces
+ * `C:\...\dist\...`, which Node's ESM loader reads as the unsupported `c:` URL scheme
+ * (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) rather than a drive letter — `pathToFileURL(...).href`
+ * converts it to the `file://...` URL `import()` actually expects, on every platform.
+ */
+function distImport(...segments) {
+  return import(pathToFileURL(join(root, 'dist', ...segments)).href);
+}
 
 // Statically importing from `../dist/...` (as this file used to) only resolves once `npm run
 // build` has produced it, and CI's own lint step runs before its build step (see
@@ -34,11 +44,11 @@ async function main() {
     return;
   }
 
-  const { resolveConfig } = await import(join(root, 'dist', 'core', 'config.js'));
-  const { analyseDocument } = await import(join(root, 'dist', 'core', 'document.js'));
-  const { runDeterministicRules } = await import(join(root, 'dist', 'core', 'runner.js'));
-  const { deterministicRules } = await import(join(root, 'dist', 'deterministic', 'index.js'));
-  const { resolveRulePack } = await import(join(root, 'dist', 'rule-pack', 'loader.js'));
+  const { resolveConfig } = await distImport('core', 'config.js');
+  const { analyseDocument } = await distImport('core', 'document.js');
+  const { runDeterministicRules } = await distImport('core', 'runner.js');
+  const { deterministicRules } = await distImport('deterministic', 'index.js');
+  const { resolveRulePack } = await distImport('rule-pack', 'loader.js');
 
   let values;
   try {

--- a/scripts/ci/assert-corpus-report.mjs
+++ b/scripts/ci/assert-corpus-report.mjs
@@ -9,39 +9,52 @@
  */
 import { readFileSync } from 'node:fs';
 
-const [reportPath] = process.argv.slice(2);
+// `process.exit()` mid-script would skip the remaining checks below whenever an earlier one fails,
+// and can truncate output that has not finished flushing; wrapping the checks in a function and
+// using `process.exitCode` (the pattern this project's own `src/cli/main.ts` already follows) gets
+// the same distinct exit codes -- 2 for a usage error, 1 for a failed assertion -- without either
+// risk.
+function main() {
+  const [reportPath] = process.argv.slice(2);
 
-if (reportPath === undefined) {
-  console.error('usage: node scripts/ci/assert-corpus-report.mjs <report.json>');
-  process.exit(2);
-}
+  if (reportPath === undefined) {
+    console.error('usage: node scripts/ci/assert-corpus-report.mjs <report.json>');
+    process.exitCode = 2;
+    return;
+  }
 
-const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
 
-if (report.conformance?.claim !== 'none') {
-  console.error(
-    `the bundled pack must not claim conformance, got ${JSON.stringify(report.conformance?.claim)}`,
+  if (report.conformance?.claim !== 'none') {
+    console.error(
+      `the bundled pack must not claim conformance, got ${JSON.stringify(report.conformance?.claim)}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (report.conformance?.packAuthority !== 'provisional') {
+    console.error(
+      `the bundled pack must report provisional authority, got ${JSON.stringify(
+        report.conformance?.packAuthority,
+      )}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const total = report.results.reduce((n, file) => n + file.diagnostics.length, 0);
+
+  if (total === 0) {
+    console.error('expected diagnostics on the original corpus, got none');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `deterministic-only run produced ${total} diagnostics across ${report.results.length} files, ` +
+      'exit code 1 as documented',
   );
-  process.exit(1);
 }
 
-if (report.conformance?.packAuthority !== 'provisional') {
-  console.error(
-    `the bundled pack must report provisional authority, got ${JSON.stringify(
-      report.conformance?.packAuthority,
-    )}`,
-  );
-  process.exit(1);
-}
-
-const total = report.results.reduce((n, file) => n + file.diagnostics.length, 0);
-
-if (total === 0) {
-  console.error('expected diagnostics on the original corpus, got none');
-  process.exit(1);
-}
-
-console.log(
-  `deterministic-only run produced ${total} diagnostics across ${report.results.length} files, ` +
-    'exit code 1 as documented',
-);
+main();

--- a/scripts/ci/assert-rules-provisional.mjs
+++ b/scripts/ci/assert-rules-provisional.mjs
@@ -8,28 +8,40 @@
  */
 import { readFileSync } from 'node:fs';
 
-const [rulesPath, expectedCountRaw = '14'] = process.argv.slice(2);
+// See the matching comment in scripts/ci/assert-corpus-report.mjs: `process.exitCode` inside a
+// wrapping function, not `process.exit()` mid-script, keeps the distinct usage/assertion exit codes
+// without skipping cleanup or truncating output.
+function main() {
+  const [rulesPath, expectedCountRaw = '14'] = process.argv.slice(2);
 
-if (rulesPath === undefined) {
-  console.error('usage: node scripts/ci/assert-rules-provisional.mjs <rules.json> [expectedCount]');
-  process.exit(2);
+  if (rulesPath === undefined) {
+    console.error(
+      'usage: node scripts/ci/assert-rules-provisional.mjs <rules.json> [expectedCount]',
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const expectedCount = Number.parseInt(expectedCountRaw, 10);
+  const rules = JSON.parse(readFileSync(rulesPath, 'utf8'));
+
+  if (rules.length !== expectedCount) {
+    console.error(`expected ${expectedCount} rules, got ${rules.length}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const nonProvisional = rules.filter((rule) => rule.status !== 'provisional');
+
+  if (nonProvisional.length > 0) {
+    console.error(
+      `rules claiming non-provisional status: ${nonProvisional.map((rule) => rule.id).join(', ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`all ${rules.length} rules report provisional status`);
 }
 
-const expectedCount = Number.parseInt(expectedCountRaw, 10);
-const rules = JSON.parse(readFileSync(rulesPath, 'utf8'));
-
-if (rules.length !== expectedCount) {
-  console.error(`expected ${expectedCount} rules, got ${rules.length}`);
-  process.exit(1);
-}
-
-const nonProvisional = rules.filter((rule) => rule.status !== 'provisional');
-
-if (nonProvisional.length > 0) {
-  console.error(
-    `rules claiming non-provisional status: ${nonProvisional.map((rule) => rule.id).join(', ')}`,
-  );
-  process.exit(1);
-}
-
-console.log(`all ${rules.length} rules report provisional status`);
+main();

--- a/scripts/evaluate-semantic.mjs
+++ b/scripts/evaluate-semantic.mjs
@@ -17,93 +17,105 @@ import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-if (!existsSync(join(root, 'dist', 'evaluation', 'evaluate.js'))) {
-  console.error('dist/ is missing. Run "npm run build" first.');
-  process.exit(2);
-}
 
-const { evaluateSemanticEvaluators, formatEvaluationReport } = await import(
-  join(root, 'dist', 'evaluation', 'evaluate.js')
-);
-const { LlamaCppClient } = await import(join(root, 'dist', 'model-client', 'llama-client.js'));
+// `process.exitCode` inside a wrapping function, not `process.exit()` mid-script, keeps the
+// distinct build-missing/usage-error exit codes below without skipping the rest of the script (the
+// real, always-set `process.exitCode = 1` cases further down already followed this pattern; the
+// three early `process.exit(2)` guards were the outliers).
+async function main() {
+  if (!existsSync(join(root, 'dist', 'evaluation', 'evaluate.js'))) {
+    console.error('dist/ is missing. Run "npm run build" first.');
+    process.exitCode = 2;
+    return;
+  }
 
-let values;
-try {
-  ({ values } = parseArgs({
-    args: process.argv.slice(2),
-    options: {
-      split: { type: 'string', default: 'heldout' },
-      endpoint: { type: 'string', default: 'http://127.0.0.1:8080' },
-      model: { type: 'string', default: 'local-ste-adjudicator' },
-      timeout: { type: 'string', default: '30000' },
-      concurrency: { type: 'string', default: '2' },
-      out: { type: 'string' },
-      json: { type: 'boolean', default: false },
-    },
-    strict: true,
-    allowPositionals: false,
-  }));
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(2);
-}
-
-const split = values.split;
-if (!['dev', 'heldout', 'all'].includes(split)) {
-  console.error(`--split must be dev, heldout or all (got "${split}")`);
-  process.exit(2);
-}
-const endpoint = values.endpoint;
-const model = values.model;
-const timeout = Number(values.timeout);
-const concurrency = Number(values.concurrency);
-const out = values.out;
-
-const transport = new LlamaCppClient({ endpoint, requestTimeoutMs: timeout });
-
-const report = await evaluateSemanticEvaluators({
-  fixturesDir: join(root, 'fixtures'),
-  split,
-  transport,
-  config: {
-    semantic: {
-      enabled: true,
-      endpoint,
-      model,
-      requestTimeoutMs: timeout,
-      maxConcurrency: concurrency,
-      // Caching off: a measurement run must actually exercise the model.
-      cache: false,
-    },
-  },
-});
-
-if (values.json) {
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-} else {
-  process.stdout.write(`${formatEvaluationReport(report)}\n`);
-}
-
-if (out !== undefined) {
-  writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
-  console.error(`wrote ${out}`);
-}
-
-if (report.overall.failureRate > 0.5) {
-  console.error(
-    `\nMore than half the requests failed (${(report.overall.failureRate * 100).toFixed(0)}%). ` +
-      'Check that the server is running and that the model can produce the required JSON.',
+  const { evaluateSemanticEvaluators, formatEvaluationReport } = await import(
+    join(root, 'dist', 'evaluation', 'evaluate.js')
   );
-  process.exitCode = 1;
+  const { LlamaCppClient } = await import(join(root, 'dist', 'model-client', 'llama-client.js'));
+
+  let values;
+  try {
+    ({ values } = parseArgs({
+      args: process.argv.slice(2),
+      options: {
+        split: { type: 'string', default: 'heldout' },
+        endpoint: { type: 'string', default: 'http://127.0.0.1:8080' },
+        model: { type: 'string', default: 'local-ste-adjudicator' },
+        timeout: { type: 'string', default: '30000' },
+        concurrency: { type: 'string', default: '2' },
+        out: { type: 'string' },
+        json: { type: 'boolean', default: false },
+      },
+      strict: true,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
+  }
+
+  const split = values.split;
+  if (!['dev', 'heldout', 'all'].includes(split)) {
+    console.error(`--split must be dev, heldout or all (got "${split}")`);
+    process.exitCode = 2;
+    return;
+  }
+  const endpoint = values.endpoint;
+  const model = values.model;
+  const timeout = Number(values.timeout);
+  const concurrency = Number(values.concurrency);
+  const out = values.out;
+
+  const transport = new LlamaCppClient({ endpoint, requestTimeoutMs: timeout });
+
+  const report = await evaluateSemanticEvaluators({
+    fixturesDir: join(root, 'fixtures'),
+    split,
+    transport,
+    config: {
+      semantic: {
+        enabled: true,
+        endpoint,
+        model,
+        requestTimeoutMs: timeout,
+        maxConcurrency: concurrency,
+        // Caching off: a measurement run must actually exercise the model.
+        cache: false,
+      },
+    },
+  });
+
+  if (values.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatEvaluationReport(report)}\n`);
+  }
+
+  if (out !== undefined) {
+    writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+    console.error(`wrote ${out}`);
+  }
+
+  if (report.overall.failureRate > 0.5) {
+    console.error(
+      `\nMore than half the requests failed (${(report.overall.failureRate * 100).toFixed(0)}%). ` +
+        'Check that the server is running and that the model can produce the required JSON.',
+    );
+    process.exitCode = 1;
+  }
+
+  // A run that produced no labelled cases cannot report precision or recall. Exiting 0 would let a
+  // caller record "no failures" for a measurement that measured nothing.
+  if (report.overall.labelled === 0 && report.cases.length > 0) {
+    console.error(
+      `\nNo case in this split carries a gold label, so precision, recall and F1 are undefined. ` +
+        `${report.cases.length} candidate(s) were adjudicated but none is referenced by a fixture ` +
+        'annotation for the same rule. Add annotations for the candidate rules before quoting metrics.',
+    );
+    process.exitCode = 1;
+  }
 }
 
-// A run that produced no labelled cases cannot report precision or recall. Exiting 0 would let a
-// caller record "no failures" for a measurement that measured nothing.
-if (report.overall.labelled === 0 && report.cases.length > 0) {
-  console.error(
-    `\nNo case in this split carries a gold label, so precision, recall and F1 are undefined. ` +
-      `${report.cases.length} candidate(s) were adjudicated but none is referenced by a fixture ` +
-      'annotation for the same rule. Add annotations for the candidate rules before quoting metrics.',
-  );
-  process.exitCode = 1;
-}
+await main();

--- a/scripts/evaluate-semantic.mjs
+++ b/scripts/evaluate-semantic.mjs
@@ -13,10 +13,20 @@
  */
 import { existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * A filesystem path is not a URL: on Windows, `join(root, 'dist', ...)` produces
+ * `C:\...\dist\...`, which the ESM loader reads as the unsupported `c:` URL scheme
+ * (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) rather than a drive letter — `pathToFileURL(...).href`
+ * converts it to the `file://...` URL `import()` actually expects, on every platform.
+ */
+function distImport(...segments) {
+  return import(pathToFileURL(join(root, 'dist', ...segments)).href);
+}
 
 // `process.exitCode` inside a wrapping function, not `process.exit()` mid-script, keeps the
 // distinct build-missing/usage-error exit codes below without skipping the rest of the script (the
@@ -29,10 +39,11 @@ async function main() {
     return;
   }
 
-  const { evaluateSemanticEvaluators, formatEvaluationReport } = await import(
-    join(root, 'dist', 'evaluation', 'evaluate.js')
+  const { evaluateSemanticEvaluators, formatEvaluationReport } = await distImport(
+    'evaluation',
+    'evaluate.js',
   );
-  const { LlamaCppClient } = await import(join(root, 'dist', 'model-client', 'llama-client.js'));
+  const { LlamaCppClient } = await distImport('model-client', 'llama-client.js');
 
   let values;
   try {

--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -1,5 +1,5 @@
-#!/usr/bin/env node
-// Plain Node 22 ESM, no dependencies.
+// Plain Node ESM, no dependencies. Always invoked as `node scripts/fetch-sources.mjs` (see
+// `fixtures:fetch` in package.json), never executed directly, so this file carries no shebang.
 // Fetches raw bytes for each source descriptor, caches them under .cache/sources/<key>,
 // and writes fixtures/provenance.lock.json recording real HTTP status, sha256, timestamp.
 

--- a/scripts/merge-candidate-verdicts.mjs
+++ b/scripts/merge-candidate-verdicts.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Merge reviewer verdicts on heuristic candidates into the fixture adjudication records.
  *
@@ -29,141 +28,156 @@ import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
-let values;
-try {
-  ({ values } = parseArgs({
-    args: process.argv.slice(2),
-    options: {
-      verdicts: { type: 'string', default: 'fixtures/verdicts' },
-      packets: { type: 'string', default: 'fixtures/packets' },
-      fixtures: { type: 'string', default: 'fixtures' },
-      check: { type: 'boolean', default: false },
-    },
-    strict: true,
-    allowPositionals: false,
-  }));
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(2);
-}
-
-const verdictsDir = resolve(values.verdicts);
-const packetsDir = resolve(values.packets);
-const fixturesDir = resolve(values.fixtures);
-const checkOnly = values.check;
-
-const jsonFiles = (dir) => readdirSync(dir).filter((f) => f.endsWith('.json'));
-
 /** Stable identity of a candidate passage: which rule, and which characters. */
 const key = (ruleId, span) => `${ruleId}@${span.start}-${span.end}`;
 
-const packets = new Map();
-for (const file of jsonFiles(packetsDir)) {
-  const packet = JSON.parse(readFileSync(join(packetsDir, file), 'utf8'));
-  packets.set(packet.fixtureId, new Map(packet.candidates.map((c) => [key(c.ruleId, c.span), c])));
-}
+const jsonFiles = (dir) => readdirSync(dir).filter((f) => f.endsWith('.json'));
 
-const problems = [];
-/** fixtureId -> passageId -> adjudication record */
-const merged = new Map();
-
-for (const file of jsonFiles(verdictsDir).toSorted()) {
-  const doc = JSON.parse(readFileSync(join(verdictsDir, file), 'utf8'));
-  const reviewer = doc.reviewer;
-  if (typeof reviewer !== 'string' || reviewer.length === 0) {
-    problems.push(`${file}: missing reviewer id`);
-    continue;
+// `process.exitCode` inside a wrapping function, not `process.exit()` mid-script, keeps the
+// distinct "problems found" exit code without skipping the summary line every run (including a
+// failing one) writes to stderr below.
+function main() {
+  let values;
+  try {
+    ({ values } = parseArgs({
+      args: process.argv.slice(2),
+      options: {
+        verdicts: { type: 'string', default: 'fixtures/verdicts' },
+        packets: { type: 'string', default: 'fixtures/packets' },
+        fixtures: { type: 'string', default: 'fixtures' },
+        check: { type: 'boolean', default: false },
+      },
+      strict: true,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
   }
-  for (const [fixtureId, rows] of Object.entries(doc.verdicts ?? {})) {
-    const candidates = packets.get(fixtureId);
-    if (candidates === undefined) {
-      problems.push(`${reviewer}: no candidate packet for fixture "${fixtureId}"`);
+
+  const verdictsDir = resolve(values.verdicts);
+  const packetsDir = resolve(values.packets);
+  const fixturesDir = resolve(values.fixtures);
+  const checkOnly = values.check;
+
+  const packets = new Map();
+  for (const file of jsonFiles(packetsDir)) {
+    const packet = JSON.parse(readFileSync(join(packetsDir, file), 'utf8'));
+    packets.set(
+      packet.fixtureId,
+      new Map(packet.candidates.map((c) => [key(c.ruleId, c.span), c])),
+    );
+  }
+
+  const problems = [];
+  /** fixtureId -> passageId -> adjudication record */
+  const merged = new Map();
+
+  for (const file of jsonFiles(verdictsDir).toSorted()) {
+    const doc = JSON.parse(readFileSync(join(verdictsDir, file), 'utf8'));
+    const reviewer = doc.reviewer;
+    if (typeof reviewer !== 'string' || reviewer.length === 0) {
+      problems.push(`${file}: missing reviewer id`);
       continue;
     }
-    for (const row of rows) {
-      if (row.span === undefined || row.span === null) {
-        problems.push(`${reviewer}/${fixtureId}: verdict for "${row.passageId}" has no span`);
+    for (const [fixtureId, rows] of Object.entries(doc.verdicts ?? {})) {
+      const candidates = packets.get(fixtureId);
+      if (candidates === undefined) {
+        problems.push(`${reviewer}: no candidate packet for fixture "${fixtureId}"`);
         continue;
       }
-      const id = key(row.ruleId, row.span);
-      const candidate = candidates.get(id);
-      if (candidate === undefined) {
-        problems.push(`${reviewer}/${fixtureId}: no candidate at ${id}`);
-        continue;
+      for (const row of rows) {
+        if (row.span === undefined || row.span === null) {
+          problems.push(`${reviewer}/${fixtureId}: verdict for "${row.passageId}" has no span`);
+          continue;
+        }
+        const id = key(row.ruleId, row.span);
+        const candidate = candidates.get(id);
+        if (candidate === undefined) {
+          problems.push(`${reviewer}/${fixtureId}: no candidate at ${id}`);
+          continue;
+        }
+        // The quote is the second half of the binding, and the half that catches a wrong span: a
+        // verdict pointing at the right offsets in the wrong revision of a fixture would still fail.
+        if (row.quote !== candidate.quote) {
+          problems.push(
+            `${reviewer}/${fixtureId}/${id}: quote does not match the text at that span`,
+          );
+        }
+        if (row.evaluatorId !== candidate.evaluatorId) {
+          problems.push(`${reviewer}/${fixtureId}/${id}: evaluatorId does not match packet`);
+        }
+        const byFixture = merged.get(fixtureId) ?? new Map();
+        if (byFixture.has(id)) {
+          problems.push(`${reviewer}/${fixtureId}: duplicate verdict for ${id}`);
+          continue;
+        }
+        byFixture.set(id, {
+          // Taken from the packet, not the verdict: this is a run-local label and the packet holds
+          // the current one. The binding that matters is the span and the quote, both verified
+          // above.
+          passageId: candidate.passageId,
+          ruleId: candidate.ruleId,
+          evaluatorId: candidate.evaluatorId,
+          quote: candidate.quote,
+          span: { start: candidate.span.start, end: candidate.span.end },
+          verdict: row.verdict,
+          reason: row.reason,
+          reviewer,
+          reviewerConfidence: row.reviewerConfidence,
+        });
+        merged.set(fixtureId, byFixture);
       }
-      // The quote is the second half of the binding, and the half that catches a wrong span: a
-      // verdict pointing at the right offsets in the wrong revision of a fixture would still fail.
-      if (row.quote !== candidate.quote) {
-        problems.push(`${reviewer}/${fixtureId}/${id}: quote does not match the text at that span`);
-      }
-      if (row.evaluatorId !== candidate.evaluatorId) {
-        problems.push(`${reviewer}/${fixtureId}/${id}: evaluatorId does not match packet`);
-      }
-      const byFixture = merged.get(fixtureId) ?? new Map();
-      if (byFixture.has(id)) {
-        problems.push(`${reviewer}/${fixtureId}: duplicate verdict for ${id}`);
-        continue;
-      }
-      byFixture.set(id, {
-        // Taken from the packet, not the verdict: this is a run-local label and the packet holds
-        // the current one. The binding that matters is the span and the quote, both verified above.
-        passageId: candidate.passageId,
-        ruleId: candidate.ruleId,
-        evaluatorId: candidate.evaluatorId,
-        quote: candidate.quote,
-        span: { start: candidate.span.start, end: candidate.span.end },
-        verdict: row.verdict,
-        reason: row.reason,
-        reviewer,
-        reviewerConfidence: row.reviewerConfidence,
-      });
-      merged.set(fixtureId, byFixture);
     }
   }
-}
 
-for (const [fixtureId, candidates] of packets) {
-  const judged = merged.get(fixtureId) ?? new Map();
-  for (const [id, candidate] of candidates) {
-    if (!judged.has(id)) {
-      problems.push(`${fixtureId}: candidate ${id} ("${candidate.passageId}") has no verdict`);
+  for (const [fixtureId, candidates] of packets) {
+    const judged = merged.get(fixtureId) ?? new Map();
+    for (const [id, candidate] of candidates) {
+      if (!judged.has(id)) {
+        problems.push(`${fixtureId}: candidate ${id} ("${candidate.passageId}") has no verdict`);
+      }
     }
   }
-}
 
-if (problems.length > 0) {
-  for (const problem of problems) process.stderr.write(`${problem}\n`);
-  process.stderr.write(`\n${problems.length} problem(s); nothing written.\n`);
-  process.exit(1);
-}
+  if (problems.length > 0) {
+    for (const problem of problems) process.stderr.write(`${problem}\n`);
+    process.stderr.write(`\n${problems.length} problem(s); nothing written.\n`);
+    process.exitCode = 1;
+    return;
+  }
 
-const manifest = JSON.parse(readFileSync(join(fixturesDir, 'manifest.json'), 'utf8'));
-let written = 0;
-let total = 0;
-for (const fixture of manifest.fixtures) {
-  const judged = merged.get(fixture.id);
-  if (judged === undefined) continue;
-  // Sort by span so the file is stable regardless of which reviewer produced which row.
-  const records = [...judged.values()].toSorted(
-    (a, b) =>
-      a.span.start - b.span.start || a.span.end - b.span.end || a.ruleId.localeCompare(b.ruleId),
+  const manifest = JSON.parse(readFileSync(join(fixturesDir, 'manifest.json'), 'utf8'));
+  let written = 0;
+  let total = 0;
+  for (const fixture of manifest.fixtures) {
+    const judged = merged.get(fixture.id);
+    if (judged === undefined) continue;
+    // Sort by span so the file is stable regardless of which reviewer produced which row.
+    const records = [...judged.values()].toSorted(
+      (a, b) =>
+        a.span.start - b.span.start || a.span.end - b.span.end || a.ruleId.localeCompare(b.ruleId),
+    );
+    total += records.length;
+    if (checkOnly) continue;
+    const path = join(fixturesDir, fixture.annotationPath);
+    const annotation = JSON.parse(readFileSync(path, 'utf8'));
+    annotation.candidateAdjudications = records;
+    const reviewers = new Set([...(annotation.reviewers ?? []), ...records.map((r) => r.reviewer)]);
+    // `annotation` comes from `JSON.parse`, so its element types are unresolved (`any`) to the
+    // type checker even though every reviewer id is a string at runtime; give an explicit compare
+    // instead of relying on the (unprovable-here) string-array default.
+    annotation.reviewers = [...reviewers].toSorted((a, b) => String(a).localeCompare(String(b)));
+    writeFileSync(path, `${JSON.stringify(annotation, null, 2)}\n`);
+    written += 1;
+  }
+
+  process.stderr.write(
+    checkOnly
+      ? `ok: ${total} verdicts bind to ${merged.size} fixtures with no problems\n`
+      : `${total} verdicts written to ${written} annotation files\n`,
   );
-  total += records.length;
-  if (checkOnly) continue;
-  const path = join(fixturesDir, fixture.annotationPath);
-  const annotation = JSON.parse(readFileSync(path, 'utf8'));
-  annotation.candidateAdjudications = records;
-  const reviewers = new Set([...(annotation.reviewers ?? []), ...records.map((r) => r.reviewer)]);
-  // `annotation` comes from `JSON.parse`, so its element types are unresolved (`any`) to the
-  // type checker even though every reviewer id is a string at runtime; give an explicit compare
-  // instead of relying on the (unprovable-here) string-array default.
-  annotation.reviewers = [...reviewers].toSorted((a, b) => String(a).localeCompare(String(b)));
-  writeFileSync(path, `${JSON.stringify(annotation, null, 2)}\n`);
-  written += 1;
 }
 
-process.stderr.write(
-  checkOnly
-    ? `ok: ${total} verdicts bind to ${merged.size} fixtures with no problems\n`
-    : `${total} verdicts written to ${written} annotation files\n`,
-);
+main();

--- a/scripts/validate-fixtures.mjs
+++ b/scripts/validate-fixtures.mjs
@@ -11,24 +11,34 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const built = join(root, 'dist', 'fixture-tools', 'validate.js');
 
-if (!existsSync(built)) {
-  console.error('dist/ is missing. Run "npm run build" first.');
-  process.exit(2);
+// `process.exitCode` inside a wrapping function, not `process.exit()` mid-script, keeps the
+// distinct build-missing/validation-failure exit codes without skipping the remaining checks or
+// truncating output that has not finished flushing.
+async function main() {
+  const built = join(root, 'dist', 'fixture-tools', 'validate.js');
+
+  if (!existsSync(built)) {
+    console.error('dist/ is missing. Run "npm run build" first.');
+    process.exitCode = 2;
+    return;
+  }
+
+  const { validateFixtureCorpus } = await import(built);
+  const report = validateFixtureCorpus(join(root, 'fixtures'));
+
+  for (const note of report.notes) console.log(`note: ${note}`);
+
+  if (!report.ok) {
+    console.error(`\n${report.failures.length} fixture validation failure(s):`);
+    for (const failure of report.failures) console.error(`  - ${failure}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `OK: ${report.summary}. Provenance, licences, digests and protected literals verified.`,
+  );
 }
 
-const { validateFixtureCorpus } = await import(built);
-const report = validateFixtureCorpus(join(root, 'fixtures'));
-
-for (const note of report.notes) console.log(`note: ${note}`);
-
-if (!report.ok) {
-  console.error(`\n${report.failures.length} fixture validation failure(s):`);
-  for (const failure of report.failures) console.error(`  - ${failure}`);
-  process.exit(1);
-}
-
-console.log(
-  `OK: ${report.summary}. Provenance, licences, digests and protected literals verified.`,
-);
+await main();

--- a/scripts/validate-fixtures.mjs
+++ b/scripts/validate-fixtures.mjs
@@ -8,9 +8,19 @@
  */
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * A filesystem path is not a URL: on Windows, `join(root, 'dist', ...)` produces
+ * `C:\...\dist\...`, which the ESM loader reads as the unsupported `c:` URL scheme
+ * (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) rather than a drive letter — `pathToFileURL(...).href`
+ * converts it to the `file://...` URL `import()` actually expects, on every platform.
+ */
+function distImport(...segments) {
+  return import(pathToFileURL(join(root, 'dist', ...segments)).href);
+}
 
 // `process.exitCode` inside a wrapping function, not `process.exit()` mid-script, keeps the
 // distinct build-missing/validation-failure exit codes without skipping the remaining checks or
@@ -24,7 +34,7 @@ async function main() {
     return;
   }
 
-  const { validateFixtureCorpus } = await import(built);
+  const { validateFixtureCorpus } = await distImport('fixture-tools', 'validate.js');
   const report = validateFixtureCorpus(join(root, 'fixtures'));
 
   for (const note of report.notes) console.log(`note: ${note}`);

--- a/src/deterministic/rules/mechanics.ts
+++ b/src/deterministic/rules/mechanics.ts
@@ -388,16 +388,23 @@ export const numberUnitFormatRule: DeterministicRule<z.output<typeof numberUnitO
         const m = /^([+±-]?\d+(?:[.,]\d+)?)(\s*)([^\s\d].*)$/.exec(raw);
         const unit = m?.[3];
         const gap = m?.[2];
-        if (m !== undefined && m !== null && unit !== undefined && gap !== undefined) {
+        // Capture group 1 is not optional in the regex above, so it is always populated whenever `m`
+        // matches; the `string | undefined` type here is only `noUncheckedIndexedAccess` being unable
+        // to see that. `quantity` makes the always-true case explicit instead of leaving an unguarded
+        // `m[1]` that would silently interpolate as the literal text "undefined" if that invariant
+        // were ever broken by a future regex edit. `RegExp.exec` also returns `RegExpExecArray | null`,
+        // never `undefined`, so the guard below only checks against `null`.
+        const quantity = m?.[1];
+        if (m !== null && unit !== undefined && gap !== undefined && quantity !== undefined) {
           const exempt = noSpace.has(unit) || noSpace.has(unit.charAt(0));
           if (!exempt && options.unitSpacing === 'required' && gap.length === 0) {
             diagnostics.push(
               buildDiagnostic(numberUnitMeta, policy, {
                 category: 'deterministic-violation',
-                message: `Put a space between the number and the unit: "${m[1]} ${unit}".`,
+                message: `Put a space between the number and the unit: "${quantity} ${unit}".`,
                 range: region.range,
                 evidence: raw,
-                suggestions: [`${m[1] ?? ''} ${unit}`],
+                suggestions: [`${quantity} ${unit}`],
                 meta: { quantity: raw, expectedSpacing: 'required' },
               }),
             );
@@ -406,10 +413,10 @@ export const numberUnitFormatRule: DeterministicRule<z.output<typeof numberUnitO
             diagnostics.push(
               buildDiagnostic(numberUnitMeta, policy, {
                 category: 'deterministic-violation',
-                message: `Remove the space between the number and the unit: "${m[1]}${unit}".`,
+                message: `Remove the space between the number and the unit: "${quantity}${unit}".`,
                 range: region.range,
                 evidence: raw,
-                suggestions: [`${m[1] ?? ''}${unit}`],
+                suggestions: [`${quantity}${unit}`],
                 meta: { quantity: raw, expectedSpacing: 'forbidden' },
               }),
             );

--- a/src/fixture-tools/manifest-schema.ts
+++ b/src/fixture-tools/manifest-schema.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 
 export const licenceEvidenceSchema = z.object({
   /** Where the licence statement is published. */
-  url: z.string().url(),
+  url: z.url(),
   /** Verbatim licence statement, or the path of the licence file in the upstream repository. */
   quote: z.string().min(10),
   /** How the evidence was obtained. */
@@ -33,7 +33,7 @@ export const fixtureEntrySchema = z.object({
   id: z.string().regex(/^[a-z0-9][a-z0-9-]{2,60}$/, 'ids are lower-case kebab-case'),
   title: z.string().min(3),
   sourceOrganisation: z.string().min(2),
-  sourceUrl: z.string().url(),
+  sourceUrl: z.url(),
   /** ISO-8601 date the source was retrieved. */
   retrievedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   /** SPDX identifier where one exists, otherwise the licence's published name. */
@@ -101,7 +101,7 @@ export const fixtureManifestSchema = z.object({
 });
 
 export const provenanceRecordSchema = z.object({
-  url: z.string().url(),
+  url: z.url(),
   httpStatus: z.number().int(),
   fetchedAt: z.string().min(4),
   sha256: z.string().regex(/^[0-9a-f]{64}$/),

--- a/test/e2e/textlint-run.test.ts
+++ b/test/e2e/textlint-run.test.ts
@@ -1,6 +1,7 @@
 import { TextlintKernel, type TextlintPluginCreator } from '@textlint/kernel';
 import markdownPluginModule from '@textlint/textlint-plugin-markdown';
 import textPluginModule from '@textlint/textlint-plugin-text';
+import type { TextlintRuleModule } from '@textlint/types';
 import { describe, expect, it, beforeEach } from 'vitest';
 
 // The published typings for these plugins declare a default export whose shape TypeScript resolves
@@ -23,6 +24,18 @@ import { rules, rulesConfig } from '../../src/textlint/preset.js';
  */
 
 const kernel = new TextlintKernel();
+
+// `rules` is indexed by rule id (`noUncheckedIndexedAccess` types the lookup as possibly
+// `undefined`); these tests deliberately pin a single rule under test by its known id, so a missing
+// entry is a real bug in the test itself (a typo'd id, or a rule renamed without updating callers),
+// not a case to paper over with a non-null assertion.
+function mustGetRule(id: string): TextlintRuleModule {
+  const rule = rules[id];
+  if (rule === undefined) {
+    throw new Error(`preset does not define a rule named "${id}"`);
+  }
+  return rule;
+}
 
 function presetRules(only?: readonly string[]) {
   return Object.entries(rules)
@@ -50,8 +63,8 @@ describe('textlint lint run', () => {
     expect(result.messages).toHaveLength(1);
     const message = result.messages[0];
     expect(message?.ruleId).toBe('unapproved-vocabulary');
-    expect(message?.line).toBe(3);
-    expect(message?.column).toBe(1);
+    expect(message?.loc.start.line).toBe(3);
+    expect(message?.loc.start.column).toBe(1);
     expect(message?.message).toContain('[deterministic-violation][provisional]');
     expect(message?.message).toContain('"Prior to" is not approved');
   });
@@ -59,8 +72,8 @@ describe('textlint lint run', () => {
   it('points at the right column mid-line', async () => {
     const text = 'Please utilise the bracket.\n';
     const result = await kernel.lintText(text, options(['unapproved-vocabulary']));
-    expect(result.messages[0]?.line).toBe(1);
-    expect(result.messages[0]?.column).toBe(text.indexOf('utilise') + 1);
+    expect(result.messages[0]?.loc.start.line).toBe(1);
+    expect(result.messages[0]?.loc.start.column).toBe(text.indexOf('utilise') + 1);
   });
 
   it('reports nothing inside a fenced code block', async () => {
@@ -68,7 +81,7 @@ describe('textlint lint run', () => {
       '\n',
     );
     const result = await kernel.lintText(text, options());
-    const inFence = result.messages.filter((m) => m.line === 4);
+    const inFence = result.messages.filter((m) => m.loc.start.line === 4);
     expect(inFence).toEqual([]);
   });
 
@@ -102,8 +115,8 @@ describe('textlint lint run', () => {
     expect(ruleIds).toContain('one-instruction-per-sentence');
     expect(ruleIds).toContain('number-unit-format');
     for (const message of result.messages) {
-      expect(message.line).toBeGreaterThan(0);
-      expect(message.column).toBeGreaterThan(0);
+      expect(message.loc.start.line).toBeGreaterThan(0);
+      expect(message.loc.start.column).toBeGreaterThan(0);
     }
   });
 
@@ -214,7 +227,7 @@ describe('per-rule textlint options', () => {
       rules: [
         {
           ruleId: 'sentence-length-procedural',
-          rule: rules['sentence-length-procedural']!,
+          rule: mustGetRule('sentence-length-procedural'),
           options: { floorWords: 1, maxGradeLevel: 3 },
         },
       ],
@@ -237,7 +250,7 @@ describe('per-rule textlint options', () => {
       rules: [
         {
           ruleId: 'number-unit-format',
-          rule: rules['number-unit-format']!,
+          rule: mustGetRule('number-unit-format'),
           options: {
             shared: { diagnostics: { severity: { 'deterministic-violation': 'info' } } },
           },
@@ -253,7 +266,7 @@ describe('per-rule textlint options', () => {
       rules: [
         {
           ruleId: 'number-unit-format',
-          rule: rules['number-unit-format']!,
+          rule: mustGetRule('number-unit-format'),
           options: { shared: { rules: { 'number-unit-format': { severity: 'warning' } } } },
         },
       ],
@@ -268,7 +281,7 @@ describe('per-rule textlint options', () => {
       rules: [
         {
           ruleId: 'unapproved-vocabulary',
-          rule: rules['unapproved-vocabulary']!,
+          rule: mustGetRule('unapproved-vocabulary'),
           options: { shared: { rules: { 'unapproved-vocabulary': { enabled: false } } } },
         },
       ],

--- a/test/e2e/textlint-tester.test.ts
+++ b/test/e2e/textlint-tester.test.ts
@@ -36,9 +36,21 @@ const TextLintTester = TextLintTesterModule as unknown as new () => Tester;
 
 const tester = new TextLintTester();
 
+// `rules` is indexed by rule id (`noUncheckedIndexedAccess` types the lookup as possibly
+// `undefined`); each call below pins a single rule under test by its known id, so a missing entry
+// is a real bug in the test itself (a typo'd id, or a rule renamed without updating callers), not a
+// case to paper over with a non-null assertion.
+function mustGetRule(id: string): unknown {
+  const rule = rules[id];
+  if (rule === undefined) {
+    throw new Error(`preset does not define a rule named "${id}"`);
+  }
+  return rule;
+}
+
 clearAnalysisCache();
 
-tester.run('no-contractions', rules['no-contractions']!, {
+tester.run('no-contractions', mustGetRule('no-contractions'), {
   valid: [
     { text: 'Do not remove the cover.\n' },
     { text: 'The unit does not start.\n' },
@@ -81,7 +93,7 @@ tester.run('no-contractions', rules['no-contractions']!, {
   ],
 });
 
-tester.run('unapproved-vocabulary', rules['unapproved-vocabulary']!, {
+tester.run('unapproved-vocabulary', mustGetRule('unapproved-vocabulary'), {
   valid: [
     { text: 'Use the bracket.\n' },
     { text: 'Open the file at /opt/utilise/bin now.\n' },
@@ -121,7 +133,7 @@ tester.run('unapproved-vocabulary', rules['unapproved-vocabulary']!, {
   ],
 });
 
-tester.run('no-repeated-words', rules['no-repeated-words']!, {
+tester.run('no-repeated-words', mustGetRule('no-repeated-words'), {
   valid: [
     { text: 'Remove the cover.\n' },
     { text: 'The value that that follows is set.\n' },
@@ -151,7 +163,7 @@ tester.run('no-repeated-words', rules['no-repeated-words']!, {
   ],
 });
 
-tester.run('number-unit-format', rules['number-unit-format']!, {
+tester.run('number-unit-format', mustGetRule('number-unit-format'), {
   valid: [{ text: 'Torque the bolt to 25 Nm now.\n' }, { text: 'Charge to 80% now.\n' }],
   invalid: [
     {
@@ -167,7 +179,7 @@ tester.run('number-unit-format', rules['number-unit-format']!, {
   ],
 });
 
-tester.run('one-instruction-per-sentence', rules['one-instruction-per-sentence']!, {
+tester.run('one-instruction-per-sentence', mustGetRule('one-instruction-per-sentence'), {
   valid: [
     { text: 'Remove the cover and the filter.\n' },
     { text: 'The unit reads the sensor and writes the value.\n' },

--- a/test/unit/protected-regions.test.ts
+++ b/test/unit/protected-regions.test.ts
@@ -48,6 +48,28 @@ describe('protected-region extraction', () => {
     expect(doc.positionAt(text.indexOf('Prose.')).line).toBe(6);
   });
 
+  it('finds newline positions correctly even when the text has an astral character before them', () => {
+    // Regression: an earlier version of this test located newlines by spreading the string
+    // (`[...text]`), which walks Unicode code points. A code point outside the BMP (like an emoji)
+    // is one JS array element from `[...text]` but two UTF-16 code units in the plain string
+    // `text.length`/`text[i]` indexes -- the same indexing `doc.maskedText` and `positionAt` use.
+    // Past that character, a code-point index and a code-unit index diverge, so `doc.maskedText[i]`
+    // (code-unit indexed) would be checked against the wrong `i` (code-point indexed). This fixture
+    // puts a surrogate-pair emoji before a newline specifically to catch that class of bug again.
+    const text = 'Prose with an emoji \u{1F389}\nmore prose.\n';
+    const doc = analyse(text);
+    const newlinePositions: number[] = [];
+    for (let i = 0; i < text.length; i += 1) {
+      if (text[i] === '\n') newlinePositions.push(i);
+    }
+    // Two UTF-16 code units for the emoji push the first newline's code-unit index one past where a
+    // naive code-point count would land.
+    expect(newlinePositions[0]).toBe(text.indexOf('\n'));
+    for (const i of newlinePositions) {
+      expect(doc.maskedText[i]).toBe('\n');
+    }
+  });
+
   const cases: readonly [string, string, ProtectedRegionKind][] = [
     ['fenced code', '```bash\nrm -rf /tmp/x\n```\n', 'fenced-code'],
     ['inline code', 'Set `MAX_RETRIES` now.\n', 'inline-code'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,24 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/**/index.ts', 'src/cli/**'],
       reporter: ['text-summary', 'lcov'],
+      // Without `thresholds`, coverage is measured but never enforced: a change that quietly drops
+      // coverage passes `npm test` the same as one that doesn't, unlike everything else in this
+      // project's QA setup (the fixture ground-truth script, the corpus tests) which fails loud on
+      // drift instead of just reporting it.
+      //
+      // These numbers are today's real coverage, from `npm run test:coverage` on this exact commit
+      // (statements 91.9%, branches 81.61%, functions 92.04%, lines 94.67%), each given roughly a
+      // point of slack below the real figure. That is deliberate margin, not laziness: v8's own
+      // coverage counting has small run-to-run jitter, and a hard ratchet set to the exact current
+      // number would fail on that jitter alone, not on an actual regression. A change that drops
+      // coverage by more than that margin fails the build; a change that holds or improves it does
+      // not need this comment touched.
+      thresholds: {
+        statements: 91,
+        branches: 81,
+        functions: 91,
+        lines: 94,
+      },
     },
   },
 });


### PR DESCRIPTION
## What

QA/tooling-currency work, reconstructed onto current `main` (post `#50`'s oxlint migration) after that migration removed the ESLint/typescript-eslint toolchain this PR originally targeted. Every genuine correctness fix from the original work was kept; the ESLint-specific config wiring was dropped since it's now moot.

### 1. Dependency audit
`@textlint/*` family and `textlint`/`textlint-tester` (15.7.1→15.8.0), `zod` (4.1.10→4.4.3), `prettier` (3.6.2→3.9.6), `vitest`/`@vitest/coverage-v8` (4.0.0→4.1.10), `@types/node` already current on `main`. Bumps to now-removed packages (`typescript-eslint`, `@eslint/js`, `eslint-plugin-n`) dropped — `main` already replaced that whole toolchain with oxlint.

### 2. Real correctness fixes (originally surfaced by the now-removed strictTypeChecked tier, kept on their own merit)
Deprecated zod/textlint API replacements (`z.string().url()` → `z.url()`; textlint's deprecated `.line`/`.column` → `.loc.start.line`/`.loc.start.column`), a dead-code removal plus a real message-formatting inconsistency fix in `mechanics.ts`, and non-null assertions replaced with a fail-loud `mustGetRule()` helper in the e2e tests.

### 3. Real Node-runtime script fixes (originally surfaced by the now-removed eslint-plugin-n, kept on their own merit)
Dead shebangs removed from 3 scripts, `process.exit()` → `process.exitCode` across 5 CI/build scripts (exit codes verified byte-identical), `scripts/build-candidate-packets.mjs` converted from a static `dist/` import (unresolvable before `npm run build`) to the guarded dynamic-import pattern its sibling scripts use — and further fixed to convert those paths through `pathToFileURL(...).href` before `import()`, since a raw filesystem path fails on Windows (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) — caught by review.

### 4. Coverage thresholds
`vitest.config.ts` previously measured coverage without enforcing it. Thresholds set from real numbers on this reconstructed code (91/81/91/94), and CI's test step switched from `npm test` to `npm run test:coverage` so the thresholds are actually evaluated in CI, not just locally.

## Verification

- `rm -rf node_modules && npm ci`, `npm run typecheck`, `npm run lint` (oxlint + prettier) — clean
- `npm run build:clean` — clean
- `npm run test:coverage` — 486/486 passing, at/above thresholds
- `node scripts/validate-fixtures.mjs`, all `scripts/ci/*.sh` — clean
- No inline `eslint-disable`/stale suppression comments anywhere in the diff