### PR TITLE
fix(fixtures,docs): reconcile ground truth, records, docs and example config after #56

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ found, and the whole configuration silently loads no rules at all.
       "sentence-length-descriptive": { "maxGradeLevel": 7 },
       "no-contractions": true,
       "abbreviation-introduction": {
-        "additionalWellKnown": ["VACUUM", "PRAGMA", "WAL"]
+        "additionalWellKnown": ["WAL"]
       },
       "punctuation-constraints": { "maxCommas": 2 },
       "passive-voice-candidate": false

--- a/docs/implementation-report.md
+++ b/docs/implementation-report.md
@@ -95,15 +95,22 @@ response schema, prompts, evaluation, pipeline smoke), architecture (module boun
 ```
 node dist/cli/main.js lint fixtures/original/*.md   --deterministic-only --json
 node dist/cli/main.js lint fixtures/compliant/*.md  --deterministic-only --json
-→ deterministic violations: original 111 → compliant 60
+→ deterministic violations: original 121 → compliant 75
 ```
 
-By rule on the originals: `punctuation-constraints` 30, `abbreviation-introduction` 20,
-`number-unit-format` 20, `sentence-length-descriptive` 15, `no-contractions` 11,
-`unapproved-vocabulary` 6, `one-instruction-per-sentence` 4, `sentence-length-procedural` 3,
-`list-instruction-structure` 1, `no-repeated-words` 1.
+By rule on the originals: `sentence-length-descriptive` 35, `punctuation-constraints` 30,
+`number-unit-format` 17, `abbreviation-introduction` 11, `no-contractions` 11,
+`unapproved-vocabulary` 6, `one-instruction-per-sentence` 4, `list-instruction-structure` 3,
+`sentence-length-procedural` 3, `no-repeated-words` 1.
 
-The 60 remaining on the rewritten corpus are overwhelmingly the findings reviewers **refused** — see
+These counts were re-measured after the protected-region and well-known-list change that stopped
+`abbreviation-introduction` flagging protected all-caps tokens (which accounts for
+`abbreviation-introduction` 20 → 11 and `number-unit-format` 20 → 17). The other movements since the
+figures first published here — most visibly `sentence-length-descriptive` 15 → 35 — come from earlier
+segmentation work, not from that change; they are reported as measured rather than reconciled to the
+older numbers.
+
+The 75 remaining on the rewritten corpus are overwhelmingly the findings reviewers **refused** — see
 false-positive risk below. They are not oversights; they are recorded as `disputed`.
 
 ### Fixture provenance, independently verified
@@ -196,13 +203,13 @@ re-reading the code that implements it.
 
 ### False positives (observed, not hypothetical)
 
-| Rule                                         | Fires on                                                                  | Why it is wrong                                                                                    |
-| -------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `abbreviation-introduction`                  | `VACUUM`, `FULL`, `ANALYZE`, `PRAGMA`, `WAL`, `LLVM`, `FIPS`, `RFC`, `ON` | Command names, keywords, product names and CMake literals are not abbreviations of a longer phrase |
-| `number-unit-format`                         | `3.20.5`, `2.4.64`, `140-2`, `1910.132`                                   | Version strings, standard designations and regulatory citations are not quantity+unit pairs        |
-| `punctuation-constraints`                    | `SSL/TLS`; semicolons in an `(i)/(ii)/(iii)` legal list                   | A compound protocol name; legal list separators                                                    |
-| `punctuation-constraints`, `no-contractions` | `'hello!'` in an **unfenced** terminal transcript                         | If the source does not mark a transcript as code, the linter cannot know it is not prose           |
-| `sentence-length-descriptive`                | a flat HTML index of `PRAGMA` names                                       | Not a sentence; no punctuation for the segmenter                                                   |
+| Rule                                         | Fires on                                                | Why it is wrong                                                                          |
+| -------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `abbreviation-introduction`                  | `FULL`, `LLVM`, `ON`                                    | Command names, product names and CMake literals are not abbreviations of a longer phrase |
+| `number-unit-format`                         | `3.20.5`, `2.4.64`, `1910.132`                          | Version strings and regulatory citations are not quantity+unit pairs                     |
+| `punctuation-constraints`                    | `SSL/TLS`; semicolons in an `(i)/(ii)/(iii)` legal list | A compound protocol name; legal list separators                                          |
+| `punctuation-constraints`, `no-contractions` | `'hello!'` in an **unfenced** terminal transcript       | If the source does not mark a transcript as code, the linter cannot know it is not prose |
+| `sentence-length-descriptive`                | a flat HTML index of `PRAGMA` names                     | Not a sentence; no punctuation for the segmenter                                         |
 
 The dominant class is **an identifier that looks like an abbreviation or a quantity**.
 `approvedTerms`, `approvedTechnicalTerms` and `additionalWellKnown` are the mitigation and are the
@@ -237,10 +244,12 @@ off by default for this reason.
 1. **Run the evaluation suite against a real llama.cpp model and calibrate the thresholds.** The
    tooling, the ground truth and the split discipline are in place; the numbers are the gap. Without
    them the confidence thresholds are guesses.
-2. **Cut the abbreviation and quantity false positives.** Together they are 40 of the 111 findings on
-   the corpus, and nearly all are identifiers. An identifier-shape pre-filter — a token appearing in a
-   code span or table cell elsewhere in the document is probably not prose — would remove most of them
-   without a rule-pack change.
+2. **Cut the remaining abbreviation and quantity false positives.** Together they are 28 of the 121
+   findings on the corpus, down from 40 of 111 before the protected-region and well-known-list change,
+   which already implemented most of the identifier-shape pre-filter this item originally proposed: a
+   token corroborated by a naming region elsewhere in the document is now masked. What is left is the
+   case that filter cannot reach — a command or product name in running prose with nothing nearby to
+   corroborate it.
 3. **Obtain a licensed rule pack and exercise the import boundary end to end.** The path is
    implemented and unit-tested, but it has never carried real normative data. That is the difference
    between a useful plain-English linter and the tool this was meant to be.

--- a/docs/implementation-report.md
+++ b/docs/implementation-report.md
@@ -84,7 +84,7 @@ Every command below was run in this session; the output is what it printed.
 | End-to-end textlint            | `npx vitest run test/e2e`                                                       | 16 kernel tests + 29 `textlint-tester` cases, all passed                                                                                             |
 | Deterministic-only, no service | `test/integration/semantic-service.test.ts`                                     | fake server received **0** requests; run notice `semantic-disabled` emitted                                                                          |
 | Semantic mode vs fake server   | same file                                                                       | 22 integration tests passed over real HTTP                                                                                                           |
-| CLI on the corpus              | `node dist/cli/main.js lint fixtures/original/*.md --deterministic-only --json` | 18 files, **111 diagnostics**, `conformance.claim: "none"`                                                                                           |
+| CLI on the corpus              | `node dist/cli/main.js lint fixtures/original/*.md --deterministic-only --json` | 18 files, **121 deterministic violations** (226 diagnostics in total, the rest `review-required`), `conformance.claim: "none"`                       |
 
 Test suite composition: 15 files — unit (rules, protected regions, offsets, fix safety, broker,
 response schema, prompts, evaluation, pipeline smoke), architecture (module boundaries), integration
@@ -137,7 +137,7 @@ copyleft source is present; the validator rejects them, and CC-BY sources propag
 ### Adjudication
 
 70 change records across 18 fixtures: **32 accepted, 36 disputed, 2 deferred**. Mean reviewer
-confidence 0.893. 107 semantic invariants and 22 unresolved findings recorded.
+confidence 0.895. 107 semantic invariants and 20 unresolved findings recorded.
 
 That 36 disputed exceeds 32 accepted is the most useful number in this report: **on real technical
 documentation, more than half of what these provisional rules flag was judged wrong by a reviewer.**

--- a/docs/provisional-rules.md
+++ b/docs/provisional-rules.md
@@ -194,12 +194,21 @@ count, so `not not` is reported without a fix. `had` and `that` are allow-listed
 **Triggers** on the _first_ use of an abbreviation-shaped token (2–6 upper-case letters) that is not
 introduced as `Full Name (ABC)` or `ABC (Full Name)`, and is not in the well-known list.
 
-**Known failure modes — significant**
+**Known failure modes — narrowed, not eliminated**
 
-- **Command and keyword names are misread as abbreviations.** `VACUUM`, `FULL`, `ANALYZE`, `WAL`,
-  `PRAGMA` are flagged on the SQLite and PostgreSQL fixtures. They are command names, not
-  abbreviations, and "introducing" them would damage the text. Add them to `additionalWellKnown` or
-  to `approvedTerms`. Several fixture annotations record this finding as `disputed`.
+- **Command and keyword names in ordinary prose are still misread as abbreviations.** The corpus-wide
+  false positives on `VACUUM`, `ANALYZE`, `PRAGMA`, `FIPS` and `RFC` are gone: `VACUUM`, `ANALYZE`
+  and `PRAGMA` are now in the default well-known list, config assignments such as
+  `PRAGMA secure_delete=ON` are masked as protected regions, standards citations such as `RFC 2817`
+  and `FIPS 140-2` are masked as identifiers, and a bare all-caps token is masked when another
+  naming region in the same document corroborates it. What remains is the case none of those
+  mechanisms reach — a command or product name in running prose with nothing nearby to corroborate
+  it. Three such findings survive on the corpus: `FULL` in "Plain VACUUM (without FULL)"
+  (`postgres-vacuum-overview`), `LLVM` in "Building LLVM" (`llvm-getting-started-build`), and `ON`
+  in the upper-case CMake assignment `LLVM_INSTALL_UTILS=ON` (`llvm-standalone-build-table`), whose
+  key is upper-case and so does not match the lower-case config-fragment pattern. All three are
+  recorded as `disputed` in the fixture annotations. Add such terms to `additionalWellKnown` or to
+  `approvedTerms`.
 - The default well-known list is a judgement call, not a standard.
 
 ### number-unit-format
@@ -411,14 +420,14 @@ participles rather than selectable nouns.
 These were found by running the rule set over `fixtures/original/` and are recorded as `disputed`
 findings in the adjudication records. They are the honest known limits of the current rule set.
 
-| What fires                                   | On what                                                                   | Why it is wrong                                                                                                     | Mitigation                                                                         |
-| -------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `abbreviation-introduction`                  | `VACUUM`, `FULL`, `ANALYZE`, `PRAGMA`, `WAL`, `LLVM`, `FIPS`, `RFC`, `ON` | Command names, keywords, product names, directive names and CMake literals are not abbreviations of a longer phrase | `additionalWellKnown`, or `approvedTerms`                                          |
-| `number-unit-format`                         | `3.20.5`, `2.4.64`, `140-2`, `1910.132`                                   | Version strings, standard designations and regulatory citations are not quantity+unit pairs                         | none needed — report only, never fixed; add to `extraProtectedPatterns` to silence |
-| `punctuation-constraints`                    | `SSL/TLS`                                                                 | A fixed compound protocol name, not an ambiguous `and/or`                                                           | `approvedTerms`                                                                    |
-| `punctuation-constraints`                    | semicolons in an `(i)/(ii)/(iii)` legal list                              | List separators in a regulatory enumeration, not run-on joins                                                       | `forbidSemicolon: false` for such documents                                        |
-| `punctuation-constraints`, `no-contractions` | `'hello!'` inside an **unfenced** terminal transcript                     | If the source does not mark a transcript as code, the linter has no way to know it is not prose                     | fence the transcript, or use `extraProtectedPatterns`                              |
-| `sentence-length-descriptive`                | a flat HTML index of `PRAGMA` names rendered as text                      | Not a sentence at all; there is no punctuation for the segmenter to use                                             | none — inherent to unstructured input                                              |
+| What fires                                   | On what                                               | Why it is wrong                                                                                 | Mitigation                                                                         |
+| -------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `abbreviation-introduction`                  | `FULL`, `LLVM`, `ON`                                  | Command names, product names and CMake literals are not abbreviations of a longer phrase        | `additionalWellKnown`, or `approvedTerms`                                          |
+| `number-unit-format`                         | `3.20.5`, `2.4.64`, `1910.132`                        | Version strings and regulatory citations are not quantity+unit pairs                            | none needed — report only, never fixed; add to `extraProtectedPatterns` to silence |
+| `punctuation-constraints`                    | `SSL/TLS`                                             | A fixed compound protocol name, not an ambiguous `and/or`                                       | `approvedTerms`                                                                    |
+| `punctuation-constraints`                    | semicolons in an `(i)/(ii)/(iii)` legal list          | List separators in a regulatory enumeration, not run-on joins                                   | `forbidSemicolon: false` for such documents                                        |
+| `punctuation-constraints`, `no-contractions` | `'hello!'` inside an **unfenced** terminal transcript | If the source does not mark a transcript as code, the linter has no way to know it is not prose | fence the transcript, or use `extraProtectedPatterns`                              |
+| `sentence-length-descriptive`                | a flat HTML index of `PRAGMA` names rendered as text  | Not a sentence at all; there is no punctuation for the segmenter to use                         | none — inherent to unstructured input                                              |
 
 The general shape of the first two rows is the same: **a token that looks like an abbreviation or a
 quantity but is an identifier.** The rule pack's `approvedTechnicalTerms` and the config's

--- a/examples/.textlintrc.json
+++ b/examples/.textlintrc.json
@@ -13,7 +13,7 @@
       "punctuation-constraints": { "maxCommas": 3 },
       "no-repeated-words": true,
       "abbreviation-introduction": {
-        "additionalWellKnown": ["VACUUM", "PRAGMA", "WAL", "ANALYZE"],
+        "additionalWellKnown": ["WAL"],
         "severity": "warning"
       },
       "number-unit-format": { "severity": "warning" },

--- a/fixtures/annotations/httpd-mod-ssl-directive-config.json
+++ b/fixtures/annotations/httpd-mod-ssl-directive-config.json
@@ -45,14 +45,8 @@
           "end": 404
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "RFC"
-        }
-      ],
-      "reason": "'RFC 2817' is a specific IETF document citation (like the FIPS 140-2 and CFR citations elsewhere in this corpus), not a general term being repeatedly used that benefits from first-use expansion. It appears exactly once, as part of a fixed document number, and is never referred to again.",
+      "expectedDiagnostics": [],
+      "reason": "'RFC 2817' is a specific IETF document citation (like the FIPS 140-2 and CFR citations elsewhere in this corpus), not a general term being repeatedly used that benefits from first-use expansion. It appears exactly once, as part of a fixed document number, and is never referred to again. Reconciled after #56: the identifier pass now recognises standards-body citation numbers, so the whole span 'RFC 2817' is masked as a protected identifier and the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the citation 'RFC 2817' must remain byte-identical"
       ],
