### PR TITLE
docs: discover docs and tests before a functional change, reconcile both after

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,16 +3,20 @@
 ## Discover docs and tests before a functional change; reconcile both after — no confirmation needed
 
 Before changing behavior, find what already describes or covers the system being touched: search
-`README.md`, `docs/`, and doc comments for references, and search `test/` for coverage of the same
-code paths. Do this before writing the change, not after — the discovery is what the post-change
-reconciliation checks against.
+`README.md`, `docs/`, and doc comments for references, and search `test/` **and `scripts/ci/`** for
+coverage of the same code paths — `.github/workflows/ci.yml` runs `scripts/ci/*.sh` as assertions
+separate from `npm test` (e.g. `check-rules-provisional.sh` hard-codes the expected rule count), so
+a change that only reconciles `test/` can still leave one of those scripts stale and fail CI. Do
+this before writing the change, not after — the discovery is what the post-change reconciliation
+checks against.
 
 After the change, treat that discovery list as part of the work, not a follow-up: update or remove
 whichever of those docs actually describe the changed behavior, and update or remove whichever of
-those tests now assert the old behavior — not every file discovery turned up regardless of
-relevance. Definition of done includes removing or updating stale tests and documentation, not just
-adding new ones; a task that changes behavior but leaves a doc or a test describing the old behavior
-in place is incomplete, not finished-with-a-follow-up.
+those tests or CI assertion scripts now assert the old behavior — not every file discovery turned up
+regardless of relevance. Definition of done includes removing or updating stale tests, CI assertion
+scripts, and documentation, not just adding new ones; a task that changes behavior but leaves a doc,
+a test, or a `scripts/ci/*.sh` check describing the old behavior in place is incomplete, not
+finished-with-a-follow-up.
 
 ## Agents share this session's rate limit — retry, don't substitute
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,18 @@
 # Working on this repo
 
-## Documentation stays in sync with code — no confirmation needed
+## Discover docs and tests before a functional change; reconcile both after — no confirmation needed
 
-Update whichever of `README.md`, `docs/`, or doc comments actually describe the changed behavior, in
-the same task, without asking first — not every file in those locations regardless of relevance.
-Stale documentation is never acceptable output; a task that changes behavior but leaves the docs
-describing the old behavior is incomplete, not finished-with-a-follow-up.
+Before changing behavior, find what already describes or covers the system being touched: search
+`README.md`, `docs/`, and doc comments for references, and search `test/` for coverage of the same
+code paths. Do this before writing the change, not after — the discovery is what the post-change
+reconciliation checks against.
+
+After the change, treat that discovery list as part of the work, not a follow-up: update or remove
+whichever of those docs actually describe the changed behavior, and update or remove whichever of
+those tests now assert the old behavior — not every file discovery turned up regardless of
+relevance. Definition of done includes removing or updating stale tests and documentation, not just
+adding new ones; a task that changes behavior but leaves a doc or a test describing the old behavior
+in place is incomplete, not finished-with-a-follow-up.
 
 ## Agents share this session's rate limit — retry, don't substitute
 


### PR DESCRIPTION
## What

Extends the existing "documentation stays in sync" `CLAUDE.md` guideline to explicitly cover tests, and splits it into two steps instead of one:

1. **Before** a functional change: discover what already describes the system being touched (`README.md`/`docs/`/doc comments) and what already covers it (`test/`).
2. **After** the change: use that same discovery list to reconcile, not just to add — update or remove whichever of those docs/tests describe the *old* behavior.

## Why

The prior wording only named documentation drift and only described the after-the-fact reconciliation step, leaving the discovery step implicit. Definition of done now explicitly includes removing or updating stale tests and documentation, not just adding new ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXVhFQhSfdvdu8n7houDK6)_