### PR TITLE
chore: add Dependabot config for npm and github-actions (grouped weekly updates)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot version updates. Vulnerability alerts and security-update PRs are a separate,
+# repository-level setting (Settings > Code security > Dependabot) and are not controlled by this
+# file — they already fire independently of the schedule below (see the moderate advisory GitHub
+# reports on this repo's Dependabot alerts page).
+#
+# Both ecosystems are grouped into a single weekly PR each, rather than one PR per outdated
+# dependency, so routine bumps do not create a flood of individual reviews.
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` with version-update checks for both ecosystems this repo actually
uses:

- `npm` (`package.json`/`package-lock.json`), weekly
- `github-actions` (`.github/workflows/ci.yml`), weekly

Both ecosystems use a single `groups` entry (`patterns: ["*"]`) so routine bumps land as one PR per
ecosystem per week instead of one PR per outdated dependency — verified this is real, current
Dependabot syntax (`groups.<name>.patterns`) against GitHub's own docs before writing it, not from
memory.

## What this does *not* do

Vulnerability alerts and automatic security-update PRs are a repository-level setting (**Settings →
Code security → Dependabot**), not something `dependabot.yml` controls. They already appear active
on this repo independently of this file — GitHub's own push output references a live advisory at
`/security/dependabot/1` (the same moderate finding `npm audit` also surfaces on `main`, and which
`#44` resolves as a side effect of its dependency bumps). This PR only adds the *scheduled version
update* half; it does not enable or change the security-alert half, and I have no tool access to
toggle that repository setting — worth a manual check if it isn't already on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXVhFQhSfdvdu8n7houDK6)_