@@ -131,14 +125,8 @@
           "end": 793
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "FIPS"
-        }
-      ],
-      "reason": "The flagged occurrence is inside the SSLFIPS directive reference heading ('SSLFIPS / SSL FIPS mode Switch / Syntax: SSLFIPS on|off ...'), where 'FIPS' is part of the literal directive name and the C API symbol 'FIPS_mode' used later, and reappears afterward only inside the fixed citation 'FIPS 140-2'. There is no ordinary-prose occurrence where expanding it would not require altering a protected identifier (SSLFIPS, FIPS_mode) or a citation number (FIPS 140-2).",
+      "expectedDiagnostics": [],
+      "reason": "The flagged occurrence is inside the SSLFIPS directive reference heading ('SSLFIPS / SSL FIPS mode Switch / Syntax: SSLFIPS on|off ...'), where 'FIPS' is part of the literal directive name and the C API symbol 'FIPS_mode' used later, and reappears afterward only inside the fixed citation 'FIPS 140-2'. There is no ordinary-prose occurrence where expanding it would not require altering a protected identifier (SSLFIPS, FIPS_mode) or a citation number (FIPS 140-2). Reconciled after #56: the corroborated-constant pass now masks the bare token, on the evidence of the identifier regions FIPS_mode and FIPS 140-2 in this same document — exactly the corroboration this note describes — so the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the directive name SSLFIPS, the C symbol FIPS_mode, and the citation 'FIPS 140-2' must all remain byte-identical"
       ],
@@ -167,14 +155,8 @@
           "end": 1489
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "number-unit-format",
-          "category": "deterministic-violation",
-          "quote": "140-2"
-        }
-      ],
-      "reason": "'140-2' is part of the fixed standard number 'FIPS 140-2', a NIST publication citation, not a quantity with a missing unit space. Inserting a space would corrupt the standard's name.",
+      "expectedDiagnostics": [],
+      "reason": "'140-2' is part of the fixed standard number 'FIPS 140-2', a NIST publication citation, not a quantity with a missing unit space. Inserting a space would corrupt the standard's name. Reconciled after #56: the identifier pass now recognises standards-body citation numbers, so all three occurrences of 'FIPS 140-2' are masked as protected identifiers and number-unit-format no longer sees them; the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the standard citation 'FIPS 140-2' must remain byte-identical everywhere it appears"
       ],

--- a/fixtures/annotations/httpd-mod-ssl-directive-config.json
+++ b/fixtures/annotations/httpd-mod-ssl-directive-config.json
@@ -338,16 +338,16 @@
       "reviewerConfidence": 0.9
     },
     {
-      "passageId": "noun-cluster-candidate:s9:777",
+      "passageId": "noun-cluster-candidate:s9:794",
       "ruleId": "noun-cluster-candidate",
       "evaluatorId": "noun-cluster-comprehension",
-      "quote": "SSLFIPS\nSSL FIPS mode Switch\nSyntax: SSLFIPS",
+      "quote": "mode Switch\nSyntax: SSLFIPS",
       "span": {
-        "start": 777,
+        "start": 794,
         "end": 821
       },
       "verdict": "non-violation",
-      "reason": "Same structural artefact as the SSLEngine heading: the directive name SSLFIPS joined across line breaks to its title 'SSL FIPS mode Switch' and its 'Syntax: SSLFIPS' declaration. Directive identity and reference-page boilerplate, not an opaque noun run.",
+      "reason": "Re-reviewed after the leading 'SSLFIPS' and 'SSL FIPS' identifiers became protected regions, which shortened this candidate from 777-821 to 794-821. What is left is the tail of the directive's title line ('... mode Switch') stitched across a line break onto the following 'Syntax: SSLFIPS' declaration label. 'mode Switch' alone is two words and under the limit; the run only reaches four content words by crossing the newline into a reference-page metadata field. Two adjacent layout fields, not a noun pile a reader must parse — the same structural artefact as the SSLEngine heading above, on a narrower span.",
       "reviewer": "reviewer-a",
       "reviewerConfidence": 0.85
     },

--- a/fixtures/annotations/llvm-standalone-build-table.json
+++ b/fixtures/annotations/llvm-standalone-build-table.json
@@ -17,19 +17,13 @@
           "end": 338
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "LLVM"
-        }
-      ],
-      "reason": "LLVM is the proper name of the project/product this document is about, not an abbreviation being introduced for a general term. There is no full expansion to write out on first use (analogous to 'SQLite' or 'Zephyr' elsewhere in this corpus); spelling out 'Low Level Virtual Machine (LLVM)' would be both historically inaccurate (the project disavows that expansion) and would not aid comprehension.",
+      "expectedDiagnostics": [],
+      "reason": "LLVM is the proper name of the project/product this document is about, not an abbreviation being introduced for a general term. There is no full expansion to write out on first use (analogous to 'SQLite' or 'Zephyr' elsewhere in this corpus); spelling out 'Low Level Virtual Machine (LLVM)' would be both historically inaccurate (the project disavows that expansion) and would not aid comprehension. Reconciled after #56: the corroborated-constant pass now masks the bare token, because the identifier region LLVM_INSTALL_UTILS elsewhere in this document establishes LLVM as a deliberate naming segment, so the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the product name LLVM must remain unchanged everywhere it appears"
       ],
       "unresolved": [
-        "whether the rule pack should special-case known product/project proper nouns the way it already special-codes for command names"
+        "the rule pack still has no notion of a product/project proper noun; LLVM is exempt here only because another naming region in the same document happens to corroborate it, so the same name in a document with no such identifier would still be flagged"
       ],
       "status": "disputed",
       "reviewerConfidence": 0.9

--- a/fixtures/annotations/postgres-vacuum-overview.json
+++ b/fixtures/annotations/postgres-vacuum-overview.json
@@ -180,14 +180,8 @@
           "end": 222
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "VACUUM"
-        }
-      ],
-      "reason": "VACUUM is the SQL command name this entire document is about, not an abbreviation of a longer phrase. Writing 'Vacuum (VACUUM)' or any invented expansion would be nonsensical; the word is already the full, correct term.",
+      "expectedDiagnostics": [],
+      "reason": "VACUUM is the SQL command name this entire document is about, not an abbreviation of a longer phrase. Writing 'Vacuum (VACUUM)' or any invented expansion would be nonsensical; the word is already the full, correct term. Reconciled after #56: the rule no longer reports this occurrence, because VACUUM was added to the rule's default well-known list, so the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the command name VACUUM must remain unchanged throughout"
       ],

--- a/fixtures/annotations/sqlite-pragma-hard-negative.json
+++ b/fixtures/annotations/sqlite-pragma-hard-negative.json
@@ -30,10 +30,8 @@
       "rewrittenText": "PRAGMAs",
       "ruleIds": ["abbreviation-introduction"],
       "originalSpans": [{ "start": 165, "end": 172 }],
-      "expectedDiagnostics": [
-        { "ruleId": "abbreviation-introduction", "category": "deterministic-violation", "quote": "PRAGMAs" }
-      ],
-      "reason": "PRAGMA is a SQLite SQL statement keyword (the SQL command used to query or set database settings), not an abbreviation of a longer phrase. There is no full term to expand it into; 'PRAGMA' is the command's actual name. This is the same class of false positive called out for SQL keywords and command names generally.",
+      "expectedDiagnostics": [],
+      "reason": "PRAGMA is a SQLite SQL statement keyword (the SQL command used to query or set database settings), not an abbreviation of a longer phrase. There is no full term to expand it into; 'PRAGMA' is the command's actual name. This is the same class of false positive called out for SQL keywords and command names generally. Reconciled after #56: PRAGMA was added to the rule's default well-known list, and the rule strips a trailing plural 's' before that lookup, so the plural 'PRAGMAs' is exempt too and the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the SQL keyword PRAGMA/PRAGMAs must remain unchanged and must not be expanded into a fabricated full term"
       ],

--- a/fixtures/annotations/sqlite-vacuum-space-reclaim.json
+++ b/fixtures/annotations/sqlite-vacuum-space-reclaim.json
@@ -131,19 +131,13 @@
           "end": 172
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "VACUUM"
-        }
-      ],
-      "reason": "VACUUM is the SQL command name being documented, not an abbreviation that requires spelling out on first use.",
+      "expectedDiagnostics": [],
+      "reason": "VACUUM is the SQL command name being documented, not an abbreviation that requires spelling out on first use. Reconciled after #56: the rule no longer reports this occurrence, because VACUUM was added to the rule's default well-known list, so the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the command name VACUUM is unchanged"
       ],
       "unresolved": [
-        "rule does not distinguish command names from true abbreviations"
+        "the rule still has no general notion of a command name; VACUUM is exempt only because it is named in the default well-known list, so an undocumented command keyword would still be flagged"
       ],
       "status": "disputed",
       "reviewerConfidence": 0.95
@@ -161,20 +155,12 @@
           "end": 363
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "FULL"
-        }
-      ],
-      "reason": "FULL is a literal PRAGMA value inside the config fragment auto_vacuum=FULL, not a prose abbreviation.",
+      "expectedDiagnostics": [],
+      "reason": "FULL is a literal PRAGMA value inside the config fragment auto_vacuum=FULL, not a prose abbreviation. Reconciled after #56: the config-fragment pass now masks the whole assignment auto_vacuum=FULL as a protected region, so the rule never sees this token and the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the literal auto_vacuum=FULL config value is unchanged"
       ],
-      "unresolved": [
-        "rule tokenizes inside a config literal instead of skipping it"
-      ],
+      "unresolved": [],
       "status": "disputed",
       "reviewerConfidence": 0.95
     },
@@ -191,19 +177,13 @@
           "end": 1527
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "PRAGMA"
-        }
-      ],
-      "reason": "PRAGMA is a SQLite SQL keyword, not an abbreviation that needs to be introduced.",
+      "expectedDiagnostics": [],
+      "reason": "PRAGMA is a SQLite SQL keyword, not an abbreviation that needs to be introduced. Reconciled after #56: this occurrence is inside the config-fragment region PRAGMA secure_delete=ON, which is now masked as protected, and PRAGMA was additionally added to the default well-known list; either alone suppresses the finding, so the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the keyword PRAGMA is unchanged"
       ],
       "unresolved": [
-        "rule does not distinguish SQL keywords from true abbreviations"
+        "the rule still has no general notion of a SQL keyword; PRAGMA is exempt here through config-fragment masking and the default well-known list, not through keyword recognition"
       ],
       "status": "disputed",
       "reviewerConfidence": 0.95
@@ -221,20 +201,12 @@
           "end": 1544
         }
       ],
-      "expectedDiagnostics": [
-        {
-          "ruleId": "abbreviation-introduction",
-          "category": "deterministic-violation",
-          "quote": "ON"
-        }
-      ],
-      "reason": "\"ON\" is the literal boolean value of the secure_delete PRAGMA, not an abbreviation needing introduction.",
+      "expectedDiagnostics": [],
+      "reason": "\"ON\" is the literal boolean value of the secure_delete PRAGMA, not an abbreviation needing introduction. Reconciled after #56: the config-fragment pass now masks the whole assignment PRAGMA secure_delete=ON as a protected region, so short words inside a config literal are no longer tokenized as prose and the expected diagnostic has been removed.",
       "semanticInvariants": [
         "the literal secure_delete=ON config value is unchanged"
       ],
-      "unresolved": [
-        "rule flags common short words like ON inside config literals as abbreviations"
-      ],
+      "unresolved": [],
       "status": "disputed",
       "reviewerConfidence": 0.9
     }

--- a/fixtures/verdicts/reviewer-a.json
+++ b/fixtures/verdicts/reviewer-a.json
@@ -94,16 +94,16 @@
         "reviewerConfidence": 0.9
       },
       {
-        "passageId": "noun-cluster-candidate:s9:777",
+        "passageId": "noun-cluster-candidate:s9:794",
         "ruleId": "noun-cluster-candidate",
         "evaluatorId": "noun-cluster-comprehension",
-        "quote": "SSLFIPS\nSSL FIPS mode Switch\nSyntax: SSLFIPS",
+        "quote": "mode Switch\nSyntax: SSLFIPS",
         "span": {
-          "start": 777,
+          "start": 794,
           "end": 821
         },
         "verdict": "non-violation",
-        "reason": "Same structural artefact as the SSLEngine heading: the directive name SSLFIPS joined across line breaks to its title 'SSL FIPS mode Switch' and its 'Syntax: SSLFIPS' declaration. Directive identity and reference-page boilerplate, not an opaque noun run.",
+        "reason": "Re-reviewed after the leading 'SSLFIPS' and 'SSL FIPS' identifiers became protected regions, which shortened this candidate from 777-821 to 794-821. What is left is the tail of the directive's title line ('... mode Switch') stitched across a line break onto the following 'Syntax: SSLFIPS' declaration label. 'mode Switch' alone is two words and under the limit; the run only reaches four content words by crossing the newline into a reference-page metadata field. Two adjacent layout fields, not a noun pile a reader must parse — the same structural artefact as the SSLEngine heading above, on a narrower span.",
         "reviewerConfidence": 0.85
       },
       {


### PR DESCRIPTION
Closes #55. Closes #54.

Both are the fast-follow reconciliation for #56, which stopped `abbreviation-introduction` flagging protected all-caps tokens. They were opened as separate issues by artifact family; they land together here because this branch is where both were developed. Two commits, one per issue, reviewable independently.

## Commit 1 — #55: rebind the orphaned noun-cluster verdict

#56's document-wide corroboration pass now recognises `SSL FIPS` in `httpd-mod-ssl-directive-config.md` as a citation-pattern identifier and masks it. Correct behaviour, but it shortened a `noun-cluster-candidate` from `777-821` to `794-821`, breaking the ground-truth binding in both directions:

```
reviewer-a/httpd-mod-ssl-directive-config: no candidate at noun-cluster-candidate@777-821
httpd-mod-ssl-directive-config: candidate noun-cluster-candidate@794-821 … has no verdict
```

Verdicts join on `(ruleId, span, quote)`, so a moved span orphans the verdict even though the judgement is about the same region of the page.

Per the issue's instruction not to force the old offsets to persist, the new span was re-reviewed on its own terms. The masked-out head (`SSLFIPS\nSSL FIPS `) was exactly the text that made the old "directive identity boilerplate" rationale true, and it is no longer in the candidate. What survives is `mode Switch\nSyntax: SSLFIPS` — the tail of the title line stitched across a newline onto the `Syntax:` label. `mode Switch` alone is two content words, under the limit of three; the run only reaches four by crossing into a metadata field. Same structural artefact as the `SSLEngine` candidate above it (`207-262`, also `non-violation`), so the verdict stays **non-violation** at `0.85` with a reason describing the span that now exists.

## Commit 2 — #54: reconcile records, docs and example config

**Scope, measured not assumed.** Replaying `corpus.test.ts`'s two deterministic assertions without vitest's stop-at-first-failure enumerates the full stale set, confirming the issue's Reproducibility list exactly: **10 records across 5 files** (4 / 3 / 1 / 1 / 1). Nine are `abbreviation-introduction`; one is `number-unit-format` on `"140-2"`, a knock-on of `FIPS 140-2` now masking as a citation identifier.

Each stale `expectedDiagnostics` entry is removed, and each `reason` records which of #56's four mechanisms suppresses it — verified per record by inspecting the covering protected region, not inferred from the commit message:

| Token(s) | Mechanism |
|---|---|
| `VACUUM` ×2, `PRAGMAs` | default well-known list (trailing plural `s` stripped before lookup) |
| `FULL`, `PRAGMA`, `ON` | config-fragment masking of the whole assignment |
| `RFC`, `140-2` | identifier masking of standards-body citations |
| `FIPS`, `LLVM` | corroborated-constant masking, on the evidence of `FIPS_mode` / `FIPS 140-2` and `LLVM_INSTALL_UTILS` |

`status` stays `disputed` — the enum has no `resolved` value, and these records remain the audit trail for a rewrite that was declined. `unresolved` notes are **narrowed rather than deleted** where the general weakness survives: the rule still has no notion of a command name, SQL keyword or product noun, and each exemption here is incidental to a different mechanism.

**The failure mode is narrowed, not eliminated.** `FULL`, `LLVM` and `ON` still fire in running prose at spans in *other* fixtures — `"Plain VACUUM (without FULL)"`, `"Building LLVM"`, and the upper-case CMake assignment `LLVM_INSTALL_UTILS=ON` (whose key is upper-case and so does not match the lower-case config-fragment pattern). All three are already correctly annotated as `disputed` with live expectations. The docs now say this rather than claiming the class is fixed.

**Documentation.** `provisional-rules.md` and `implementation-report.md` false-positive tables now list only tokens measured as still firing. Corpus counts re-measured with the CLI command the report documents: 121 → 75 deterministic violations, `abbreviation-introduction` 20 → 11, `number-unit-format` 20 → 17. Movements **not** caused by #56 — most visibly `sentence-length-descriptive` 15 → 35, from earlier segmentation work — are reported as measured and labelled as such rather than silently attributed to this change.

**Example config.** `additionalWellKnown` reduced to `["WAL"]`: `VACUUM`, `PRAGMA` and `ANALYZE` are now in the default list, `WAL` is not (and appears nowhere in the corpus, so its absence from the corpus is not evidence it is unnecessary).

`examples/.ste-ai.json`'s `approvedTerms` is **deliberately left unchanged**, which is a departure from the issue's AC5 as written. Measuring the corpus with and without `VACUUM`/`PRAGMA` shows those entries still suppress a `noun-cluster-candidate` on `"VACUUM reclaims storage occupied"` in `postgres-vacuum-overview`. Removing them would introduce an unjudged candidate and break `check-candidate-ground-truth.sh` — the exact failure class commit 1 repairs. AC5 asks for entries "reduced to only what remains necessary"; these remain necessary, for a different rule than the issue assumed.

## Verification

| Check | Result |
|---|---|
| `vitest run` (full suite) | **545 / 545 passed**, 26 files |
| `scripts/ci/check-candidate-ground-truth.sh` | pass — `105 verdicts bind to 17 fixtures with no problems` |
| `scripts/ci/check-rules-provisional.sh` | pass — all 14 rules provisional |
| `scripts/ci/check-exit-codes.sh` | pass |
| `node scripts/validate-fixtures.mjs` | pass — 18 fixtures, digests and protected literals verified |
| `npm run typecheck` | pass |
| `npm run lint` | pass |

Both acceptance-criteria sets are met. The `corpus.test.ts` failure that was previously red on this branch — and red on `main` — is fixed by commit 2.

## Note on one figure left alone

`implementation-report.md:7` claims "344 passing tests"; the suite is now 545. That drift is not from #56 and the line was not in #54's scope, so it is untouched — flagged here rather than silently corrected, since that report is framed as a point-in-time session record.