### PR TITLE
docs(design): consolidated design record for layered rule packs (#64)

### DIFF
--- a/docs/design/64-layered-rule-packs/00-decisions.md
+++ b/docs/design/64-layered-rule-packs/00-decisions.md
@@ -17,9 +17,9 @@ unqualified in the spec that proposed it:
 
 | Overturned                                   | Still asserted in                       |
 | -------------------------------------------- | --------------------------------------- |
-| `rulePacks` as a new config key              | `01:178`, the config table, conflict C1 |
-| Composed output satisfies `RulePack` exactly | `01:14`, its opening premise            |
-| `replace` mode, and replace-only-at-index-0  | `01` (C2, C5, C6); depended on by `02`  |
+| `rulePacks` as a new config key              | `01:186`, the config table, conflict C1 |
+| Composed output satisfies `RulePack` exactly | `01:22-23`, its opening premise         |
+| `replace` mode, and replace-only-at-index-0  | `01` (C2, C6); depended on by `02`      |
 | Conformance claims are in scope              | most of `02`                            |
 
 Each spec carries a banner pointing here, so a reader who opens one directly is not led into an
@@ -34,7 +34,7 @@ substitutes instead — its three branches each return one pack, and none combin
 So the documented behaviour and the implemented behaviour already disagree — with one qualifier that
 sentence conjoins two keys and only one of them layers today: `config.approvedTerms` really is spread
 together with `pack.approvedTechnicalTerms` at `analyse.ts:255`. `rulePack` is the half that
-substitutes. `03:477` states this precisely; the claim here is the same one, narrowed to the key it
+substitutes. `03:494-495` states this precisely; the claim here is the same one, narrowed to the key it
 actually applies to. Layering closes that gap rather than adding something new. `03` found a second instance of the same drift: `README.md` is not
 alone, and the reconciliation list in that spec names the rest.
 
@@ -78,10 +78,12 @@ for having produced `03` at all.
 
 ## Agreed across specs
 
-- **The bundled pack becomes layer 0**, present unless displaced by a `replace` entry, rather than a
-  fallback used when nothing is configured.
-- **`replace` is legal only as the first layer.** A later `replace` makes every preceding entry dead
-  config, which is better rejected than honoured.
+- **The bundled pack becomes layer 0**, rather than a fallback used when nothing is configured.
+  ~~present unless displaced by a `replace` entry~~ — struck: `replace` is removed by "Superseded by
+  project stage" below, so nothing displaces it.
+- ~~**`replace` is legal only as the first layer.**~~ Struck for the same reason. The specs agreed on
+  this validation rule, and it has no subject once the mode is gone; it is recorded here because the
+  agreement was real and would need reinstating with the mode.
 - **Merge keys are per-field, not global.** Verified: `termPattern` (`helpers.ts:10`) matches with
   flags `giu` and collapses whitespace, while `approvedTerms` protection
   (`protected-regions.ts:552`) matches with flags `gu`, case-sensitively and without folding. A single
@@ -131,12 +133,15 @@ exact command so the number can be re-derived rather than trusted:
 
 ```bash
 grep -vE '^\s*(//|\*|/\*)' <file> \
-  | grep -coE 'packPermitsConformanceClaim|verifiedAuthority|verifiedRuleStatus|trustedRulePackIds|conformanceClaim|metadata\.authority'
+  | grep -oE 'packPermitsConformanceClaim|verifiedAuthority|verifiedRuleStatus|trustedRulePackIds|conformanceClaim|metadata\.authority' \
+  | wc -l
 ```
 
 That is occurrences of the removal candidates, with comment-only lines excluded — a rule worth
 stating, because counting matching _lines_ instead, or leaving comments in, gives materially
-different totals, and the scope of the proposed removal is argued from this table.
+different totals, and the scope of the proposed removal is argued from this table. The `| wc -l` is
+the load-bearing part: `grep -c` counts matching **lines** and ignores `-o`, which yields 28 rather
+than 35 on the same files.
 
 | File                                | References |
 | ----------------------------------- | ---------: |

--- a/docs/design/64-layered-rule-packs/00-decisions.md
+++ b/docs/design/64-layered-rule-packs/00-decisions.md
@@ -1,0 +1,142 @@
+# Layered rule packs — consolidated design and open decisions
+
+Design record for [issue #64](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/64).
+Three specs were produced independently against commit `9d78a8b`, each with a scope boundary so they
+would not design across each other:
+
+| Spec                                                             | Scope                                                                             |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [`01-merge-core.md`](./01-merge-core.md)                         | Config shape, per-field merge algorithm, retraction, conflict detection, ordering |
+| [`02-authority-trust.md`](./02-authority-trust.md)               | Per-entry authority, the trust boundary under composition, provenance             |
+| [`03-migration-verification.md`](./03-migration-verification.md) | Blast radius, back-compatibility, test strategy, staged rollout                   |
+
+This file records what the three agree on, where two of them disagreed, and what remains for a human
+to decide. It supersedes nothing in the specs; they hold the detail and the citations.
+
+## Framing correction: this is a defect, not a feature
+
+`README.md:74-75` already states that `rulePack` and `approvedTerms` let a repository supply its own
+vocabulary **"on top of the bundled provisional pack"**. `resolveRulePack` (`loader.ts:49-56`)
+substitutes instead — its three branches each return one pack, and none combines them.
+
+So the documented behaviour and the implemented behaviour already disagree. Layering closes that gap
+rather than adding something new. `03` found a second instance of the same drift: `README.md` is not
+alone, and the reconciliation list in that spec names the rest.
+
+## Resolved: the two places the specs disagreed
+
+### 1. The composed output type — the authority requirement wins
+
+`01` proposed that composition output satisfy the existing `RulePack` interface exactly, so no rule
+or consumer would change. `02` requires a distinct `ComposedRulePack` in which every entry carries a
+required `EntryProvenance`.
+
+These cannot both hold. `RulePack` has nowhere to put per-entry authority — `approvedTechnicalTerms`
+is `readonly string[]` (`types.ts:484`), and a string cannot carry provenance.
+
+**Decision: `02` wins; `01`'s zero-consumer-change property is what gives.**
+
+The reason is the concrete attack `02` documents: an untrusted layer adds a technical term, that term
+is protected before any rule runs (`analyse.ts:254-257`), and a normative dictionary entry then never
+matches. Without per-entry provenance nothing distinguishes that entry from a trusted one. The cost —
+a breaking type change and a wider blast radius — is real and belongs to `03`'s inventory.
+
+### 2. The config key — widen `rulePack`, do not add `rulePacks`
+
+`01` proposed a new `rulePacks` key alongside `rulePack`. `03` proposed widening the existing
+`rulePack` key to accept an array.
+
+**Decision: `03` wins, on measured behaviour.** Executed against the config schema at this commit:
+
+```
+new key `rulePacks` on current schema → ACCEPTED, and the key is SILENTLY STRIPPED
+array passed to existing `rulePack`  → REJECTED (fails loud)
+```
+
+`steAiConfigSchema` (`config.ts:119`) is a plain `z.object`, so it strips unknown keys. A config
+written for a newer linter and run against an older one would therefore lose its entire layer stack
+and lint against the bundled pack with no signal. Widening the existing key converts that same
+version skew into a loud parse failure.
+
+This is a design decision that surfaced only from asking a migration question, which is the argument
+for having produced `03` at all.
+
+## Agreed across specs
+
+- **The bundled pack becomes layer 0**, present unless displaced by a `replace` entry, rather than a
+  fallback used when nothing is configured.
+- **`replace` is legal only as the first layer.** A later `replace` makes every preceding entry dead
+  config, which is better rejected than honoured.
+- **Merge keys are per-field, not global.** Verified: `termPattern` (`helpers.ts:10`) matches with
+  flags `giu` and collapses whitespace, while `approvedTerms` protection
+  (`protected-regions.ts:552`) matches with flags `gu`, case-sensitively and without folding. A single
+  normaliser would therefore be wrong for one of them.
+- **Override direction is one-way.** The overriding layer owns the resulting entry's provenance
+  entirely; it is never inherited from the layer being overridden.
+- **Retraction needs its own syntax.** Union alone cannot express a locale layer un-banning a term an
+  organisation layer banned. `01` specifies a `retract` block and records why `options.allow` is not
+  the mechanism.
+- **Characterisation tests come first.** Both `02` and `03` found independently that no test imports
+  `src/rule-pack/loader.ts`; `grep -rln "authority\|conformance\|rulePack" test/` returns zero files.
+  Nothing else should merge before that gap is closed.
+
+## Open — needs a human decision
+
+### A. `limits` merge policy
+
+`01` recommends **last-wins**, with this argument: `limits` is required in `rulePackSchema`, so a
+most-restrictive-wins rule would pin the bundled pack's values (procedural grade level 7) as a
+ceiling no organisation could raise, pushing every such operator back onto `replace` — which is the
+defect this work exists to fix.
+
+Stated cost: a product layer can loosen an organisation's limit, guarded only by a notice.
+
+The alternative is an organisation-set floor that lower layers cannot loosen, which blocks a locale
+or product layer from a legitimate override. **Not decided.**
+
+### B. Conformance claims under mixed authority
+
+`02` proposes splitting `packPermitsConformanceClaim` into:
+
+- `entryPermitsConformanceClaim` — per entry, so a finding from a trusted normative layer keeps its
+  standing even in a mixed stack;
+- `stackPermitsConformanceClaim` — run level, requiring **unanimity** across contributing layers.
+
+The asymmetry driving it: a positive finding is attributable to one entry, whereas silence is a
+property of the whole stack. Unanimity is deliberately strict — one untrusted layer anywhere disables
+run-level conformance claims. **Not decided.**
+
+`02` also closes a self-attack worth preserving: defining "contributing layer" as "has a surviving
+entry" would let a pure-retraction untrusted layer escape the unanimity check entirely.
+
+## Related defects found while specifying
+
+Both are independent of layering and are tracked separately:
+
+- **`sourceRef` passes through untrusted.** `runner.ts:110` assigns `meta.sourceRef` from the pack
+  unconditionally. `verifiedRuleStatus` caps an untrusted pack's _status_, and the citation _string_
+  is copied verbatim, so an untrusted pack can print a fabricated standard citation on a diagnostic.
+- **The rule-pack loader has no test coverage**, as above.
+
+## Documentation already inaccurate, before any of this lands
+
+`02` and `03` found the same drift independently:
+
+- `rule-pack-import.md:51` and `:135` describe `packPermitsConformanceClaim()` with two conditions.
+  `loader.ts:76-83` enforces three — the third being membership in `trustedRulePackIds`. The docs
+  describe the gate as more permissive than the code.
+- `DISCLAIMER.md:64-65` states a pack "changes the `ruleStatus` on diagnostics to whatever the pack
+  declares", which holds only once an operator has trusted it.
+- `README.md:74-75`, as above.
+
+## Method note
+
+The specs were produced by three agents working in isolated worktrees from `9d78a8b`, each instructed
+to cite a file and line for every claim about current behaviour and to state uncertainty rather than
+guess. Claims reproduced in this file were re-verified directly before being recorded here. Where a
+spec labelled something as its own proposal rather than an existing fact — `01` does this for
+"weakest authority wins", since `ruleStatusSchema` declares no ordering — that label is preserved.
+
+`03` recorded that it could not run the test suite (no `node_modules` in its worktree) and flagged
+"main is green at `9d78a8b`" as unconfirmed. The full suite was run separately at that commit:
+545 tests, all passing.

--- a/docs/design/64-layered-rule-packs/00-decisions.md
+++ b/docs/design/64-layered-rule-packs/00-decisions.md
@@ -80,34 +80,85 @@ for having produced `03` at all.
   `src/rule-pack/loader.ts`; `grep -rln "authority\|conformance\|rulePack" test/` returns zero files.
   Nothing else should merge before that gap is closed.
 
-## Open — needs a human decision
+## Decided by the maintainer
 
-### A. `limits` merge policy
+### A. `limits` merge policy — last-wins
 
-`01` recommends **last-wins**, with this argument: `limits` is required in `rulePackSchema`, so a
-most-restrictive-wins rule would pin the bundled pack's values (procedural grade level 7) as a
-ceiling no organisation could raise, pushing every such operator back onto `replace` — which is the
-defect this work exists to fix.
+**Decided: last-wins**, matching how ESLint and Ruff resolve overlapping configuration. A later
+layer's limit replaces an earlier one; there is no organisation-set floor that lower layers cannot
+loosen.
 
-Stated cost: a product layer can loosen an organisation's limit, guarded only by a notice.
+This follows `01`'s recommendation. Its argument stands: `limits` is required in `rulePackSchema`, so
+a most-restrictive-wins rule would pin the bundled pack's values (procedural grade level 7) as a
+ceiling no organisation could raise.
 
-The alternative is an organisation-set floor that lower layers cannot loosen, which blocks a locale
-or product layer from a legitimate override. **Not decided.**
+Accepted cost, recorded so it is not rediscovered as a surprise: a product or locale layer can loosen
+an organisation's limit. The conventional-tooling behaviour was preferred over enforcement.
 
-### B. Conformance claims under mixed authority
+### B. Conformance under mixed authority — not in scope
 
-`02` proposes splitting `packPermitsConformanceClaim` into:
+**Decided: the product does not make conformance claims, so there is nothing to protect here.**
 
-- `entryPermitsConformanceClaim` — per entry, so a finding from a trusted normative layer keeps its
-  standing even in a mixed stack;
-- `stackPermitsConformanceClaim` — run level, requiring **unanimity** across contributing layers.
+The maintainer's framing: this is a configurable linter that flags prose exceeding a threshold and
+suggests it could be tighter. It is a per-repository capability that may import organisation-level
+dictionaries, stay local-only, or mix the two. Conformance standing for a supplied pack is not a
+goal.
 
-The asymmetry driving it: a positive finding is attributable to one entry, whereas silence is a
-property of the whole stack. Unanimity is deliberately strict — one untrusted layer anywhere disables
-run-level conformance claims. **Not decided.**
+That resolves the question by removing it. It also removes the reason a subsystem exists, which is a
+larger change than the decision it settles.
 
-`02` also closes a self-attack worth preserving: defining "contributing layer" as "has a surviving
-entry" would let a pure-retraction untrusted layer escape the unanimity check entirely.
+#### What this decision cascades into
+
+The authority machinery exists to guard one path: a supplied pack declaring `normative` authority and
+having that claim honoured after an operator names it in `trustedRulePackIds`. With conformance out
+of scope, that path has no destination. Surface measured at this commit — 33 references across 8
+files:
+
+| File                                | References |
+| ----------------------------------- | ---------: |
+| `src/rule-pack/loader.ts`           |         11 |
+| `src/cli/main.ts`                   |          8 |
+| `src/core/runner.ts`                |          6 |
+| `src/analysis/analyse.ts`           |          3 |
+| `src/rule-pack/provisional-pack.ts` |          2 |
+| `src/rule-pack/schema.ts`           |          1 |
+| `src/core/types.ts`                 |          1 |
+| `src/core/config.ts`                |          1 |
+
+Candidates for removal, each serving only the conformance path: `packPermitsConformanceClaim`,
+`verifiedAuthority`, `verifiedRuleStatus`, the `trustedRulePackIds` config key, and
+`metadata.authority` / `metadata.conformanceClaim` in the pack schema.
+
+**What is kept, and what each protects when working correctly:**
+
+- **`provisional` rule status and the `[provisional]` tag** — tells a reader a finding comes from an
+  authored heuristic rather than a standard. Honest, cheap, and independent of the conformance path.
+- **`sourceRef` per rule** — says where a rule is documented. With authority elevation gone this
+  becomes pure provenance, which is the same thing layered packs need per entry.
+- **`DISCLAIMER.md`'s trademark and non-implementation statements** — these describe what the package
+  is not, and remain true. Its "supplying authorised material" section describes the removed path and
+  would need reconciling.
+- **The disclaimer line in CLI output** — states plainly that the tool certifies nothing.
+
+This also shrinks the `sourceRef` defect (#66). Without an authority-elevation path there is no
+trusted-versus-untrusted distinction for a citation to cross; attributing a `sourceRef` to the pack
+that supplied it is then the same work as per-entry provenance, rather than a separate fix.
+
+## Superseded by project stage
+
+The maintainer has confirmed the repository is a prototype with no users. Two conclusions recorded
+above lose their supporting argument:
+
+- **The `rulePack` versus `rulePacks` decision.** The measured version-skew argument — a config
+  written for a newer linter silently losing its layer stack on an older one — requires users on old
+  versions. The weaker argument for widening the existing key (one key is less confusing than two)
+  is unaffected.
+- **`replace` mode.** It was specified to preserve the current substituting behaviour for configs
+  already in use. Without such configs to preserve, packs can always compose, which removes a config
+  mode, the "`replace` only at index 0" validation rule, and its test cases.
+
+Spec `03`'s back-compatibility analysis should be read with this in mind. Its blast-radius inventory,
+test strategy and staged rollout remain applicable; its back-compat reasoning does not.
 
 ## Related defects found while specifying
 

--- a/docs/design/64-layered-rule-packs/00-decisions.md
+++ b/docs/design/64-layered-rule-packs/00-decisions.md
@@ -11,7 +11,19 @@ would not design across each other:
 | [`03-migration-verification.md`](./03-migration-verification.md) | Blast radius, back-compatibility, test strategy, staged rollout                   |
 
 This file records what the three agree on, where two of them disagreed, and what remains for a human
-to decide. It supersedes nothing in the specs; they hold the detail and the citations.
+to decide. The specs hold the detail and the citations, and they are **not** rewritten to match this
+record — so where the two differ, this file wins. Four things it overturns, each still asserted
+unqualified in the spec that proposed it:
+
+| Overturned                                   | Still asserted in                       |
+| -------------------------------------------- | --------------------------------------- |
+| `rulePacks` as a new config key              | `01:178`, the config table, conflict C1 |
+| Composed output satisfies `RulePack` exactly | `01:14`, its opening premise            |
+| `replace` mode, and replace-only-at-index-0  | `01` (C2, C5, C6); depended on by `02`  |
+| Conformance claims are in scope              | most of `02`                            |
+
+Each spec carries a banner pointing here, so a reader who opens one directly is not led into an
+overturned design.
 
 ## Framing correction: this is a defect, not a feature
 
@@ -19,8 +31,11 @@ to decide. It supersedes nothing in the specs; they hold the detail and the cita
 vocabulary **"on top of the bundled provisional pack"**. `resolveRulePack` (`loader.ts:49-56`)
 substitutes instead — its three branches each return one pack, and none combines them.
 
-So the documented behaviour and the implemented behaviour already disagree. Layering closes that gap
-rather than adding something new. `03` found a second instance of the same drift: `README.md` is not
+So the documented behaviour and the implemented behaviour already disagree — with one qualifier that
+sentence conjoins two keys and only one of them layers today: `config.approvedTerms` really is spread
+together with `pack.approvedTechnicalTerms` at `analyse.ts:255`. `rulePack` is the half that
+substitutes. `03:477` states this precisely; the claim here is the same one, narrowed to the key it
+actually applies to. Layering closes that gap rather than adding something new. `03` found a second instance of the same drift: `README.md` is not
 alone, and the reconciliation list in that spec names the rest.
 
 ## Resolved: the two places the specs disagreed
@@ -111,16 +126,25 @@ larger change than the decision it settles.
 
 The authority machinery exists to guard one path: a supplied pack declaring `normative` authority and
 having that claim honoured after an operator names it in `trustedRulePackIds`. With conformance out
-of scope, that path has no destination. Surface measured at this commit — 33 references across 8
-files:
+of scope, that path has no destination. The surface is 35 references across 8 files, counted by this
+exact command so the number can be re-derived rather than trusted:
+
+```bash
+grep -vE '^\s*(//|\*|/\*)' <file> \
+  | grep -coE 'packPermitsConformanceClaim|verifiedAuthority|verifiedRuleStatus|trustedRulePackIds|conformanceClaim|metadata\.authority'
+```
+
+That is occurrences of the removal candidates, with comment-only lines excluded — a rule worth
+stating, because counting matching _lines_ instead, or leaving comments in, gives materially
+different totals, and the scope of the proposed removal is argued from this table.
 
 | File                                | References |
 | ----------------------------------- | ---------: |
-| `src/rule-pack/loader.ts`           |         11 |
-| `src/cli/main.ts`                   |          8 |
-| `src/core/runner.ts`                |          6 |
-| `src/analysis/analyse.ts`           |          3 |
-| `src/rule-pack/provisional-pack.ts` |          2 |
+| `src/cli/main.ts`                   |         11 |
+| `src/rule-pack/loader.ts`           |         10 |
+| `src/core/runner.ts`                |          5 |
+| `src/analysis/analyse.ts`           |          5 |
+| `src/rule-pack/provisional-pack.ts` |          1 |
 | `src/rule-pack/schema.ts`           |          1 |
 | `src/core/types.ts`                 |          1 |
 | `src/core/config.ts`                |          1 |
@@ -189,5 +213,7 @@ spec labelled something as its own proposal rather than an existing fact — `01
 "weakest authority wins", since `ruleStatusSchema` declares no ordering — that label is preserved.
 
 `03` recorded that it could not run the test suite (no `node_modules` in its worktree) and flagged
-"main is green at `9d78a8b`" as unconfirmed. The full suite was run separately at that commit:
-545 tests, all passing.
+"main is green at `9d78a8b`" as unconfirmed. Confirmed since, and the answer needs its commit
+naming: at `9d78a8b` the suite is green (545 tests). At `ebcc623` — the commit this branch was cut
+from, and a different tree — one corpus assertion was failing, pre-existing from #56 and fixed by
+#58. `03`'s Stage 0 precondition is therefore discharged only against a tree that has #58 in it.

--- a/docs/design/64-layered-rule-packs/01-merge-core.md
+++ b/docs/design/64-layered-rule-packs/01-merge-core.md
@@ -1,5 +1,11 @@
 # Layered rule packs — the composition core
 
+> **Read [`00-decisions.md`](./00-decisions.md) first.** This spec is one of three produced
+> independently, and the decision record overturns part of it: the new `rulePacks` config key is
+> replaced by widening the existing `rulePack`, `replace` mode is dropped, and the composed output
+> no longer has to satisfy `RulePack` exactly. Nothing below has been rewritten to match, on purpose
+> — the specs are the reasoning, `00` is the conclusion.
+
 Spec scope: the merge algorithm and the schema/config changes that support it.
 Out of scope (owned elsewhere): authority/trust, `trustedRulePackIds`, `verifiedAuthority`,
 per-entry provenance reporting, migration, fixtures, pack distribution. Seams are marked
@@ -119,7 +125,7 @@ Two call sites bind the result directly and neither has a channel for load-time 
 - `limits` → five consumers, each `options.X ?? pack.limits.X`:
   `structure-rules.ts:43`, `candidate-rules.ts:331`, `sentence-length.ts:28-30`.
 - `rules` → indexed by `ruleId` in `runDeterministicRules` (`src/core/runner.ts:51`), then used for
-  `enabled` (`:58`), options base (`:60-63`, a **shallow spread**:
+  `enabled` (`:59`), options base (`:62-65`, a **shallow spread**:
   `{...packSpec?.options, ...stripControlKeys(userConfig)}`), `severity` (`:78`), and
   `status`/`sourceRef` on emitted diagnostics (`:93-113`).
 - `dictionary.approved` → **no production reader at this commit.** A grep over `src/` for
@@ -223,10 +229,11 @@ export const steAiConfigSchema = z
   });
 ```
 
-Note the zod idiom in this file is v4-flavoured (`z.record(z.string(), …)`, `.prefault({})`,
-`ctx.addIssue({ code: 'custom' })` — see `config.ts:104,139-144`). `.superRefine` on the object means
-`SteAiConfig` stays `z.output<typeof steAiConfigSchema>` (`config.ts:147`) and `resolveConfig`
-(`config.ts:150-152`) is unchanged.
+Note the zod idiom in this file is v4-flavoured (`z.record(z.string(), …)`, `.prefault({})` — see
+`config.ts:104,139-144`). `.superRefine`, `.refine` and `ctx.addIssue` appear nowhere in `src/`
+today, so the block above introduces that idiom rather than following it. Putting it on the object
+keeps `SteAiConfig` as `z.output<typeof steAiConfigSchema>` (`config.ts:147`) and leaves
+`resolveConfig` (`config.ts:150-152`) unchanged.
 
 ### Normalisation to a canonical stack
 
@@ -285,7 +292,9 @@ say _only_ what it changes. So:
 // src/rule-pack/schema.ts
 
 /** Unchanged. The contract a base pack satisfies. Existing packs keep parsing. */
-export const rulePackSchema = z.object({/* …as today… */});
+export const rulePackSchema = z.object({
+  /* …as today… */
+});
 
 /** What an `extend` layer may be. Everything optional except metadata. */
 export const rulePackLayerContentSchema = z.object({
@@ -563,7 +572,7 @@ value is consumed directly by rules that iterate these arrays with no notion of 
 `vocabulary.ts:53-61` builds its working list straight from `pack.dictionary.unapproved`,
 `:164-172` from `pack.dictionary.preferred`, `:242` from `pack.contractions`. A sentinel is a _layer_
 operation smuggled into _pack data_; it would either have to survive into the composed pack (forcing
-every consumer to learn to skip it, and `RulePack` in `types.ts:428-441` to gain an optional flag
+every consumer to learn to skip it, and `RulePack` in `types.ts:428-440` to gain an optional flag
 that is meaningless post-composition) or be stripped, in which case it is a separate concept wearing
 an entry's clothes. Keeping it in its own field means **the composed pack contains only live
 entries** and `RulePack` is untouched. That is the decisive argument.
@@ -585,7 +594,7 @@ It is the wrong _layer mechanism_, for three verified reasons:
    pack and wants to retract an _org_ pack's entry would have to write into
    `rules["unapproved-vocabulary"].options.allow`, which — under the shallow `options` merge —
    **replaces** the org layer's `allow` array wholesale. Retraction would clobber allow-listing.
-   And `docs/rule-pack-import.md:159-162` explicitly warns against smuggling data through
+   And `docs/rule-pack-import.md:153-156` explicitly warns against smuggling data through
    `rules[].options`.
 3. **It cannot reach three of the seven fields.** There is no `allow` for
    `approvedTechnicalTerms`, for `dictionary.approved`, or for `limits`. A locale layer cannot
@@ -659,7 +668,7 @@ vocabulary compliance, so they do not catch this.
 
 **K4** differs from K3 only in that `alternatives[1..n]` (and `alternatives[0]` when
 `safeSubstitution` is false) are _advice_ — they reach the author as `suggestions`
-(`vocabulary.ts:96`) and as message text (`:86-89`), never as an applied edit. Bad advice is a defect
+(`vocabulary.ts:97`) and as message text (`:86-89`), never as an applied edit. Bad advice is a defect
 worth reporting; it does not make the pack unusable. `warning`, so textlint shows it.
 
 **K5** is a genuine, legitimate layering idiom: a product layer whose product is literally called
@@ -668,7 +677,7 @@ vocabulary matching runs against `sentence.masked` and a protected term is maske
 (`helpers.ts:18-23`, `protected-regions.ts:546-558`). Erroring would forbid the idiom. But the ban is
 now dead data, and dead bans are exactly what an audit needs to see. One subtlety the notice message
 must carry: technical-term protection is case-**sensitive** (`protected-regions.ts:552`, flags `gu`)
-while the ban is case-**insensitive** (`helpers.ts:11`, flags `giu`), so `approvedTechnicalTerms:
+while the ban is case-**insensitive** (`helpers.ts:10`, flags `giu`), so `approvedTechnicalTerms:
 ["Abort"]` shadows only `Abort`; lowercase `abort` in prose is still flagged. The shadowing is
 partial, and the notice should say so rather than claiming the ban is fully dead.
 

--- a/docs/design/64-layered-rule-packs/01-merge-core.md
+++ b/docs/design/64-layered-rule-packs/01-merge-core.md
@@ -11,7 +11,9 @@ Out of scope (owned elsewhere): authority/trust, `trustedRulePackIds`, `verified
 per-entry provenance reporting, migration, fixtures, pack distribution. Seams are marked
 **[AUTHORITY-SEAM]** and stop at the seam.
 
-All line citations are against commit `9d78a8b` (this worktree, detached HEAD).
+Line citations were written against commit `9d78a8b`, which turned out to be a sibling of this
+branch rather than an ancestor, and have since been re-checked against the branch with `main` merged
+in. Any that still name `9d78a8b` describe that commit, not this tree.
 
 ---
 
@@ -126,7 +128,7 @@ Two call sites bind the result directly and neither has a channel for load-time 
   `structure-rules.ts:43`, `candidate-rules.ts:331`, `sentence-length.ts:28-30`.
 - `rules` → indexed by `ruleId` in `runDeterministicRules` (`src/core/runner.ts:51`), then used for
   `enabled` (`:59`), options base (`:62-65`, a **shallow spread**:
-  `{...packSpec?.options, ...stripControlKeys(userConfig)}`), `severity` (`:78`), and
+  `{...packSpec?.options, ...stripControlKeys(userConfig)}`), `severity` (`:79`), and
   `status`/`sourceRef` on emitted diagnostics (`:93-113`).
 - `dictionary.approved` → **no production reader at this commit.** A grep over `src/` for
   `.approved` (excluding `approvedTerms`/`approvedTechnicalTerms`) returns nothing. The

--- a/docs/design/64-layered-rule-packs/01-merge-core.md
+++ b/docs/design/64-layered-rule-packs/01-merge-core.md
@@ -1,0 +1,876 @@
+# Layered rule packs — the composition core
+
+Spec scope: the merge algorithm and the schema/config changes that support it.
+Out of scope (owned elsewhere): authority/trust, `trustedRulePackIds`, `verifiedAuthority`,
+per-entry provenance reporting, migration, fixtures, pack distribution. Seams are marked
+**[AUTHORITY-SEAM]** and stop at the seam.
+
+All line citations are against commit `9d78a8b` (this worktree, detached HEAD).
+
+---
+
+## Summary
+
+Composition is a **left fold over an ordered layer list**, producing a value that satisfies the
+existing `RulePack` interface (`src/core/types.ts:474-486`) exactly. No rule, no evaluator and no
+consumer learns a new type. Concretely:
+
+1. Start from an implicit base: the bundled `provisionalRulePack`.
+2. If the first declared layer has `mode: "replace"`, it _becomes_ the base and the bundled pack is
+   discarded. `replace` is legal only at index 0.
+3. Every subsequent layer is applied with `mode: "extend"`: first its `retract` block removes keys
+   from the accumulator, then its own entries are upserted by key.
+4. The composed pack is checked for contradictions. Some throw, some emit `RunNotice`s, some are
+   silent by design.
+
+`rulePack: X` (singular) stays valid and is exactly `rulePacks: [{ source: X, mode: "replace" }]` —
+which is exactly today's behaviour, so the singular form is not merely tolerated, it is _defined by_
+the new algorithm.
+
+Two design constraints drive most of what follows, and both are verified rather than assumed:
+
+- **Composed array order is observable in output.** `unapprovedVocabularyRule` sorts entries by
+  `term.length` descending (`src/deterministic/rules/vocabulary.ts:64`) and then claims
+  non-overlapping ranges first-come-first-served (`vocabulary.ts:70-72`). `Array.prototype.sort` is
+  stable, so ties break by array position. Which of two equal-length terms wins an overlapping match
+  is therefore decided by composed array order. Determinism here is load-bearing, not cosmetic.
+- **The merge key must be the key the _matcher_ uses, per field, and the matchers disagree with each
+  other.** Vocabulary matching is case-insensitive and whitespace-collapsing
+  (`src/deterministic/helpers.ts:5-11`, flags `giu`, `\s+` normalisation). Technical-term protection
+  is case-**sensitive** with no whitespace normalisation (`src/core/protected-regions.ts:551-552`,
+  flags `gu`). Contractions are matched under both apostrophe forms
+  (`vocabulary.ts:248`, `variantsOf` at `vocabulary.ts:280-283`). One global normalisation function
+  would be wrong for at least one field.
+
+---
+
+## Current behaviour (verified)
+
+### Substitution, not composition
+
+`resolveRulePack` (`src/rule-pack/loader.ts:49-56`) is three branches, each returning exactly one
+pack:
+
+```ts
+if (spec === undefined) return provisionalRulePack; // loader.ts:53
+if (typeof spec === 'string') return loadRulePackFromFile(spec, baseDir); // loader.ts:54
+return parseRulePack(spec, 'inline configuration'); // loader.ts:55
+```
+
+Naming a project pack therefore discards the bundled pack whole. Measured contents of
+`provisionalRulePack` (obtained by importing `src/rule-pack/provisional-pack.ts` under `npx tsx`):
+
+| field                    | count |
+| ------------------------ | ----- |
+| `dictionary.unapproved`  | 61    |
+| `dictionary.approved`    | 6     |
+| `dictionary.preferred`   | 7     |
+| `contractions`           | 35    |
+| `approvedTechnicalTerms` | 0     |
+| `rules`                  | 14    |
+
+`limits` is `{proceduralMaxGradeLevel: 7, descriptiveMaxGradeLevel: 8,
+sentenceReadabilityFloorWords: 20, maxNounClusterLength: 3, maxSentencesPerProceduralStep: 1}`.
+`metadata.id` is `ste-ai-provisional`, `authority: "provisional"`, `conformanceClaim: "none"`.
+
+The rule count 14 is asserted by CI: `scripts/ci/check-rules-provisional.sh` passes the literal `14`
+to `scripts/ci/assert-rules-provisional.mjs`, which fails the build on a mismatch
+(`assert-rules-provisional.mjs:28-33`). That script counts _shipped rule code_ via `cli rules --json`,
+not pack entries, so composition does not by itself invalidate it — but any change that alters what
+`cli rules` prints must reconcile it.
+
+### Config today
+
+```ts
+rulePack: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),  // src/core/config.ts:124
+```
+
+Two call sites bind the result directly and neither has a channel for load-time diagnostics:
+
+- `src/analysis/analyse.ts:244` — `const pack = resolveRulePack(config.rulePack, options.baseDir ?? process.cwd());`
+- `src/evaluation/evaluate.ts:227` — `const pack = resolveRulePack(config.rulePack);`
+
+### Schema fields
+
+`rulePackSchema` (`src/rule-pack/schema.ts:93-104`) has exactly seven top-level keys:
+`metadata`, `limits`, `dictionary` (`{approved, unapproved, preferred}`), `contractions`,
+`approvedTechnicalTerms`, `rules`. Entry shapes:
+
+- `approvedTermSchema` — `{term, partsOfSpeech?, senses?}` (`schema.ts:33-37`)
+- `unapprovedTermSchema` — `{term, alternatives=[], note?, safeSubstitution=false, partOfSpeech?}`
+  (`schema.ts:39-49`). Note the brief omitted `partOfSpeech`; it exists.
+- `preferredTermSchema` — `{from, to, safeSubstitution=false, note?}` (`schema.ts:51-56`); used for
+  both `dictionary.preferred` and `contractions` (`schema.ts:99,101`).
+- `rulePackLimitsSchema` — five **required** numbers with bounds (`schema.ts:58-77`).
+- `rulePackRuleSpecSchema` — `{ruleId, status, sourceRef, enabled=true, severity?, options?}`
+  (`schema.ts:79-91`).
+
+### How pack data is consumed (this is what constrains merge semantics)
+
+- `dictionary.unapproved` → `vocabulary.ts:53-61`, concatenated with `options.additional`, filtered
+  by `options.allow` (lowercased set, `vocabulary.ts:51,61`), sorted longest-first (`:64`).
+  `safeSubstitution` gates whether a `TextFix` is attached at all (`:77-84`).
+- `dictionary.preferred` → `vocabulary.ts:164-173`, same shape of pipeline, `allow` keyed on `from`.
+- `contractions` → `vocabulary.ts:242`, `allow` keyed on `from`; apostrophe variants at `:248,280-283`.
+- `approvedTechnicalTerms` → merged into protected-region `approvedTerms` at `analyse.ts:255` and
+  `evaluate.ts:244`; matched case-sensitively (`protected-regions.ts:551-552`). Vocabulary matching
+  runs against `sentence.masked`, so a protected term can never be matched by a vocabulary rule
+  (`helpers.ts:18-23`).
+- `limits` → five consumers, each `options.X ?? pack.limits.X`:
+  `structure-rules.ts:43`, `candidate-rules.ts:331`, `sentence-length.ts:28-30`.
+- `rules` → indexed by `ruleId` in `runDeterministicRules` (`src/core/runner.ts:51`), then used for
+  `enabled` (`:58`), options base (`:60-63`, a **shallow spread**:
+  `{...packSpec?.options, ...stripControlKeys(userConfig)}`), `severity` (`:78`), and
+  `status`/`sourceRef` on emitted diagnostics (`:93-113`).
+- `dictionary.approved` → **no production reader at this commit.** A grep over `src/` for
+  `.approved` (excluding `approvedTerms`/`approvedTechnicalTerms`) returns nothing. The
+  `approved-word-sense` evaluator declares a `permittedSenses` payload key
+  (`src/semantic/evaluators.ts:28`) but the only construction of that key in the tree is
+  `test/unit/prompts.test.ts:37`; the candidate actually built by `vocabulary.ts:115-119` supplies
+  `word`, `approvedAlternatives`, `offsetInPassage` and no senses. So the merge rule for
+  `dictionary.approved` is currently unobservable in behaviour. Specified conservatively below and
+  flagged.
+
+### Run-level notices (the existing mechanism — do not invent a new one)
+
+`RunNotice` is `{code, level: 'info'|'warning'|'error', message, detail?}`
+(`src/core/types.ts:253-258`). Notices are accumulated per subsystem and concatenated into
+`AnalysisResult.notices` (`src/analysis/analyse.ts:314` and `:634`). Precedents worth copying:
+
+- `runner.ts:66-75` emits `rule-options-invalid` at `error` when a rule's options fail validation and
+  the rule is skipped — a _configuration_ defect surfaced as a notice, exactly the family my
+  conflict notices belong to.
+- `analysis/analyse.ts:515-518` (`withRunTotal`) replaces per-item notices with **one aggregate**
+  notice carrying a count. Copy this for high-cardinality merge events.
+
+Two delivery caveats, both verified:
+
+- The textlint adapter **drops `info`-level notices**: `if (notice.level === 'info') continue;`
+  (`src/textlint/adapter.ts:298-299`). Anything classified `info` is invisible to a textlint user.
+- The CLI prints every notice regardless of level (`src/cli/main.ts:246-249`), and the programmatic
+  API exposes them all on `AnalysisResult.notices`.
+
+So "info" here means "audit trail, not a nag" — and choosing it is a real decision about visibility,
+not a soft warning.
+
+---
+
+## Config schema changes
+
+### New pieces in `src/core/config.ts`
+
+```ts
+/** How a layer combines with everything declared before it. */
+export const rulePackModeSchema = z.enum(['extend', 'replace']);
+
+/** A pack reference: a path (resolved like today's `rulePack`) or an inline pack object. */
+export const rulePackSourceSchema = z.union([z.string(), z.record(z.string(), z.unknown())]);
+
+export const rulePackLayerSchema = z.object({
+  source: rulePackSourceSchema,
+  mode: rulePackModeSchema.default('extend'),
+});
+
+/** Shorthand: a bare source in the array means `{ source, mode: 'extend' }`. */
+export const rulePackLayerInputSchema = z.union([rulePackSourceSchema, rulePackLayerSchema]);
+```
+
+`steAiConfigSchema` (`src/core/config.ts:119-145`) gains one key and keeps the old one:
+
+```ts
+export const steAiConfigSchema = z
+  .object({
+    /**
+     * @deprecated Single-pack form. Exactly equivalent to
+     * `rulePacks: [{ source: <value>, mode: 'replace' }]` — it *replaces* the bundled pack.
+     */
+    rulePack: rulePackSourceSchema.optional(),
+
+    /**
+     * Ordered layer stack, lowest authority first. Each layer merges onto everything before it.
+     * The bundled provisional pack is an implicit layer 0 unless the first entry says
+     * `mode: 'replace'`.
+     */
+    rulePacks: z.array(rulePackLayerInputSchema).optional(),
+
+    // …unchanged keys…
+  })
+  .superRefine((cfg, ctx) => {
+    if (cfg.rulePack !== undefined && cfg.rulePacks !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['rulePacks'],
+        message:
+          'Set either "rulePack" or "rulePacks", not both. The singular form is equivalent to ' +
+          '`rulePacks: [{ "source": <your value>, "mode": "replace" }]`; put that entry first in ' +
+          '"rulePacks" and delete "rulePack".',
+      });
+    }
+    const layers = cfg.rulePacks ?? [];
+    layers.forEach((layer, index) => {
+      const mode = typeof layer === 'object' && 'mode' in layer ? layer.mode : 'extend';
+      if (mode === 'replace' && index > 0) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['rulePacks', index, 'mode'],
+          message:
+            `"replace" is only legal on the first layer. At index ${index} it would discard the ` +
+            `${index} layer(s) declared before it, making them dead configuration. To drop ` +
+            'individual entries from an earlier layer, use that layer\'s "retract" block.',
+        });
+      }
+    });
+  });
+```
+
+Note the zod idiom in this file is v4-flavoured (`z.record(z.string(), …)`, `.prefault({})`,
+`ctx.addIssue({ code: 'custom' })` — see `config.ts:104,139-144`). `.superRefine` on the object means
+`SteAiConfig` stays `z.output<typeof steAiConfigSchema>` (`config.ts:147`) and `resolveConfig`
+(`config.ts:150-152`) is unchanged.
+
+### Normalisation to a canonical stack
+
+Composition never sees the union types. `resolveConfig`'s consumer normalises once:
+
+```ts
+export interface NormalisedLayer {
+  readonly source: string | Record<string, unknown>;
+  readonly mode: 'extend' | 'replace';
+  /** 0-based position in the declared stack, after the implicit base. Used for notice `detail`. */
+  readonly index: number;
+}
+
+export function normaliseRulePackStack(cfg: SteAiConfig): readonly NormalisedLayer[] {
+  if (cfg.rulePack !== undefined) return [{ source: cfg.rulePack, mode: 'replace', index: 0 }];
+  return (cfg.rulePacks ?? []).map((entry, index) =>
+    typeof entry === 'object' && entry !== null && 'source' in entry
+      ? { source: entry.source, mode: entry.mode ?? 'extend', index }
+      : { source: entry as string | Record<string, unknown>, mode: 'extend' as const, index },
+  );
+}
+```
+
+Equivalences this fixes in place (all three must hold, and all three are today's behaviour):
+
+| config                    | composed result        | today's code path                              |
+| ------------------------- | ---------------------- | ---------------------------------------------- |
+| neither key               | bundled pack alone     | `loader.ts:53`                                 |
+| `rulePack: "./p.json"`    | `./p.json` alone       | `loader.ts:54`                                 |
+| `rulePack: {…}`           | that object alone      | `loader.ts:55`                                 |
+| `rulePacks: []`           | bundled pack alone     | new; allowed, silent                           |
+| `rulePacks: ["./p.json"]` | **bundled ∪ ./p.json** | new — _not_ the same as `rulePack: "./p.json"` |
+
+That last row is the one that will bite people. It is intentional: `extend` is the default because
+layering is the point, and `replace` must be spelled out because losing 61 unapproved entries and 35
+contractions should require typing the word.
+
+### Validation rules, complete list
+
+| #   | rule                                                           | outcome                                                                                       |
+| --- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| C1  | `rulePack` and `rulePacks` both set                            | zod error (config invalid)                                                                    |
+| C2  | `mode: "replace"` at index > 0                                 | zod error                                                                                     |
+| C3  | `rulePacks: []`                                                | valid; bundled pack alone                                                                     |
+| C4  | duplicate `source` string in the stack                         | valid; `info` notice `rule-pack-layer-repeated`                                               |
+| C5  | a layer's file cannot be read / is not JSON / fails its schema | `RulePackError` throw, as today (`loader.ts:26-41`), message names the layer index and source |
+| C6  | a `replace` layer fails full `rulePackSchema`                  | `RulePackError` — a replace layer becomes the base and must be complete (see below)           |
+
+### Two pack schemas, not one
+
+A `replace` layer becomes the base, so it must supply everything the base contract requires —
+notably all five `limits` (`schema.ts:58-77` has no defaults). An `extend` layer must be allowed to
+say _only_ what it changes. So:
+
+```ts
+// src/rule-pack/schema.ts
+
+/** Unchanged. The contract a base pack satisfies. Existing packs keep parsing. */
+export const rulePackSchema = z.object({/* …as today… */});
+
+/** What an `extend` layer may be. Everything optional except metadata. */
+export const rulePackLayerContentSchema = z.object({
+  metadata: rulePackMetadataSchema,
+  limits: rulePackLimitsSchema.partial().optional(),
+  dictionary: z
+    .object({
+      approved: z.array(approvedTermSchema).default([]),
+      unapproved: z.array(unapprovedTermSchema).default([]),
+      preferred: z.array(preferredTermSchema).default([]),
+    })
+    .prefault({}),
+  contractions: z.array(preferredTermSchema).default([]),
+  approvedTechnicalTerms: z.array(z.string()).default([]),
+  rules: z.array(rulePackRuleSpecSchema.partial().required({ ruleId: true })).default([]),
+  retract: retractionSchema.optional(), // §Retraction
+});
+```
+
+`metadata` stays required on a layer — a layer that cannot say who it is and under what licence has
+no business contributing normative-looking data, and the authority spec needs the per-layer record.
+
+`rules` entries become partial-except-`ruleId` for layers, because a locale layer that only wants to
+flip `enabled` should not have to restate `status` and `sourceRef` (which are the two fields the
+authority spec cares most about — restating them is precisely the escalation nobody wants).
+A `replace`/base layer still needs the full `rulePackRuleSpecSchema`.
+
+---
+
+## Per-field merge table
+
+Applied per layer, in this **fixed field order** (which also fixes notice emission order):
+`limits`, `dictionary.approved`, `dictionary.unapproved`, `dictionary.preferred`, `contractions`,
+`approvedTechnicalTerms`, `rules`, then `metadata` (synthesised last).
+
+Key normalisation functions — three of them, because the matchers differ:
+
+```ts
+/** Vocabulary key: mirrors termPattern (helpers.ts:5-11) — case-insensitive, whitespace-collapsing. */
+const vocabKey = (s: string): string => s.trim().toLowerCase().replace(/\s+/g, ' ');
+
+/** Contraction key: vocabKey plus the apostrophe fold the matcher already performs
+ *  (vocabulary.ts:280-283 maps U+0027 and U+2019 onto one entry). */
+const contractionKey = (s: string): string => vocabKey(s).replace(/’/g, "'");
+
+/** Technical-term key: the exact string. protected-regions.ts:551-552 matches case-sensitively
+ *  with no whitespace normalisation, so "Abort" and "abort" are genuinely different entries. */
+const technicalKey = (s: string): string => s;
+```
+
+Deliberately **not** applying `String.prototype.normalize('NFC')`: `termPattern`
+(`helpers.ts:5-11`) does not normalise either, so an NFC merge key would fuse two entries the
+matcher treats as distinct — a silently-lost ban. Recorded as an open question, not fixed here.
+
+| field                    | merge key                                                                | merge rule                                      | collision behaviour                                                                                 | notice                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `metadata`               | —                                                                        | not merged; **synthesised** from the layer list | n/a                                                                                                 | — **[AUTHORITY-SEAM]**                                                                                        |
+| `limits`                 | field name                                                               | **per-key last-wins** over the five scalars     | later layer's value applies                                                                         | `rule-pack-limit-overridden`, `info` if the new value is stricter-or-equal, `warning` if it loosens (§limits) |
+| `dictionary.approved`    | `vocabKey(term)`                                                         | keyed upsert, **whole-entry replace**           | later entry replaces earlier entirely (including dropping `senses`/`partsOfSpeech` the earlier had) | counted into the aggregate override notice                                                                    |
+| `dictionary.unapproved`  | `vocabKey(term)`                                                         | keyed upsert, **whole-entry replace**           | later entry replaces earlier entirely                                                               | aggregate override notice; plus `rule-pack-fix-safety-escalated` if `safeSubstitution` goes false→true        |
+| `dictionary.preferred`   | `vocabKey(from)`                                                         | keyed upsert, **whole-entry replace**           | later entry replaces earlier entirely                                                               | as above                                                                                                      |
+| `contractions`           | `contractionKey(from)`                                                   | keyed upsert, **whole-entry replace**           | later entry replaces earlier entirely                                                               | as above                                                                                                      |
+| `approvedTechnicalTerms` | `technicalKey(s)` (exact)                                                | **set union**, first-insertion order preserved  | duplicate is a no-op                                                                                | none                                                                                                          |
+| `rules`                  | `ruleId` (exact; ids are code-owned, `runner.ts:51` keys on the literal) | keyed upsert, **field-by-field merge**          | see below                                                                                           | aggregate override notice; `status` change is **[AUTHORITY-SEAM]**                                            |
+
+### Why whole-entry replace for the four term lists
+
+The alternative — field-by-field merge, so a layer could set `safeSubstitution: true` while
+inheriting `alternatives` — reads attractive and is wrong here. `alternatives`, `safeSubstitution`
+and `note` are one semantic unit: `safeSubstitution` is a claim _about `alternatives[0]`_
+specifically (`schema.ts:43-47`, and the fix is built from `alternatives[0]` at
+`vocabulary.ts:76-84`). Letting one layer supply the alternatives and another supply the safety
+claim produces an autofix nobody authored. Whole-entry replace means the layer that asserts
+`safeSubstitution: true` is the layer that also wrote the alternative it is vouching for. The cost
+is verbosity — a layer that only wants to add a `note` must restate the entry — and that is the
+correct trade for a field that authorises source mutation.
+
+`dictionary.approved` follows the same rule for consistency, but see the caveat: nothing reads it
+today, so the choice is currently unobservable and cheap to revisit.
+
+### `rules`: field-by-field, with `options` shallow
+
+```ts
+function mergeRuleSpec(base: RulePackRuleSpec, layer: Partial<RulePackRuleSpec>): RulePackRuleSpec {
+  return {
+    ...base,
+    ...definedOnly(layer), // ruleId/status/sourceRef/enabled/severity
+    ...(layer.options === undefined ? {} : { options: { ...base.options, ...layer.options } }), // SHALLOW, one level
+  };
+}
+```
+
+Field-by-field rather than whole-spec replace, because a layer partial-by-schema (above) that only
+sets `enabled: false` would otherwise wipe `status` and `sourceRef` — and `sourceRef` is what a
+diagnostic prints (`runner.ts:110`). Whole-spec replace would make "turn this rule off for our
+locale" silently erase the rule's citation.
+
+`options` is shallow-merged, one level, **because that is what the runtime already does**:
+`runner.ts:60-63` composes `{...packSpec?.options, ...stripControlKeys(userConfig)}` — a shallow
+spread — and `docs/configuration.md:150-159` documents the user-facing precedence as "merged key by
+key". A deep merge in composition would give pack layers a different combining rule than the one the
+config layer immediately above them uses, for the same object. Two different merge depths on one
+value is a bug generator. Concretely, with shallow merge a layer that sets
+`{"unapproved-vocabulary": {"allow": ["x"]}}` **replaces** the array rather than appending to it —
+correct, since array-append semantics are unrepresentable in the schema (`options` is
+`z.record(z.string(), z.unknown())`, `schema.ts:90`) and would require guessing per key.
+
+Because `options` is `unknown`-valued, composition performs no validation of it. Invalid options
+still surface exactly as today: at rule-run time, as a `rule-options-invalid` error notice
+(`runner.ts:66-75`).
+
+### Metadata of the composed pack
+
+The composed value must satisfy `RulePackMetadata` (`types.ts:412-425`), so _something_ has to be
+produced. The merge core produces this much and no more:
+
+```ts
+export interface LayerDescriptor {
+  readonly index: number; // 0 = base
+  readonly mode: 'extend' | 'replace';
+  readonly origin: string; // resolved path, or 'inline configuration'
+  readonly metadata: RulePackMetadata; // verbatim, as declared by that layer
+}
+
+export interface RulePackComposition {
+  readonly pack: RulePack; // satisfies the existing interface exactly
+  readonly layers: readonly LayerDescriptor[]; // ordered, base first
+  readonly notices: readonly RunNotice[];
+  readonly provenance: EntryProvenance; // see §Seams
+}
+```
+
+Core-owned defaults for `pack.metadata`, deliberately conservative and explicitly provisional until
+the authority spec lands:
+
+- `id`: `"composed:" + layers.map(l => l.metadata.id).join("+")` — deterministic, and it never
+  collides with a single pack's own id, so it can never accidentally match a `trustedRulePackIds`
+  entry.
+- `name`, `version`, `licence`, `source`, `retrievedAt`, `notice`: taken from the **last** layer.
+  This is a placeholder, and a poor one for `licence` in particular — a composed pack that mixes an
+  MIT bundled pack with a share-alike org pack has no single correct licence string.
+  **[AUTHORITY-SEAM]** — the licence/notice composition question belongs to the authority spec;
+  `layers[]` gives it everything it needs.
+- `authority`, `conformanceClaim`: **[AUTHORITY-SEAM]**. The core sets `authority` to the weakest
+  value present across layers and `conformanceClaim: 'none'` if any layer says `none`, purely so
+  that a half-implemented stack cannot _gain_ authority by being composed. Note the code declares no
+  ordering over `ruleStatusSchema` (`schema.ts:14` is a bare enum); "weakest" is my proposal, not an
+  existing fact, and the authority spec should either ratify it or replace it.
+
+---
+
+## `limits` policy
+
+**Recommendation: per-key last-wins, plus partial `limits` on `extend` layers, plus an override
+notice whose level depends on direction.**
+
+### Why not "most restrictive wins"
+
+All five limits are monotone in the same direction — lower is stricter. `proceduralMaxGradeLevel`,
+`descriptiveMaxGradeLevel`, `maxNounClusterLength` and `maxSentencesPerProceduralStep` are ceilings
+(`sentence-length.ts:28-29`, `candidate-rules.ts:331`, `structure-rules.ts:43`), and
+`sentenceReadabilityFloorWords` is a floor below which the check is skipped entirely
+(`sentence-length.ts:30`, and `schema.ts:68-73` explains why), so a _lower_ floor means _more_
+sentences are checked. So `min()` is well-defined. It is still wrong, for a decisive structural
+reason:
+
+`limits` is **required** in `rulePackSchema` (`schema.ts:58-77` — five required numbers, no
+defaults). Under `min()`, the bundled pack's values become a permanent ceiling that no organisation
+can ever raise, because the bundled pack is always layer 0 unless replaced. `proceduralMaxGradeLevel`
+would be pinned at 7 forever. That does not restrain a rogue product layer; it makes the org layer
+impotent. The only escape would be `mode: "replace"` — which throws away the 61 unapproved entries
+and 35 contractions, i.e. exactly the problem this design exists to solve. "Most restrictive wins"
+would push every organisation back onto `replace`.
+
+Second, `min()` and required-`limits` interact badly even in the honest case: a locale layer that
+only wants to change `maxNounClusterLength` must declare all five, and any of the other four it
+writes "wrong" (looser) is silently discarded. Silent discard of authored configuration is worse
+than a visible override.
+
+### What the recommendation costs
+
+1. **A product layer can loosen an org limit, and nothing structurally prevents it.** That is real.
+   The mitigations are (a) the override notice, (b) the declaration order requirement — the org layer
+   must be listed before the product layer, so the loosening is at least _visible_ in one config
+   file, and (c) a future `lockedLimits` / policy mechanism, which I am explicitly **not** speccing:
+   "which layer may override which" is an authority question, not a merge question.
+2. **The `info`-level override notice is invisible in textlint.** Per `adapter.ts:298-299`, `info`
+   notices are dropped. An operator running textlint sees nothing; only `ste-ai` CLI users
+   (`cli/main.ts:246-249`) and programmatic callers see it. This is why the notice level is
+   direction-dependent rather than uniformly `info`:
+
+```ts
+const STRICTER_IS_LOWER = [
+  'proceduralMaxGradeLevel',
+  'descriptiveMaxGradeLevel',
+  'sentenceReadabilityFloorWords',
+  'maxNounClusterLength',
+  'maxSentencesPerProceduralStep',
+] as const;
+
+// level = 'warning' when next > prev (looser), 'info' when next <= prev (stricter or equal)
+```
+
+A locale layer that tightens limits every run does not nag. A layer that loosens one produces a
+`warning` notice, which the textlint adapter _does_ surface, at document position 0
+(`adapter.ts:300-305`). That is the cheapest honest answer to "a product layer can loosen an org
+limit": it cannot do it quietly.
+
+3. **`limits.partial()` on layers is a schema divergence** — two pack schemas to keep in step
+   (§"Two pack schemas"). Accepted: the alternative is forcing every layer to restate five numbers,
+   which reintroduces problem 2 above.
+
+---
+
+## Retraction design
+
+### Requirement
+
+A lower layer must be able to un-ban a term an upper layer banned. Union cannot express removal.
+
+### Decision: a new top-level `retract` field on layer packs, keyed by merge key
+
+```ts
+export const retractionSchema = z.object({
+  dictionary: z
+    .object({
+      approved: z.array(z.string()).default([]),
+      unapproved: z.array(z.string()).default([]),
+      preferred: z.array(z.string()).default([]), // keyed on `from`
+    })
+    .prefault({}),
+  contractions: z.array(z.string()).default([]), // keyed on `from`
+  approvedTechnicalTerms: z.array(z.string()).default([]),
+  rules: z.array(z.string()).default([]), // keyed on ruleId
+});
+```
+
+```jsonc
+// ./locale-en-gb.json
+{
+  "metadata": { "id": "acme-locale-en-gb", "…": "…" },
+  "retract": {
+    "dictionary": { "unapproved": ["whilst"] },
+    "contractions": ["don't"],
+  },
+  "dictionary": { "unapproved": [{ "term": "whilst", "alternatives": ["while"], "note": "…" }] },
+}
+```
+
+Values are **merge keys**, normalised by the same per-field function as the merge itself
+(`vocabKey` / `contractionKey` / `technicalKey` / exact `ruleId`). A retraction that names a key not
+present in the accumulator is a no-op and emits `rule-pack-retraction-inert` at `warning` — inert
+retractions are almost always a typo or a layer that got reordered, and the failure mode (a ban you
+thought you removed is still live) is silent otherwise, which is exactly the "silence means
+compliance" failure `docs/diagnostic-policy.md` exists to prevent. `warning`, not `info`,
+specifically so the textlint adapter surfaces it.
+
+### Ordering within a layer: retract first, then upsert
+
+A layer's `retract` block applies to the accumulator **before** that layer's own entries are
+upserted. Consequences, both wanted:
+
+- `retract` + re-add of the same key is a well-defined "redefine from scratch" idiom (the example
+  above): the old entry's `alternatives`, `note` and `safeSubstitution` are gone, not inherited.
+  Without the ordering rule, whole-entry replace would already achieve this, but the explicit retract
+  documents the intent and makes the `rule-pack-entry-overridden` accounting honest.
+- A layer can never erase its own additions.
+- Layer application is idempotent: applying the same layer twice in a row yields the same
+  accumulator.
+
+### Rejected: sentinel values in the existing arrays
+
+E.g. `{"term": "whilst", "retracted": true}` or `alternatives: null`. Rejected because the composed
+value is consumed directly by rules that iterate these arrays with no notion of a non-entry:
+`vocabulary.ts:53-61` builds its working list straight from `pack.dictionary.unapproved`,
+`:164-172` from `pack.dictionary.preferred`, `:242` from `pack.contractions`. A sentinel is a _layer_
+operation smuggled into _pack data_; it would either have to survive into the composed pack (forcing
+every consumer to learn to skip it, and `RulePack` in `types.ts:428-441` to gain an optional flag
+that is meaningless post-composition) or be stripped, in which case it is a separate concept wearing
+an entry's clothes. Keeping it in its own field means **the composed pack contains only live
+entries** and `RulePack` is untouched. That is the decisive argument.
+
+### Rejected as the mechanism: reuse `options.allow`
+
+The precedent is real — `unapprovedVocabularyRule` filters pack entries against `options.allow`
+(`vocabulary.ts:20,51,61`), and `preferredTerminologyRule` (`:140,163,172`) and `noContractionsRule`
+(`:219,241-242`) each have their own. It is the right _escape hatch_ and it stays exactly as it is.
+It is the wrong _layer mechanism_, for three verified reasons:
+
+1. **It is per-rule, not per-layer.** Each of the three rules has a separate `allow` array
+   (`vocabulary.ts:20`, `:140`, `:219`). Un-banning `don't` requires an `allow` on `no-contractions`;
+   un-banning `whilst` requires a different `allow` on `unapproved-vocabulary`. A locale team would
+   have to know which rule owns which word list.
+2. **It is configuration, not pack data.** `allow` reaches a rule through
+   `{...packSpec?.options, ...stripControlKeys(userConfig)}` (`runner.ts:60-63`) — it lives in the
+   operator's `.ste-ai.json` or in the pack's own `rules[].options`. A locale layer that ships as a
+   pack and wants to retract an _org_ pack's entry would have to write into
+   `rules["unapproved-vocabulary"].options.allow`, which — under the shallow `options` merge —
+   **replaces** the org layer's `allow` array wholesale. Retraction would clobber allow-listing.
+   And `docs/rule-pack-import.md:159-162` explicitly warns against smuggling data through
+   `rules[].options`.
+3. **It cannot reach three of the seven fields.** There is no `allow` for
+   `approvedTechnicalTerms`, for `dictionary.approved`, or for `limits`. A locale layer cannot
+   un-protect a technical term through it at all.
+
+The two compose cleanly and in a fixed order: `retract` runs at **composition** time, `allow` runs at
+**rule-run** time (`vocabulary.ts:61`), over whatever composition produced. A term retracted by a
+layer is simply absent when `allow` is applied; an `allow` naming an already-retracted term is inert
+and — note — produces no notice today, and this spec does not add one (that would be a change to
+rule behaviour, outside the composition core).
+
+---
+
+## Conflict detection and classification
+
+Detection runs **once, on the composed pack**, after the fold. Running it on the composed value
+rather than pairwise between layers means (a) a conflict introduced and then repaired by a later
+layer is correctly not reported, and (b) the check also covers single-layer configs — including the
+bundled pack and today's `rulePack: X` path.
+
+I verified the bundled `provisionalRulePack` is clean against every check below (script run under
+`npx tsx` against `src/rule-pack/provisional-pack.ts`: zero cycles, zero `preferred.to` that is
+unapproved, zero unapproved-alternatives that are themselves unapproved, zero technical-term shadows,
+zero terms both approved and unapproved). So adding these checks does not break the default path.
+An imported pack that is already deployed _could_ newly fail a hard check — that is a migration
+question and belongs to the migration spec, but the merge core should flag it as a known blast
+radius.
+
+### The detectable field pairs
+
+| #   | code                                       | what is detected                                                                                                                                                                                                      | classification                                  |
+| --- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| K1  | `rule-pack-rewrite-cycle`                  | a cycle in the directed graph over `vocabKey`, edges `from → to` drawn from `dictionary.preferred` ∪ `contractions` (both are `PreferredTermEntry`, `types.ts:442-447`). Includes the 2-cycle `job→task`, `task→job`. | **hard error** (`RulePackError`)                |
+| K2  | `rule-pack-prescribes-banned-term`         | `vocabKey(entry.to) ∈ keys(dictionary.unapproved)` for any `preferred` or `contractions` entry                                                                                                                        | **hard error**                                  |
+| K3  | `rule-pack-unsafe-alternative`             | an `unapproved` entry with `safeSubstitution: true` whose `alternatives[0]` is itself an unapproved key                                                                                                               | **hard error**                                  |
+| K4  | `rule-pack-advisory-alternative-banned`    | an `unapproved` entry with `safeSubstitution: false` any of whose `alternatives` is an unapproved key                                                                                                                 | run-level notice, `warning`                     |
+| K5  | `rule-pack-ban-shadowed-by-protected-term` | a `dictionary.unapproved` key equals `vocabKey(t)` for some `t ∈ approvedTechnicalTerms`                                                                                                                              | run-level notice, `warning`                     |
+| K6  | `rule-pack-term-approved-and-unapproved`   | the same `vocabKey` appears in `dictionary.approved` and `dictionary.unapproved`                                                                                                                                      | run-level notice, `info` (see caveat)           |
+| K7  | `rule-pack-fix-safety-escalated`           | an upsert changed `safeSubstitution` from `false` to `true` for an existing key                                                                                                                                       | run-level notice, `warning`                     |
+| K8  | `rule-pack-limit-overridden`               | a later layer changed a `limits` value                                                                                                                                                                                | notice, `info`/`warning` by direction (§limits) |
+| K9  | `rule-pack-entries-overridden`             | aggregate count of keyed upserts that replaced an existing key, across `dictionary.*`, `contractions`, `rules`                                                                                                        | one aggregate notice, `info`                    |
+| K10 | `rule-pack-layer-repeated`                 | the same string `source` appears twice in the stack                                                                                                                                                                   | notice, `info`                                  |
+| K11 | `rule-pack-retraction-inert`               | a `retract` key not present in the accumulator                                                                                                                                                                        | notice, `warning`                               |
+| —   | `rules[].status` raised by a later layer   | recorded in `provenance`, not classified here                                                                                                                                                                         | **[AUTHORITY-SEAM]**                            |
+
+### Why K1–K3 are hard errors
+
+**K1 (cycle).** This is not aesthetics. `preferredTerminologyRule` rewrites every match of `from`
+into `to` (`vocabulary.ts:179-198`) and attaches a `TextFix` whenever `safeSubstitution` is set
+(`:184-191`). With `job→task` and `task→job` both live, the entries are sorted by `from.length`
+descending (`:173`) and the first to claim a range wins (`:180-182`), so the run flags one direction;
+applying the fix produces text the _other_ entry flags on the next run. `--fix` never converges. No
+run-time policy can make that sane, and there is no defensible "last wins" — the two layers are
+asserting incompatible house styles and a human has to choose. The failure must land on whoever
+assembled the stack, at load time, with both layer origins named.
+
+**K2 (prescribes a banned term).** The merged pack instructs the author, in a diagnostic message
+(`vocabulary.ts:195`: `Use "X" instead of "Y"`), to write a word the same pack bans and will flag on
+the next pass. The document cannot be made compliant by following the tool's own advice. Loading is
+the right place to refuse.
+
+**K3 (unsafe alternative under `safeSubstitution`).** `safeSubstitution: true` authorises an
+automatic source rewrite (`vocabulary.ts:77-84`). If `alternatives[0]` is itself banned, the
+autofixer edits the file into a fresh violation. The schema's own comment
+(`schema.ts:43-47`) says the flag means substitution "cannot change technical meaning" — a
+substitution that introduces a violation has already broken that contract. Note the autofix gates
+still run afterwards (`docs/rule-pack-import.md:142-146`), but they check meaning-preservation, not
+vocabulary compliance, so they do not catch this.
+
+### Why K4–K7 are notices rather than errors
+
+**K4** differs from K3 only in that `alternatives[1..n]` (and `alternatives[0]` when
+`safeSubstitution` is false) are _advice_ — they reach the author as `suggestions`
+(`vocabulary.ts:96`) and as message text (`:86-89`), never as an applied edit. Bad advice is a defect
+worth reporting; it does not make the pack unusable. `warning`, so textlint shows it.
+
+**K5** is a genuine, legitimate layering idiom: a product layer whose product is literally called
+`Abort` adds it to `approvedTechnicalTerms`, and the org's ban on `abort` then does nothing, because
+vocabulary matching runs against `sentence.masked` and a protected term is masked out
+(`helpers.ts:18-23`, `protected-regions.ts:546-558`). Erroring would forbid the idiom. But the ban is
+now dead data, and dead bans are exactly what an audit needs to see. One subtlety the notice message
+must carry: technical-term protection is case-**sensitive** (`protected-regions.ts:552`, flags `gu`)
+while the ban is case-**insensitive** (`helpers.ts:11`, flags `giu`), so `approvedTechnicalTerms:
+["Abort"]` shadows only `Abort`; lowercase `abort` in prose is still flagged. The shadowing is
+partial, and the notice should say so rather than claiming the ban is fully dead.
+
+**K6** is `info` and flagged as uncertain: `dictionary.approved` has **no production reader at this
+commit** (see Current behaviour), so a term being in both lists has no observable effect today. If
+and when the `approved-word-sense` evaluator is wired to `permittedSenses`, this should be
+re-classified — plausibly to `warning` or to a hard error, because at that point the pack would be
+telling the adjudicator that a banned word has permitted senses. Recording it now, at `info`, keeps
+the audit trail without asserting a consequence I cannot demonstrate.
+
+**K7** — a lower layer raising `safeSubstitution` to `true` is a legitimate thing for a team with
+narrower domain knowledge to do ("in our product, `abort → stop` really is safe"). It is also the
+single highest-consequence thing a layer can do, because it converts a report into a file edit. It
+must never be silent. `warning`, so it survives the textlint adapter's `info` filter.
+
+### Why K8–K11 are the low tier
+
+These are the ordinary mechanics of layering. K9 in particular is high-cardinality: a product pack
+overriding 200 org entries would emit 200 notices, which is noise, not signal. It follows the
+`withRunTotal` precedent (`analysis/analyse.ts:515-518`) — one notice, counts in `detail`:
+
+```ts
+{
+  code: 'rule-pack-entries-overridden',
+  level: 'info',
+  message: '3 layers composed; 214 entries overridden by a later layer.',
+  detail: { layers: 3, unapproved: 180, preferred: 12, contractions: 0, approved: 2, rules: 20 },
+}
+```
+
+`RunNotice.detail` is `Record<string, string | number | boolean>` (`types.ts:257`), so counts fit
+without a type change.
+
+### Delivery: composition needs a notice channel it does not have
+
+`resolveRulePack` returns a bare `RulePack` (`loader.ts:49-52`) and both callers bind it directly
+(`analyse.ts:244`, `evaluate.ts:227`). Notices produced during composition currently have nowhere to
+go. Minimal change:
+
+```ts
+// src/rule-pack/loader.ts
+export function composeRulePacks(
+  layers: readonly NormalisedLayer[],
+  baseDir = process.cwd(),
+): RulePackComposition;
+
+/** Retained. Same signature, same behaviour, notices discarded. */
+export function resolveRulePack(
+  spec: string | Record<string, unknown> | undefined,
+  baseDir = process.cwd(),
+): RulePack;
+```
+
+`prepareRun` (`analyse.ts:243-277`) calls `composeRulePacks` and threads `composition.notices` into
+the notice list it already assembles at `analyse.ts:314` and `:634`. `evaluate.ts:227` can keep using
+`resolveRulePack` — the evaluation harness has no notice sink — but it then silently drops merge
+notices, which is acceptable for a measurement harness and should be stated in a comment rather than
+left implicit.
+
+Hard errors keep using the existing `RulePackError` (`loader.ts:7-12`), with the layer index and
+resolved origin in the message, matching the existing style of `loader.ts:21,32,38`.
+
+---
+
+## Order and determinism
+
+### Declaration order, not semantic order
+
+Layers apply strictly left-to-right in declaration order. The conceptual stack
+(bundled → organisation → department → product → tech stack → industry → locale) is a _convention
+the operator expresses by ordering the array_, not something the code infers.
+
+Reason: nothing in the pack schema names a tier. `rulePackMetadataSchema` (`schema.ts:17-31`) has
+`id`, `name`, `version`, `authority`, `licence`, `source`, `retrievedAt`, `conformanceClaim`,
+`notice` — none of which identifies a layer's position in an organisational hierarchy. Sorting by
+`authority` would conflate "how normative is this" with "how specific is this", which are orthogonal
+(a locale layer is the most specific and the least normative). Inferring a tier from `metadata.id`
+would be string-guessing. Declaration order is the only ordering the configuration actually carries,
+so it is the ordering used.
+
+If a `tier` field is added later (an authority-spec question), it should be _validated against_
+declaration order — "your layers are declared out of tier order" — rather than replacing it. Keeping
+apply-order and declared-order identical is what makes a config file readable as the thing it does.
+
+### Determinism requirements
+
+1. **The fold is over an array, and every accumulator is order-preserving.** Keyed upserts use a
+   `Map` keyed by the normalised merge key. `Map` preserves insertion order, so the emitted array
+   order is: order of _first_ insertion per key. An upsert **replaces the value in place and does not
+   move the key to the end.** This is required, not incidental — see the `sort`-stability argument in
+   the Summary: composed array position decides which of two equal-length terms claims an
+   overlapping match (`vocabulary.ts:64,70-72`). Re-ordering on override would change diagnostics
+   without changing any pack's content.
+2. **Same config + same pack bytes ⇒ byte-identical composed pack.** This mirrors the guarantee the
+   rule runner already states for itself: "rules run in registry order and diagnostics are finally
+   sorted by (start, end, ruleId). Two runs over the same input therefore produce byte-identical
+   output" (`runner.ts:279-282`). Composition must not weaken it, because the pack is an input to
+   that run.
+3. **Notice order is fixed**, by construction rather than by a sort: layers are visited in order,
+   fields within a layer in the fixed order given in the merge table, keys within a field in the
+   layer's own declared array order. Aggregate notices (K9) are emitted last, after the fold.
+   Conflict-detection notices (K1–K6) are emitted after those, in the table's numeric order, and
+   within a code, sorted by merge key with `localeCompare` — matching the tie-break style already
+   used for diagnostics (`runner.ts:126-128`, `analyse.ts:307-311`).
+4. **No load-graph, therefore no cycle risk.** A pack file cannot reference another pack: the schema
+   (`schema.ts:93-104`) has no include/extends field, and this spec does not add one. Every layer is
+   loaded independently from its declared `source`. Relative paths resolve as today, against
+   `baseDir` (`loader.ts:26-27`), which for the programmatic API is `options.baseDir ?? process.cwd()`
+   (`analyse.ts:244`).
+5. **No filesystem-order or environment dependence.** Layers are read in declared order; nothing
+   globs, nothing scans a directory, nothing consults the environment.
+6. **Layer application is idempotent.** Applying the same layer twice consecutively yields the same
+   accumulator (retract-then-upsert, whole-entry replace, set union and last-wins are all
+   idempotent). This is what makes K10 (`rule-pack-layer-repeated`) a notice rather than an error:
+   the duplicate is harmless, just probably a mistake.
+
+---
+
+## Open questions and recommendations
+
+1. **Unicode normalisation of merge keys.** Recommended: none, matching `termPattern`
+   (`helpers.ts:5-11`), which does not normalise. This means `café` composed as NFC and `café`
+   composed as NFD are two entries — and _also_ two entries as far as the matcher is concerned, so
+   the merge is at least consistent with the matcher. Fixing this properly means fixing
+   `termPattern` first, which is a rule-behaviour change outside this spec. Flagged, not fixed.
+2. **`dictionary.approved` merge semantics are currently unobservable.** No production reader exists
+   at this commit (grep over `src/`; `permittedSenses` is declared at `semantic/evaluators.ts:28` and
+   constructed only in `test/unit/prompts.test.ts:37`). Whole-entry replace is specified for
+   consistency, and K6 is `info` for the same reason. Both should be revisited when the sense
+   inventory is wired up.
+3. **`limits` loosening has no structural guard.** By recommendation, only a direction-sensitive
+   notice. A `lockedLimits` or per-layer permission mechanism is the obvious next step and is an
+   authority question, not a merge question — deliberately not specced here.
+4. **Deployed single packs could newly fail K1–K3.** The checks run on the composed pack regardless
+   of layer count, so a pack that has always contained a rewrite cycle would start throwing. The
+   bundled pack is verified clean; third-party packs are not knowable from here. Recommend the
+   migration spec decide whether K1–K3 are errors from day one or errors-after-a-deprecation-window.
+5. **`rules[].options` array semantics.** Shallow merge means a layer setting `allow: [...]` replaces
+   rather than appends. Recommended, because append-vs-replace cannot be expressed in
+   `z.record(z.string(), z.unknown())` (`schema.ts:90`) without a per-key policy, and because it
+   matches `runner.ts:60-63`. If append is later wanted, it should be an explicit key convention in
+   the retraction/merge vocabulary, not a guess made by the merger.
+6. **Should K6 and K9 be `info` given `adapter.ts:298-299` drops them?** Recommended yes: they are
+   audit-trail entries and are fully available via the CLI (`cli/main.ts:246-249`) and
+   `AnalysisResult.notices`. But note this makes textlint a strictly lower-fidelity surface for merge
+   diagnostics than the CLI. If that is unacceptable, the fix is a config knob on
+   `diagnosticPolicySchema` (`config.ts:6-34`) rather than inflating every notice to `warning`.
+7. **`evaluate.ts:227` drops merge notices.** Recommended: leave it, with a comment. Alternative is
+   plumbing a notice sink through the evaluation harness for no measurement benefit.
+
+---
+
+## Seams with the authority spec
+
+The merge core hands the authority spec structured data and makes no trust decisions. Four seams:
+
+1. **`RulePackComposition.layers`** (`LayerDescriptor[]`, defined above) — ordered, base first, each
+   carrying that layer's verbatim `metadata`, its `mode`, and its resolved `origin`. Today
+   `verifiedAuthority` and `packPermitsConformanceClaim` (`loader.ts:76-98`) ask one question of one
+   pack: "is `pack.metadata.id` in `trustedRulePackIds`?" With N layers that becomes N questions with
+   an aggregation rule. `layers[]` is the input to whatever aggregation the authority spec chooses;
+   the core does not choose it.
+
+2. **`pack.metadata` of the composed pack** — the core's defaults (`id` = `composed:a+b+c`,
+   last-layer for the descriptive fields, weakest-authority, `conformanceClaim: 'none'` if any layer
+   says `none`) are placeholders chosen so that composition can never _gain_ authority. The
+   `composed:` id prefix specifically guarantees a composed pack's id cannot accidentally match a
+   `trustedRulePackIds` entry. `licence` in particular has no correct single value when layers differ
+   and needs an authority answer.
+
+3. **`rules[].status` and `sourceRef` across layers.** Field-by-field merge means a later layer can
+   raise `status` from `provisional` to `normative` while inheriting an earlier layer's `sourceRef`,
+   or replace the `sourceRef` while inheriting the status. `runner.ts:93-113` uses both — `status`
+   through `verifiedRuleStatus` (`runner.ts:99`) and `sourceRef` verbatim on the diagnostic
+   (`runner.ts:110`). The merge core records every such change in `provenance` and classifies none of
+   them. Whether a layer may raise `status` at all, and whether raising it while inheriting someone
+   else's `sourceRef` is legitimate, is the authority spec's call.
+
+4. **`EntryProvenance` — the free hook.** The keyed-upsert fold already knows, at the moment of every
+   write, which layer index wrote it. Capturing it costs nothing:
+
+   ```ts
+   export type PackField =
+     | 'limits'
+     | 'dictionary.approved'
+     | 'dictionary.unapproved'
+     | 'dictionary.preferred'
+     | 'contractions'
+     | 'approvedTechnicalTerms'
+     | 'rules';
+
+   /** field → merge key → ordered layer indices that wrote it (last is the winner). */
+   export type EntryProvenance = ReadonlyMap<PackField, ReadonlyMap<string, readonly number[]>>;
+   ```
+
+   The core populates this and uses it only for the notices in the conflict table. **What a
+   diagnostic reports about an entry's source is entirely the authority spec's design** — this spec
+   asserts only that the data is available and that the winning layer is `at(-1)`.
+
+A fifth, smaller seam: **retraction and trust interact.** An untrusted low layer can retract a
+trusted org layer's ban, and the merge core will let it, because the core has no concept of trust.
+Whether `retract` should be constrained by layer authority is an authority question. The core-side
+hook is that every retraction is already recorded in `provenance` and in the
+`rule-pack-retraction-inert` accounting, so the authority spec can gate retractions without changing
+the fold.

--- a/docs/design/64-layered-rule-packs/01-merge-core.md
+++ b/docs/design/64-layered-rule-packs/01-merge-core.md
@@ -292,9 +292,7 @@ say _only_ what it changes. So:
 // src/rule-pack/schema.ts
 
 /** Unchanged. The contract a base pack satisfies. Existing packs keep parsing. */
-export const rulePackSchema = z.object({
-  /* …as today… */
-});
+export const rulePackSchema = z.object({/* …as today… */});
 
 /** What an `extend` layer may be. Everything optional except metadata. */
 export const rulePackLayerContentSchema = z.object({

--- a/docs/design/64-layered-rule-packs/02-authority-trust.md
+++ b/docs/design/64-layered-rule-packs/02-authority-trust.md
@@ -1,0 +1,1045 @@
+# Layered rule packs: the trust model
+
+Spec owner: authority, trust, and provenance. The merge algorithm, per-field merge keys, retraction
+syntax, conflict detection and the config zod shape are **out of scope** and are referenced here as
+given. Where this spec depends on a decision the merge-algorithm spec owns, it is flagged as a
+dependency, not designed.
+
+All line citations are against commit `9d78a8b`.
+
+---
+
+## Summary
+
+Layering breaks the current trust model because that model attaches authority to _the run_ via a
+single `RulePack`, and every consumer reads it that way. Under composition the merged artefact holds
+data of mixed provenance, so "the authority of the run" stops being a well-formed question.
+
+The design in this spec:
+
+1. **Authority becomes a property of an entry, not of a run.** Every entry in the composed pack
+   carries a required, undefaulted `EntryProvenance` record naming the layer that put it there, that
+   layer's declared authority, and the authority the operator's trust list actually permits it.
+2. **Provenance is compositor-written and supplier-unwritable.** It lives on a new
+   `ComposedRulePack` type. The on-disk `rulePackSchema` is unchanged, so no supplier can assert a
+   provenance for itself.
+3. **`verifiedAuthority` moves down a level** — it becomes a per-layer function evaluated once
+   during composition, and its per-run export is removed because there is no per-run authority.
+4. **`packPermitsConformanceClaim` splits in two.** Per-entry: an entry from a trusted normative
+   layer permits a claim regardless of what other layers did. Run-level: the composed stack permits
+   a claim only under **unanimity** across every contributing layer.
+5. **Override direction is fixed: the overriding layer owns the resulting entry's provenance,
+   always.** No inheritance from below, in either direction. Where the merge algorithm merges fields
+   from several layers into one entry, the composite entry takes the **weakest** verified authority
+   of any contributing layer.
+6. **Retraction and protection are the dangerous operations,** because they act on silence rather
+   than on output, and silence carries no diagnostic to attach provenance to. Both get explicit
+   policy gates and run notices.
+
+The asymmetry that drives the whole design:
+
+> **A positive finding is attributable to one entry; silence is a property of the whole stack.**
+
+That is why per-entry authority is sound for diagnostics, and why the run-level conformance claim
+still needs unanimity.
+
+---
+
+## The current trust boundary (quoted, with citations)
+
+### The principle, as stated in the code
+
+`src/rule-pack/loader.ts:58-83`:
+
+> ```
+>  * True when output is allowed to describe findings as conformance with a standard.
+>  *
+>  * Three conditions, all required:
+>  *
+>  * 1. the pack declares `normative` authority;
+>  * 2. it declares a conformance claim other than `none`;
+>  * 3. **the operator has named the pack in `trustedRulePackIds`.**
+>  *
+>  * The third is the trust boundary. Schema validation proves a pack's shape, not its provenance:
+>  * any JSON file can assert `authority: "normative"`, so a pack cannot elevate itself. Authority is
+>  * supplier-*declared* metadata until an operator makes an explicit, auditable decision to accept
+>  * it. The bundled pack fails condition 1 regardless.
+>  *
+>  * There is no signature verification here. If you need cryptographic provenance rather than an
+>  * operator allowlist, verify the pack before handing it to this package and keep the allowlist as
+>  * the final gate.
+> ```
+
+`src/rule-pack/loader.ts:85-98`:
+
+> ```
+>  * The authority the linter will act on, as distinct from the authority the pack claims.
+>  *
+>  * An untrusted pack's diagnostics report `supplementary` — its rule data is used, but its claim to
+>  * normative standing is not honoured. The pack's own assertion stays visible in
+>  * `metadata.authority` for the audit trail.
+> ```
+
+The same principle is restated in config: `src/core/config.ts:126-132`:
+
+> ```
+>    * Packs the operator has decided to trust, by `metadata.id`.
+>    *
+>    * Schema validation proves a pack's *shape*, never its *authority*. Any JSON file can declare
+>    * `authority: "normative"`, so an imported pack is untrusted by default and its self-declared
+>    * authority is reported as supplier-declared metadata only. A pack must be named here before the
+>    * linter treats its authority as application-verified.
+> ```
+
+### Where it is enforced today
+
+| Site                            | Code                                                 | What it caps                                                                    |
+| ------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `src/rule-pack/loader.ts:80-82` | `packPermitsConformanceClaim`                        | whether output may use conformance wording                                      |
+| `src/rule-pack/loader.ts:96-97` | `verifiedAuthority`                                  | run-level authority scalar                                                      |
+| `src/core/runner.ts:139-146`    | `verifiedRuleStatus` (private)                       | the `ruleStatus` on a pack-supplied rule's diagnostics                          |
+| `src/analysis/analyse.ts:292`   | `verifiedAuthority(pack, config.trustedRulePackIds)` | `ruleStatus` on `review-required` diagnostics                                   |
+| `src/analysis/analyse.ts:607`   | `verifiedAuthority(pack, config.trustedRulePackIds)` | `ruleStatus` on every semantic diagnostic                                       |
+| `src/cli/main.ts:190-196`       | both loader functions                                | `packAuthority`, `declaredAuthority`, `conformanceClaim` per file in CLI output |
+
+All four enforcement points take a single `RulePack`. `resolveRulePack` returns exactly one
+(`src/rule-pack/loader.ts:49-56`), and `prepareRun` binds it once for the run
+(`src/analysis/analyse.ts:244`), passing it into every rule as `RuleInput.pack`
+(`src/core/runner.ts:81-89`).
+
+### Structural facts that matter for what follows
+
+- `RulePack.metadata` is one record with one `id`, one `authority`, one `conformanceClaim`
+  (`src/core/types.ts:412-426`). Trust is matched on `metadata.id` by plain string inclusion
+  (`loader.ts:82`, `loader.ts:97`, `runner.ts:145`). Nothing binds an `id` to a file path, a
+  version, or a signature. `id`, `name` and `version` are all `z.string().min(1)`
+  (`src/rule-pack/schema.ts:18-20`).
+- Dictionary entries are bare data objects with no origin field at all
+  (`src/core/types.ts:428-455`, `src/rule-pack/schema.ts:33-56`).
+- `approvedTechnicalTerms` is `readonly string[]` (`src/core/types.ts:484`) — a bare string array,
+  structurally incapable of carrying provenance. It is spread together with operator-config terms
+  into one undifferentiated protection list at `src/analysis/analyse.ts:255` and
+  `src/evaluation/evaluate.ts:244`.
+- `RulePackLimits` is five scalars (`src/core/types.ts:457-463`) consumed directly by rules with no
+  authority tracking: `src/deterministic/rules/sentence-length.ts:28-30`,
+  `src/deterministic/rules/structure-rules.ts:43`,
+  `src/deterministic/rules/candidate-rules.ts:331`.
+- `rulePackRuleSpecSchema` already carries a per-rule `sourceRef` (`src/rule-pack/schema.ts:79-91`).
+  This is the existing precedent for per-record attribution, and the model this spec extends.
+- `Diagnostic.meta` is `Readonly<Record<string, string | number | boolean>>`
+  (`src/core/types.ts:249`) — flat scalars only, so a structured provenance record cannot be smuggled
+  through it.
+- `rulePackSchema` uses plain `z.object` (`src/rule-pack/schema.ts:93-104`) with zod `^4.4.3`
+  (`package.json:110`). Verified by execution: `z.object({a: z.string()}).parse({a:'x',
+provenance:{...}})` yields `{"a":"x"}` — unknown keys are **stripped**, silently.
+
+### Existing weaknesses this spec inherits (not introduced by layering)
+
+These are real today, with a single pack, and layering multiplies each of them. Flagged here because
+they are inside the trust boundary I own.
+
+1. **An untrusted pack's `sourceRef` is written to diagnostics verbatim.** `src/core/runner.ts:96-112`
+   caps `status` through `verifiedRuleStatus` but assigns
+   `meta: { ...processed.meta, sourceRef: packSpec?.sourceRef ?? '' }` (line 110) **unconditionally**
+   whenever `packSpec !== undefined`. An untrusted pack can therefore put the string
+   `"ASD-STE100 Issue 8, Writing Rule 3.1"` onto a diagnostic that reports `supplementary`. The
+   authority scalar is capped; the citation is not.
+2. **Documentation understates the trust condition.** `docs/rule-pack-import.md:51` says
+   "`packPermitsConformanceClaim()` returns true only for 'normative' + not 'none'." and the table at
+   `docs/rule-pack-import.md:135` gives `true` if `conformanceClaim !== 'none'`. Both omit condition
+   3 — the `trustedRulePackIds` requirement — i.e. the documented function is _more permissive than
+   the implemented one_. Safe in practice (the code is stricter than the doc), wrong as a contract.
+3. **No test covers the trust boundary.** `grep -rln "authority\|conformance\|rulePack" test/`
+   returns nothing across all 27 files under `test/`. `verifiedAuthority`,
+   `packPermitsConformanceClaim` and `verifiedRuleStatus` are unexercised. (Testing is out of scope
+   for this spec; recording the gap is not.)
+4. **Config already overrides pack limits with no record.** `options.maxSentencesPerStep ??
+pack.limits.maxSentencesPerProceduralStep` (`structure-rules.ts:43`) and the equivalents in
+   `sentence-length.ts:28-30` and `candidate-rules.ts:331` let operator config silently displace a
+   normative limit. Local today; a supply-chain issue once layers can do the same.
+
+---
+
+## What layering breaks
+
+`resolveRulePack` returning one pack (`loader.ts:49-56`) is load-bearing for four distinct
+assumptions, each of which fails independently:
+
+**1. "The pack" is a well-defined referent.** `verifiedAuthority(pack, …)` asks a question about a
+singular object. With seven layers there is no single `metadata.authority` and no single
+`metadata.id` to match against `trustedRulePackIds`. Every one of the six enforcement sites above
+would have to be handed _something_, and any scalar chosen is a summary that is false for some
+entries.
+
+**2. Trusting one layer would launder the rest.** If the compositor produced a merged `RulePack` with
+one synthesised `metadata` block, the natural implementation picks the top layer's or the most
+authoritative layer's metadata — and `verifiedAuthority` then reports one answer for every entry in
+the merged dictionary. A single trusted normative layer would elevate every other layer's entries to
+`normative` on output. That is the privilege-escalation bug the brief names, and it is the _default_
+outcome of naive composition, not an edge case.
+
+**3. Silence becomes composable, and nothing tracks it.** Today the only way an entry stops firing is
+operator config (`options.allow`, `vocabulary.ts:51,61,172`) or a protected literal. Under layering,
+a higher layer can retract a lower layer's entry, or add a protected literal that neutralises it. A
+retracted entry produces no diagnostic and therefore has nowhere to hang provenance. The reader sees
+a clean run and cannot distinguish "the normative check passed" from "an unauthorised layer removed
+the normative check".
+
+**4. Limits and protection lists have no per-entry granularity at all.** `RulePackLimits` is five
+scalars; `approvedTechnicalTerms` is `string[]`. Both are consumed pre-merge-agnostically
+(`analyse.ts:255`, `sentence-length.ts:28-30`). Neither can express "this value came from layer 4"
+without a type change. A limit is the highest-leverage laundering target in the system: raising
+`proceduralMaxGradeLevel` from 7 to 20 disables a rule that will still report `normative` status,
+because status comes from `rules[].status` (`runner.ts:96-99`) and the limit comes from somewhere
+else entirely.
+
+---
+
+## Per-entry authority design
+
+### The record
+
+New type, in `src/core/types.ts`, beside `RulePack`:
+
+```ts
+/** Position in the layer stack. Fixed order, lowest precedence first. */
+export type PackLayer =
+  'bundled' | 'organisation' | 'department' | 'product' | 'tech-stack' | 'industry' | 'locale';
+
+/** Where a contribution came from, when it did not come from a rule pack layer. */
+export type ContributionOrigin = 'pack' | 'operator-config' | 'builtin';
+
+/**
+ * Why an entry in the composed pack is in the composed pack, and what authority it may claim.
+ *
+ * Written **only** by the compositor. No supplier can assert this: it does not exist in
+ * `rulePackSchema`, and it lives on `ComposedRulePack`, a type no parse path produces.
+ *
+ * Required and deliberately not defaulted, on the same principle as `reviewerKind`
+ * (`src/fixture-tools/annotation-schema.ts:80-91`): an optional origin makes "nothing produced
+ * this" indistinguishable from "we forgot to record what produced this".
+ */
+export interface EntryProvenance {
+  readonly origin: ContributionOrigin;
+  /** `metadata.id` of the contributing layer. Absent only when `origin !== 'pack'`. */
+  readonly packId: string;
+  /** `metadata.version` of the contributing layer, verbatim. */
+  readonly packVersion: string;
+  readonly layer: PackLayer | 'operator-config' | 'builtin';
+  /** Precedence index in the resolved stack. Lower = lower layer. */
+  readonly layerIndex: number;
+  /** What that layer asserted about itself. Supplier-declared metadata, never acted on directly. */
+  readonly declaredAuthority: RuleStatus;
+  /** What the operator's trust list permits this layer to claim. Never stronger than declared. */
+  readonly verifiedAuthority: RuleStatus;
+  /** Whether the operator named this layer in `trustedRulePackIds`. */
+  readonly trusted: boolean;
+  /** What the layer's supplier claims, for the audit trail only. */
+  readonly conformanceClaim: RulePackMetadata['conformanceClaim'];
+  /** The layer's citation for this entry, when it supplied one. Attributed, never asserted. */
+  readonly sourceRef?: string;
+  /**
+   * Entries this one displaced, top-down. Present when a higher layer overrode or merged over a
+   * lower layer's entry. Empty array means "this entry displaced nothing", which is a different
+   * fact from "we did not check".
+   */
+  readonly displaces: readonly DisplacedEntry[];
+}
+
+export interface DisplacedEntry {
+  readonly packId: string;
+  readonly packVersion: string;
+  readonly layer: PackLayer | 'operator-config' | 'builtin';
+  readonly verifiedAuthority: RuleStatus;
+  /** `override` = whole entry replaced. `field-merge` = some fields survived from below. */
+  readonly kind: 'override' | 'field-merge' | 'retraction';
+}
+```
+
+### Where it attaches
+
+A new composed type, distinct from `RulePack`. `RulePack` stays exactly as it is — it describes one
+parsed layer, and the import boundary contract in `docs/rule-pack-import.md` stays true of a layer.
+
+```ts
+/** One entry of type `T`, plus the compositor's record of how it got here. */
+export type Provenanced<T> = T & { readonly provenance: EntryProvenance };
+
+export interface ComposedRulePack {
+  /** Every layer that was resolved, in precedence order. Replaces the singular `metadata`. */
+  readonly layers: readonly ResolvedLayer[];
+
+  readonly limits: {
+    readonly [K in keyof RulePackLimits]: Provenanced<{ readonly value: RulePackLimits[K] }>;
+  };
+
+  readonly dictionary: {
+    readonly approved: readonly Provenanced<ApprovedTermEntry>[];
+    readonly unapproved: readonly Provenanced<UnapprovedTermEntry>[];
+    readonly preferred: readonly Provenanced<PreferredTermEntry>[];
+  };
+  readonly contractions: readonly Provenanced<PreferredTermEntry>[];
+
+  /** Was `readonly string[]`. See "breaking changes" below — a string cannot carry provenance. */
+  readonly approvedTechnicalTerms: readonly Provenanced<{ readonly term: string }>[];
+
+  readonly rules: readonly Provenanced<RulePackRuleSpec>[];
+
+  /** Retractions that were applied, and by whom. Silence needs a record too. */
+  readonly retractions: readonly AppliedRetraction[];
+}
+
+export interface ResolvedLayer {
+  readonly layer: PackLayer;
+  readonly layerIndex: number;
+  readonly metadata: RulePackMetadata;
+  readonly verifiedAuthority: RuleStatus;
+  readonly trusted: boolean;
+  /** Contributed at least one surviving entry, override, or retraction. See unanimity, below. */
+  readonly contributing: boolean;
+}
+```
+
+`RuleInput.pack` (`src/core/rule.ts`, supplied at `src/core/runner.ts:84`) changes from `RulePack` to
+`ComposedRulePack`. Rules read `entry.provenance` where they already read `entry.term`,
+`entry.alternatives` etc. and pass it through to `buildDiagnostic`.
+
+The single-layer case is not special-cased: with no layers configured, the compositor produces a
+`ComposedRulePack` of exactly one layer (`bundled`), every entry provenanced to
+`ste-ai-provisional@0.1.0` with `declaredAuthority: 'provisional'`, `trusted: false`,
+`verifiedAuthority: 'provisional'` (from `src/rule-pack/provisional-pack.ts:24-33`). One code path,
+no "layered mode" flag.
+
+### Attachment rules at merge time
+
+The merge algorithm is another agent's. These are the constraints it must satisfy; they are about
+authority only, not about _which_ entry wins.
+
+- **A1.** Every entry in `ComposedRulePack` has exactly one `provenance`. It is not optional and has
+  no default. A compositor that cannot name an entry's origin must fail, not guess.
+- **A2.** `provenance` is written by the compositor and by nothing else. No parse path can produce
+  it: it is absent from `rulePackSchema`, and zod v4 strips unknown keys (verified above), so a pack
+  that ships a `provenance` key has it discarded at `parseRulePack` (`loader.ts:15-24`). **Harden
+  this**: switch the entry schemas in `src/rule-pack/schema.ts` to `z.strictObject` so a pack that
+  attempts it fails loudly rather than being quietly cleaned. Silent stripping is the right
+  behaviour for correctness and the wrong behaviour for an audit trail.
+- **A3.** `verifiedAuthority` on a provenance record is computed once, per layer, at composition,
+  from that layer's own `metadata` and the operator's trust list. It is never recomputed downstream
+  and never derived from a neighbouring layer.
+- **A4.** Whole-entry override: the surviving entry's provenance is the **overriding layer's**,
+  entire, with the displaced entry recorded in `displaces` with `kind: 'override'`. Nothing is
+  inherited from below.
+- **A5.** Field-level merge (if the merge algorithm does any): the composite entry's
+  `verifiedAuthority` is the **weakest** across every layer that contributed any surviving field,
+  under the lattice `normative > supplementary > provisional`. `packId`/`packVersion`/`layer` name
+  the top contributing layer; every other contributor appears in `displaces` with
+  `kind: 'field-merge'`.
+- **A6.** Operator-config contributions (`rules.*.additional` at `vocabulary.ts:55-60` and
+  `vocabulary.ts:166-171`; `config.approvedTerms` at `analyse.ts:255`) get a synthetic provenance:
+  `origin: 'operator-config'`, `declaredAuthority: 'supplementary'`, `verifiedAuthority:
+'supplementary'`, `trusted: true`. Trusted because the operator wrote it; never `normative`
+  because config is not a licensed rule pack and is not covered by `trustedRulePackIds`. This closes
+  the hole where config-supplied entries would be the one class with no provenance.
+- **A7.** Retractions are recorded in `ComposedRulePack.retractions` with the retracting layer's
+  provenance and the retracted entry's provenance. A retraction is a contribution: a layer that
+  contributes nothing but retractions is `contributing: true`.
+
+### Breaking changes this implies
+
+Stated plainly rather than buried:
+
+- `approvedTechnicalTerms: readonly string[]` → `readonly Provenanced<{term: string}>[]`. Public via
+  the `./rule-pack` and `./core` exports (`package.json:20-27`). Unavoidable: a `string` cannot carry
+  provenance, and this list is the single highest-value laundering target (see attack 3).
+- `RuleInput.pack` type change — affects every rule and any third-party rule.
+- `Diagnostic` gains a required field (below).
+- `verifiedAuthority` and `packPermitsConformanceClaim` are exported from `src/rule-pack/index.ts`
+  (`export * from './loader.js'`). Their replacement is an API break.
+
+---
+
+## Changes to `verifiedAuthority` and `packPermitsConformanceClaim`
+
+### `verifiedAuthority`
+
+The existing body is correct; only its scope is wrong. It becomes a **per-layer** function, applied
+once for each layer during composition, and its run-level export is **removed**.
+
+```ts
+/**
+ * The authority a single layer will be acted on with, as distinct from the authority it claims.
+ *
+ * Unchanged in substance from the pre-layering `verifiedAuthority`
+ * (`src/rule-pack/loader.ts:92-98`). What changed is when it runs: once per layer at composition,
+ * not once per run. There is no per-run authority any more, because a composed stack does not have
+ * one — asking for it is the question that laundered every other layer's entries.
+ */
+export function verifiedLayerAuthority(
+  metadata: RulePackMetadata,
+  trustedRulePackIds: readonly string[] = [],
+): RuleStatus {
+  if (metadata.authority !== 'normative') return metadata.authority;
+  return isTrustedLayer(metadata, trustedRulePackIds) ? 'normative' : 'supplementary';
+}
+
+/** Read the already-verified authority off an entry. Total, cheap, and the only downstream form. */
+export function entryAuthority(provenance: EntryProvenance): RuleStatus {
+  return provenance.verifiedAuthority;
+}
+```
+
+`src/core/runner.ts:139-146` (`verifiedRuleStatus`) is deleted: a composed `rules[]` entry already
+carries `provenance.verifiedAuthority`, computed at composition. The unconditional `sourceRef`
+assignment at `runner.ts:110` is replaced by the attributed form (see attack 5).
+
+The two `analyse.ts` call sites (`:292`, `:607`) currently pass a run-level scalar into
+`undecidedCandidateDiagnostics` and `analyseSemantically`. Both are handled per-candidate instead —
+see "Semantic and review-required diagnostics" below.
+
+**Optional convenience only**, and explicitly not a trust primitive:
+
+```ts
+/**
+ * The weakest verified authority among contributing layers. A conservative one-line summary for
+ * human-facing output. NEVER the input to a trust decision: it is a summary, and summarising is
+ * exactly what this design removed. Use `entryAuthority` for anything load-bearing.
+ */
+export function effectiveStackAuthority(composed: ComposedRulePack): RuleStatus;
+```
+
+### `packPermitsConformanceClaim`
+
+Splits into two functions with genuinely different semantics.
+
+```ts
+/**
+ * True when a finding produced by this entry may be described as non-conformance with a standard.
+ *
+ * The same three conditions as before, evaluated against the entry's own layer:
+ * 1. the layer declares `normative` authority;
+ * 2. it declares a conformance claim other than `none`;
+ * 3. the operator has named the layer in `trustedRulePackIds`.
+ *
+ * A positive finding is attributable to one entry, so a trusted normative layer's finding keeps its
+ * standing even in a stack containing untrusted layers. The finding says "entry E from pack P fired
+ * on this span", and that statement is unaffected by what layer 6 declares about a different word.
+ */
+export function entryPermitsConformanceClaim(p: EntryProvenance): boolean {
+  return p.trusted && p.declaredAuthority === 'normative' && p.conformanceClaim !== 'none';
+}
+
+/**
+ * True when the RUN as a whole may be described as a conformance check.
+ *
+ * Requires **unanimity**: every contributing layer must independently satisfy all three conditions.
+ *
+ * The asymmetry with `entryPermitsConformanceClaim` is deliberate and is the crux of this design. A
+ * run-level claim is a statement about SILENCE — "this document was checked against the standard and
+ * nothing fired". Silence is a property of the whole stack, not of any entry: an untrusted layer can
+ * retract a normative entry, protect a literal, or raise a limit, and the check that would have
+ * fired never runs. There is no diagnostic to attribute, and no way to detect the absence without
+ * counterfactual evaluation. So one untrusted or non-normative contributing layer disqualifies the
+ * run-level claim entirely, while leaving every trusted layer's individual findings intact.
+ */
+export function stackPermitsConformanceClaim(composed: ComposedRulePack): boolean {
+  const contributing = composed.layers.filter((l) => l.contributing);
+  return (
+    contributing.length > 0 &&
+    contributing.every(
+      (l) =>
+        l.trusted && l.metadata.authority === 'normative' && l.metadata.conformanceClaim !== 'none',
+    )
+  );
+}
+```
+
+**"Contributing" is defined to include retractions and overrides**, not only surviving entries. A
+layer whose entire contribution is `retract: ["utilise"]` contributes nothing that survives as an
+entry but changes what the run is silent about — the exact case unanimity exists to catch. Defining
+"contributing" as "has a surviving entry" would let a pure-retraction untrusted layer escape the
+check completely. (This is a hole in the obvious definition; it is closed here deliberately.)
+
+**Consequence the merge-algorithm spec must accommodate:** the bundled provisional layer declares
+`authority: 'provisional'` and `conformanceClaim: 'none'`
+(`src/rule-pack/provisional-pack.ts:28,32`). Under unanimity, if the bundled layer contributes
+anything at all, no run-level conformance claim is ever reachable. An operator holding a licensed
+pack must therefore be able to **fully replace** the bundled layer, not merely extend it. This is a
+dependency on the merge spec's `replace` mode, flagged, not designed here. If `replace` cannot
+evacuate the bundled layer entirely, `stackPermitsConformanceClaim` is permanently `false` and
+should be documented as such rather than weakened.
+
+### Answering the three options in the brief, explicitly
+
+- _All layers trusted and normative?_ — Yes, for the **run-level** claim. That is
+  `stackPermitsConformanceClaim`.
+- _Any layer untrusted poisons the whole run?_ — Yes, for the **run-level** claim, and for nothing
+  else. It does not poison individual findings.
+- _Per-entry, so a diagnostic from a trusted layer may claim conformance while one from an untrusted
+  layer may not?_ — Yes, for **diagnostics**. That is `entryPermitsConformanceClaim`.
+
+The three are not alternatives; they answer two different questions that the current single-pack API
+conflates because with one pack they coincide.
+
+---
+
+## `trustedRulePackIds` semantics
+
+### Per-layer, evaluated at composition
+
+The operator trusts **each layer individually**. `trustedRulePackIds` keeps its meaning — an
+allowlist of pack ids the operator has decided to accept — and its matching predicate is evaluated
+once per layer against that layer's `metadata.id`, rather than once per run.
+
+A layer not named is untrusted. Untrusted is the default, unchanged
+(`src/core/config.ts:133`, `.default([])`).
+
+### Override direction — the precise rule
+
+> **When a higher layer overrides a lower layer's entry, the resulting entry's authority and
+> provenance are the OVERRIDING layer's, entirely. Nothing is inherited from below, in either
+> direction.**
+
+Worked, in both directions:
+
+| Below                                                                                                           | Above                                                          | Result                                                                                                     | Why                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| trusted normative `@acme/std` bans "utilise"                                                                    | untrusted `@team/vocab` overrides the entry (new alternatives) | entry reports **supplementary**, provenance `@team/vocab`, `displaces: [{@acme/std, normative, override}]` | the surviving entry is the untrusted layer's work; inheriting `normative` from below is the privilege escalation                                                                           |
+| untrusted `@team/vocab` bans "utilise"                                                                          | trusted normative `@acme/std` overrides it                     | entry reports **normative**, provenance `@acme/std`                                                        | the surviving entry is entirely the trusted layer's; an override is not contaminated by what it replaced                                                                                   |
+| trusted normative supplies `{term, alternatives}`; untrusted supplies `{safeSubstitution: true}` merged onto it | —                                                              | entry reports **supplementary** (A5, weakest wins), both layers in `displaces`                             | a composite entry is only as trustworthy as its weakest contributor — and `safeSubstitution` gates autofix (`vocabulary.ts:77-84`), so this is precisely where weakest-wins earns its keep |
+
+**A downgrade must be visible, not merely correct.** An untrusted layer overriding a normative entry
+produces a correct `supplementary` — and a reader scanning a mostly-normative run will not notice one
+downgraded line. So the compositor emits a run notice:
+
+```
+code:    'authority-downgraded-by-layer'
+level:   'warning'
+message: '3 entr(ies) from a normative layer were overridden by a layer of lower verified
+          authority. Findings for those entries report the overriding layer's authority.'
+detail:  { entries: 3, byPackId: '@team/vocab', displacedPackId: '@acme/std' }
+```
+
+`RunNotice.detail` is `Readonly<Record<string, string | number | boolean>>`
+(`src/core/types.ts:257`), so the detail must be flat scalars — one notice per (overriding layer,
+displaced layer) pair rather than one carrying a nested list.
+
+### Retraction: the case with no diagnostic to attach to
+
+A higher layer removing a lower layer's entry is the one operation that produces _nothing_. It is
+therefore gated by policy, not merely recorded:
+
+- **Default policy: a layer may not retract an entry whose verified authority is stronger than its
+  own.** The retraction is refused, the entry survives, and a notice is emitted:
+  `retraction-refused-weaker-layer` (`level: 'error'`).
+- Opt-in config key `allowWeakerLayerRetraction: boolean`, default `false`. When enabled, the
+  retraction applies and the notice becomes `retraction-of-stronger-entry` (`level: 'warning'`),
+  still recorded in `ComposedRulePack.retractions`.
+- A retraction of an equal-or-weaker entry applies normally, recorded, notice at `level: 'info'`.
+
+Retraction _syntax_ is the merge spec's; whether a given retraction is _permitted_ is this spec's.
+
+### Recommended hardening (owner decision required)
+
+Both are recommendations, not settled design. I flag rather than decide because they change the
+config contract, which another agent owns.
+
+1. **Version pinning.** Today trust is `trustedRulePackIds.includes(pack.metadata.id)` — a plain
+   string match on a free-text field (`schema.ts:18`, `loader.ts:82`). A supplier can ship v3.0 with
+   entirely different content under a trusted id and inherit trust with no operator action. With one
+   pack the operator points at one file and the exposure is bounded; with seven independently-owned
+   layers it is a supply-chain hole. Recommend accepting `"@acme/std@2.1.0"` alongside bare
+   `"@acme/std"` (bare = any version), and documenting the bare form as the weaker choice.
+2. **Duplicate-id rejection.** Two layers in one stack declaring the same `metadata.id` make trust
+   ambiguous and enable id squatting (attack 6). Recommend the compositor throws `RulePackError` on
+   a duplicate id within a stack. Cheap, and it closes the squat completely.
+
+---
+
+## Per-entry provenance and diagnostic output
+
+### The diagnostic field
+
+`Diagnostic` gains a **required** field:
+
+```ts
+export interface Diagnostic {
+  // …existing fields…
+  readonly ruleStatus: RuleStatus;
+  /**
+   * What put the rule data behind this finding into the run.
+   *
+   * Required and not defaulted, on the `reviewerKind` principle
+   * (`src/fixture-tools/annotation-schema.ts:80-91`): "record what produced a record, on the
+   * record". An optional field makes "this finding has no pack origin" and "we forgot to set it"
+   * the same value, and the second is the one that laundered authority.
+   *
+   * `ruleStatus` and `provenance.verifiedAuthority` must agree; the invariant is asserted at
+   * construction.
+   */
+  readonly provenance: EntryProvenance;
+}
+```
+
+Every diagnostic has one. `origin` is the discriminator that makes "no pack entry" a _stated value_
+rather than an absence:
+
+| Producer                                             | `origin`          | provenance is                                                     |
+| ---------------------------------------------------- | ----------------- | ----------------------------------------------------------------- |
+| a dictionary entry (`vocabulary.ts:91-105`)          | `pack`            | the entry's own                                                   |
+| operator-config `additional` (`vocabulary.ts:55-60`) | `operator-config` | synthetic, per A6                                                 |
+| a limit-consuming rule (`sentence-length.ts:28-30`)  | `pack`            | the **weakest** of the rule spec's and the limit's — see attack 4 |
+| a hard-coded heuristic with no pack input            | `builtin`         | synthetic `builtin` layer, `verifiedAuthority: 'provisional'`     |
+| `review-required` (`analyse.ts:543-555`)             | inherited         | the originating candidate's entry provenance                      |
+| semantic (`analyse.ts:607`)                          | inherited         | the originating candidate's entry provenance                      |
+
+`buildDiagnostic` (`src/core/rule.ts:205-224`) gains a required `provenance` parameter (or a required
+`draft.provenance`), so a rule that omits it fails to compile. Compile-time enforcement is the point:
+the field is required so it cannot be silently absent, and required-at-the-constructor is where that
+is actually enforced.
+
+### Semantic and review-required diagnostics
+
+Both currently take a **run-level** authority scalar: `analyse.ts:292` and `analyse.ts:607` both pass
+`verifiedAuthority(pack, config.trustedRulePackIds)`. Under layering both become per-candidate.
+
+`CandidatePassage` (raised by rules at e.g. `vocabulary.ts:108-124`) gains
+`readonly provenance: EntryProvenance`, copied from the entry that raised it. Then:
+
+- `undecidedCandidateDiagnostics` (`analyse.ts:535-556`) sets `ruleStatus:
+candidate.provenance.verifiedAuthority` and `provenance: candidate.provenance` per candidate,
+  dropping its `ruleStatus` parameter.
+- `analyseSemantically` (`analyse.ts:600-609`) likewise drops its `ruleStatus` argument and reads it
+  off each candidate.
+
+This is strictly more correct than today even before layering: a semantic verdict on a passage raised
+by a provisional heuristic currently reports the _pack's_ run-level authority, not the heuristic's.
+
+### Human-readable output
+
+`formatMessage` (`src/textlint/adapter.ts:190-193`) is currently:
+
+```ts
+const status = diagnostic.ruleStatus === 'normative' ? 'normative' : diagnostic.ruleStatus;
+return `[${diagnostic.category}][${status}] ${diagnostic.message}`;
+```
+
+Proposed:
+
+```ts
+`[${category}][${status}] ${message}${attribution}`;
+```
+
+where `attribution` is `` ` (flagged by ${packId}@${packVersion})` `` **only when the composed stack
+has more than one contributing layer**, and empty otherwise.
+
+Two reasons for the conditional. First, a single-layer run's output stays byte-identical to today, so
+layering costs nothing to existing users and does not churn
+`test/integration/cli-output.test.ts` / `test/e2e/textlint-tester.test.ts`. Second, in a one-layer run
+the attribution carries no information: there is only one candidate.
+
+**Render `packId@packVersion`, never `metadata.name`.** `name` is free text
+(`src/rule-pack/schema.ts:19`) and a pack could set it to
+`"ASD STEMG — certified conformant"`. See attack 9 — this is my own design's new attack surface.
+
+CLI text mode (`src/cli/main.ts:236-245`) gets the same attribution appended to the message line.
+
+### JSON output
+
+`src/cli/main.ts:145-155` builds per-file result entries with three scalars, populated at
+`main.ts:190-196`:
+
+```ts
+packAuthority: verifiedAuthority(analysis.pack, analysis.config.trustedRulePackIds),
+declaredAuthority: analysis.pack.metadata.authority,
+conformanceClaim: packPermitsConformanceClaim(…) ? analysis.pack.metadata.conformanceClaim : 'none',
+```
+
+All three are single-pack scalars and all three become false under layering. Replaced by:
+
+```jsonc
+{
+  "file": "…",
+  "diagnostics": [
+    {
+      "…": "…",
+      "provenance": {
+        "packId": "…",
+        "packVersion": "…",
+        "layer": "…",
+        "declaredAuthority": "…",
+        "verifiedAuthority": "…",
+        "trusted": true,
+        "sourceRef": "…",
+        "displaces": [],
+      },
+    },
+  ],
+  "layers": [
+    {
+      "layer": "bundled",
+      "layerIndex": 0,
+      "packId": "ste-ai-provisional",
+      "packVersion": "0.1.0",
+      "declaredAuthority": "provisional",
+      "verifiedAuthority": "provisional",
+      "trusted": false,
+      "conformanceClaim": "none",
+      "contributing": true,
+    },
+  ],
+  "effectiveAuthority": "provisional", // weakest contributing layer; a summary, not a decision
+  "conformanceClaim": "none", // stackPermitsConformanceClaim(); 'none' otherwise
+}
+```
+
+`retractions` appears once at the top level alongside `conformance`, since it is a stack property,
+not a per-file one.
+
+The top-level `conformance` block (`main.ts:213-217`) keeps `disclaimer` verbatim and takes
+`claim`/`packAuthority` from the composed stack rather than `results[0]`.
+
+**Separately**: `main.ts:266` prints, unconditionally,
+`"Provisional rules only; no conformance claim."` — regardless of the pack. That is already
+inaccurate today for a trusted normative pack, though it errs conservatively (under-claims), so it is
+not a soundness bug. Under layering it should be derived: emit the fixed sentence when
+`stackPermitsConformanceClaim` is false, and when true emit the layer summary plus the disclaimer
+that the tool certifies nothing. `docs/DISCLAIMER.md:40-41` promises the current wording — see
+"Disclaimer impact".
+
+---
+
+## Adversarial review of this proposal
+
+Each case: the attack, whether it works, what stops it, and what residual risk remains.
+
+### 1. Silent retraction of a normative entry by an untrusted layer
+
+_Attack._ Org layer (untrusted) retracts the normative pack's ban on "utilise". Document uses
+"utilise" freely. Run is clean. Reader reads clean as conformant.
+
+_Naively:_ works completely, and is invisible — no diagnostic, no entry, nothing to attribute.
+
+_Stopped by:_ default refusal of retractions that target a stronger-authority entry, the
+`retraction-refused-weaker-layer` notice, `ComposedRulePack.retractions` as a durable record, and
+`allowWeakerLayerRetraction` defaulting to `false`. Even with the opt-in enabled, the retracting layer
+is `contributing: true` (per the definition above), so `stackPermitsConformanceClaim` is false.
+
+_Residual._ An operator who sets `allowWeakerLayerRetraction: true` and ignores warnings is not
+protected. That is an operator decision, made explicitly, and recorded — which is the whole shape of
+the existing trust boundary.
+
+### 2. Override laundering
+
+_Attack._ Untrusted layer overrides a trusted normative entry, keeps its provenance, reports
+`normative`.
+
+_Naively:_ this is the **default** outcome of merging entries and picking metadata from the strongest
+layer.
+
+_Stopped by:_ A4 — the overriding layer owns the resulting provenance, entire — plus A5's
+weakest-wins for field-level merges, plus the `authority-downgraded-by-layer` notice so the downgrade
+is visible rather than merely correct.
+
+_Residual._ None I can find for whole-entry override. Field-level merge depends on the merge
+algorithm reporting _which_ layers contributed _which_ surviving fields. If it cannot, A5 cannot be
+computed and the entry must fall back to the weakest authority among all layers touching that merge
+key. **Dependency on the merge spec.**
+
+### 3. Protection-list laundering via `approvedTechnicalTerms`
+
+_Attack._ Untrusted layer adds `"utilise"` — or a whole phrase — to `approvedTechnicalTerms`. The
+term is protected as a literal name **before any rule runs**
+(`analyse.ts:254-257`, `evaluate.ts:243-245`), so the trusted normative dictionary entry never
+matches. No diagnostic. No override. No retraction. Nothing in the merged dictionary changed.
+
+_Naively:_ works perfectly and is the cleanest attack in the set, because it never touches the thing
+being protected. It is also currently structurally undetectable: `approvedTechnicalTerms` is
+`readonly string[]` (`types.ts:484`) spread into an undifferentiated list with `config.approvedTerms`.
+
+_Stopped by:_ the `approvedTechnicalTerms` type change to `Provenanced<{term}>[]`, plus a run notice
+when a protection entry's verified authority is weaker than any contributing normative layer's:
+
+```
+code:    'protection-weaker-than-normative-layer'
+level:   'warning'
+message: '7 protected literal(s) were supplied by a layer of lower authority than a contributing
+          normative layer. Text matching them was exempt from every vocabulary check.'
+```
+
+The notice lists counts and the supplying pack id; it does **not** claim which findings were
+suppressed, because knowing that needs counterfactual evaluation and this design does not do
+counterfactuals. Unanimity also fails, so the run-level claim is off.
+
+_Residual._ The notice is a warning about a _possibility_, not a detection. An operator can
+legitimately have many protected literals. Honest statement of limit: this design makes the
+protection auditable, not verified. Verifying it would require running the vocabulary rules twice —
+once with the weaker layer's protections and once without — and diffing. That is a real option and I
+am deliberately not specifying it: it doubles rule execution cost and the trade-off is the merge/
+performance owner's call. **Flagged as an open question.**
+
+### 4. Limit laundering
+
+_Attack._ Untrusted tech-stack layer sets `proceduralMaxGradeLevel: 20`. The normative
+`sentence-length-procedural` rule spec still declares `status: normative` and is still trusted, so
+its diagnostics — the ones that still fire — report `normative`. But the limit that decides whether
+it fires at all came from an untrusted layer, and now almost nothing fires.
+
+_Naively:_ works, and is invisible: `runner.ts:96-99` derives status from `rules[].status`, while the
+limit is read separately by the rule at `sentence-length.ts:28-30`. The two have no connection in the
+current code.
+
+_Stopped by:_ per-field limit provenance in `ComposedRulePack.limits` (each limit is a
+`Provenanced<{value}>`), plus the rule-side rule that **a diagnostic gated by a limit takes the
+weaker of the rule spec's verified authority and the limit's verified authority**. The three
+limit-consuming sites (`sentence-length.ts:28-30`, `structure-rules.ts:43`,
+`candidate-rules.ts:331`) each read the provenance alongside the value and pass the weaker to
+`buildDiagnostic`.
+
+_Residual._ Loosening a limit reduces the _number_ of findings; the weaker-of rule only marks the
+findings that survive. It does not surface the suppression. A limit whose provenance is weaker than a
+contributing normative layer's should also emit `limit-weaker-than-normative-layer` — same shape as
+attack 3's notice, same honest limit. Note also that operator config already does this to limits with
+no record at all (`structure-rules.ts:43`, `sentence-length.ts:28-30`) — pre-existing, and A6's
+`operator-config` provenance closes it as a side effect.
+
+### 5. Fabricated `sourceRef`
+
+_Attack._ Untrusted layer supplies `rules: [{ruleId: "sentence-length-procedural", status:
+"normative", sourceRef: "ASD-STE100 Issue 8, Writing Rule 3.1"}]`. Status is capped to
+`supplementary` by `verifiedRuleStatus` (`runner.ts:139-146`) — but `runner.ts:110` assigns
+`meta.sourceRef` **unconditionally** whenever `packSpec !== undefined`. The fabricated citation lands
+on the diagnostic verbatim, next to a `supplementary` tag that most readers will not weigh against a
+specific-looking standard citation.
+
+_Naively:_ works **today**, with one pack. Layering adds six more suppliers who can do it.
+
+_Stopped by:_ `sourceRef` becomes attributed, not asserted. It moves onto `EntryProvenance.sourceRef`
+(where it sits beside `packId`, `trusted`, and `verifiedAuthority`) and is rendered as
+`claimed by @team/vocab@1.4.0: "ASD-STE100 Issue 8, Writing Rule 3.1"` when the supplying layer is
+untrusted, and plainly when trusted. Additionally: an untrusted layer's `sourceRef` never silently
+replaces a trusted layer's `sourceRef` for the same rule id without the
+`authority-downgraded-by-layer` notice.
+
+_Residual._ A trusted layer can still cite anything it likes. That is correct and intended — trust is
+exactly the operator's decision to accept a supplier's citations. The trust boundary's own doc
+comment already says so: "Authority is supplier-_declared_ metadata until an operator makes an
+explicit, auditable decision to accept it" (`loader.ts:68-70`).
+
+### 6. Id squatting
+
+_Attack._ Operator trusts `@acme/std`. The locale layer — a different file, a different supplier —
+declares `metadata.id: "@acme/std"`. Trust is a plain `includes` on a free-text field
+(`loader.ts:82,97`, `schema.ts:18`), so the locale layer is trusted and every entry it contributes
+reports `normative`.
+
+_Naively:_ works. With one pack the operator points at one file so the exposure is bounded; with
+seven independently-sourced layers it is a real supply-chain hole.
+
+_Stopped by:_ the duplicate-id rejection recommended above (`RulePackError` on two layers sharing an
+id in one stack). That closes the _collision_ case completely and cheaply.
+
+_Residual._ It does **not** close the case where the squatting layer is the _only_ one with that id —
+e.g. the operator trusts `@acme/std` intending the org layer, and the industry layer claims the name
+while the real `@acme/std` is not in the stack. Layer-qualified trust entries
+(`"industry:@acme/std@2.1.0"`) would close it. **Flagged as an open question**, because it changes
+the config contract that another agent owns. Note that even the collision fix has a cost: a
+legitimate stack that includes the same pack at two layers becomes an error. I judge that acceptable
+— a pack appearing twice in one stack is already a config smell — but it is a real behavioural
+constraint, not a free win.
+
+### 7. Mixed-authority run read as normative
+
+_Attack._ No forgery at all. Six of seven layers are trusted and normative; one is not. A reader
+scans output that is overwhelmingly `[normative]`, sees a handful of `[supplementary]` lines, and
+reads the run as a conformance check.
+
+_Naively:_ works, because the current output has no run-level statement that would contradict it —
+and `packAuthority` (`main.ts:190`) is a single scalar that would report `normative`.
+
+_Stopped by:_ `stackPermitsConformanceClaim` returns false (unanimity), the JSON `conformanceClaim`
+is `none`, `effectiveAuthority` is the **weakest** contributing layer, `layers[]` names every layer
+with its trust flag, and the CLI summary line states it in words. The reader is not asked to infer
+the run's standing from a scan of individual lines.
+
+_Residual._ This is a human-factors mitigation, and human-factors mitigations degrade. It is the same
+class of risk the existing `[provisional]` tag already carries.
+
+### 8. Pure-retraction layer escaping unanimity
+
+_Attack on my own design._ Define "contributing" as "has at least one surviving entry" — the obvious
+definition. A layer whose entire content is retractions then contributes zero surviving entries, is
+`contributing: false`, is excluded from the unanimity check, and an untrusted layer that does nothing
+but delete normative checks leaves `stackPermitsConformanceClaim` returning `true`.
+
+_Stopped by:_ the definition given above — contributing means a surviving entry **or** an override
+**or** a retraction. Recorded here explicitly because the obvious definition is wrong in exactly the
+direction that matters, and an implementer reaching for the natural one would reintroduce it.
+
+### 9. Provenance strings as an output channel (attack on my own design)
+
+_Attack._ This design puts pack-controlled strings into human-facing output next to authority
+wording. `metadata.name`, `id` and `version` are all unconstrained `z.string().min(1)`
+(`schema.ts:18-20`). A pack sets `name: "ASD STEMG — certified conformant (Issue 8)"` and every
+message in a mixed run reads `… (flagged by ASD STEMG — certified conformant (Issue 8))`.
+
+_Stopped by:_ render `id@version` only, never `name`; cap the rendered length; never place a
+pack-supplied string adjacent to the word "conformance". `id` and `version` are still supplier-
+controlled, so an id like `"asd-ste100-official"` is possible — but an id is understood as a name,
+not as a claim, and the `trusted: false` flag travels with it in JSON.
+
+_Residual._ Real but small, and it is a genuinely new surface this design creates. Worth a schema
+constraint on `id`/`version` character sets, which I am not specifying because it touches the import
+boundary schema that `docs/rule-pack-import.md` documents.
+
+### 10. Supplier-written provenance
+
+_Attack._ A pack ships `"provenance": {"trusted": true, "verifiedAuthority": "normative"}` on each
+dictionary entry.
+
+_Stopped by:_ two independent barriers. `provenance` does not exist in `rulePackSchema`
+(`schema.ts:33-104`), and zod v4 `z.object` strips unknown keys — verified by execution against the
+repo's `zod@^4.4.3` (`package.json:110`). And `ComposedRulePack` is a distinct type produced only by
+the compositor; no parse path returns it. A2 additionally recommends `z.strictObject` so the attempt
+fails loudly instead of being silently cleaned — silent stripping is correct behaviour and a poor
+audit trail.
+
+_Residual._ None, provided the compositor never spreads a raw parsed object into a composed entry
+(`{...parsedEntry, provenance}` is safe _because_ zod already stripped; `{...rawJson, provenance}`
+would not be). Worth an architecture test.
+
+### 11. Trust-list drift across versions
+
+_Attack._ Operator trusts `@acme/std` at v2.1 after review. Supplier ships v3.0 with a different
+dictionary. Trust is matched on `id` only (`loader.ts:82`), so v3.0 is trusted with no operator
+action.
+
+_Stopped by:_ nothing in the current design. Version pinning (recommended above) would close it.
+
+_Residual._ Open. This exists today; layering multiplies it by seven independently-owned suppliers on
+independent release cadences. **Flagged as an open question** rather than decided, because it changes
+the config contract.
+
+---
+
+## Disclaimer impact
+
+`docs/DISCLAIMER.md` has four passages that layering makes inaccurate. Quoted exactly, with what
+changes.
+
+### 1. "the active rule pack" — singular referent (lines 32-38)
+
+> `provisional` status is not cosmetic. It is carried in:
+>
+> - each rule's `meta.status` and `meta.sourceRef`;
+> - every diagnostic, as the `[provisional]` tag in the message and the `ruleStatus` field in the
+>   programmatic and JSON output;
+> - **the active rule pack's `metadata.authority` and `metadata.conformanceClaim`, which the bundled
+>   pack sets to `provisional` and `none` respectively.**
+
+"the active rule pack's `metadata`" presumes one pack. Under layering there is no singular active
+pack. The third bullet must become the layer stack: each contributing layer's declared and verified
+authority, and the composed stack's conformance answer. The first two bullets stay true and should
+gain the per-entry provenance field as a fourth carrier.
+
+### 2. The `packPermitsConformanceClaim` promise (lines 40-41)
+
+> `packPermitsConformanceClaim()` returns `false` for the bundled pack, and the CLI prints
+> `Provisional rules only; no conformance claim.` on every run.
+
+Two problems. The function is being replaced by `entryPermitsConformanceClaim` /
+`stackPermitsConformanceClaim`, so the name must change. And "on every run" is a promise about the
+unconditional line at `src/cli/main.ts:266` — which this spec proposes to derive rather than
+hard-code. The replacement must state the derived behaviour: the sentence is printed whenever
+`stackPermitsConformanceClaim` is false, which is every run of the shipped configuration, because the
+bundled layer declares `provisional`/`none` (`src/rule-pack/provisional-pack.ts:28,32`).
+
+### 3. "What a passing run means" (lines 44-47) — the most important change
+
+> A clean run means: _this document did not trigger the provisional checks that were enabled._ It
+> does not mean the document is Simplified Technical English, and it does not mean the document is
+> correct, safe, or complete.
+
+The sentence survives, but "the checks that were enabled" is now doing work it cannot do. Under
+layering, _which checks were enabled_ is a composition outcome: a higher layer may have retracted a
+lower layer's check, protected a literal that exempts text from it, or raised a limit so it no longer
+fires. The disclaimer must add, in substance:
+
+> Which checks were enabled is itself an outcome of composing the configured layers. A higher layer
+> can retract a lower layer's entry, exempt text from it by protecting a literal, or relax a limit so
+> the check no longer fires. A clean run therefore says nothing about checks that composition
+> removed. The run's `layers` and `retractions` output records what each layer contributed and what
+> it removed.
+
+This is the sentence the whole spec exists to protect. It is also the sentence that stops being true
+by itself, because it was written when one pack governed a run.
+
+### 4. "Supplying authorised material" (lines 60-66)
+
+> If you hold a licence that permits it, an authorised rule pack can supply normative limits, a
+> controlled dictionary, and per-rule authority through the documented import boundary — see
+> [`rule-pack-import.md`](./rule-pack-import.md). **Doing so changes the `ruleStatus` on diagnostics
+> to whatever the pack declares.**
+
+The bolded sentence is **already inaccurate before layering**: `ruleStatus` changes to whatever
+`verifiedAuthority` permits, not to whatever the pack declares. An untrusted pack declaring
+`normative` yields `supplementary` (`loader.ts:96-97`, `runner.ts:144-145`). Under layering it
+becomes actively misleading, because "the pack" is plural and the answer is per-entry. Replacement:
+
+> Doing so changes the `ruleStatus` on diagnostics to the authority the operator has verified for the
+> layer that supplied the entry behind each finding — which is the layer's declared authority only
+> when the operator has named that layer in `trustedRulePackIds`, and `supplementary` otherwise.
+
+Also singular: "an authorised rule pack can supply" becomes "one or more authorised layers can
+supply".
+
+### Unaffected
+
+Line 26 — "Every rule this package ships is classified `provisional`." — is a statement about shipped
+rule _code_, which layering does not change. `scripts/ci/assert-rules-provisional.mjs` continues to
+assert exactly this and needs no change from this spec.
+
+### Also inaccurate, outside `DISCLAIMER.md`
+
+Not my file to change, but inside the authority contract I own, so recorded:
+
+- `docs/rule-pack-import.md:51` — "`packPermitsConformanceClaim()` returns true only for 'normative'
+  - not 'none'." — omits the `trustedRulePackIds` condition (`loader.ts:82`). Already wrong.
+- `docs/rule-pack-import.md:135` — table row `packPermitsConformanceClaim()` | `false` | `true` if
+  `conformanceClaim !== 'none'` — same omission. Both describe a **more permissive** function than
+  exists. Errs in the safe direction (code stricter than doc) but is a false contract, and layering
+  makes the table's two-column shape wrong anyway.
+- `README.md:248-249` — "term mappings, contractions and per-rule authority all come from the active
+  pack. Supply a licensed pack and diagnostics report its authority and citations instead of
+  `provisional`." — same singular-pack framing and same omission of the trust gate.
+
+---
+
+## Open questions
+
+1. **Can the bundled layer be fully evacuated?** Unanimity plus the bundled layer's
+   `provisional`/`none` metadata (`provisional-pack.ts:28,32`) means no run-level conformance claim
+   is reachable unless `replace` at the bundled layer removes it entirely. **Dependency on the merge
+   spec.** If it cannot, `stackPermitsConformanceClaim` is permanently `false` and should be
+   documented as such rather than weakened.
+2. **Does the merge algorithm report per-field contributors?** A5 (weakest-wins for field-level
+   merges) needs to know which layers contributed which surviving fields. If the merge output cannot
+   express that, the fallback is weakest-authority-among-all-layers-touching-the-key, which is
+   correct but coarse. **Dependency on the merge spec.**
+3. **Version-pinned trust entries?** Recommended (attacks 6, 11), not decided — changes the config
+   contract another agent owns.
+4. **Layer-qualified trust entries** (`"industry:@acme/std@2.1.0"`)? Closes the residual squat in
+   attack 6 that duplicate-id rejection does not. Same config-contract dependency.
+5. **`Diagnostic.provenance` required or optional?** I specify **required**, on the `reviewerKind`
+   principle. The cost is real: it is a breaking change to a public type, and every rule and
+   `buildDiagnostic` call site changes. An optional field is cheaper and reintroduces exactly the
+   ambiguity the precedent exists to remove.
+6. **Counterfactual verification of protection and limit suppression?** Attacks 3 and 4 are made
+   auditable, not detected. Detection would need a double run (with and without the weaker layer's
+   protections/limits) and a diff. That is a real design option with a real cost; I have deliberately
+   not specified it, because the cost is a performance/merge decision.
+7. **Do operator-config contributions become a real layer?** A6 gives them synthetic provenance. It
+   may be cleaner to model them as an explicit top layer in the stack rather than a synthetic origin.
+   Touches the config schema another agent owns.
+8. **`approvedTechnicalTerms` breaking change acceptable?** `string[]` →
+   `Provenanced<{term: string}>[]` is required for attack 3 and is a public API break
+   (`package.json:20-27`). No workaround exists: a string cannot carry provenance.

--- a/docs/design/64-layered-rule-packs/02-authority-trust.md
+++ b/docs/design/64-layered-rule-packs/02-authority-trust.md
@@ -210,13 +210,7 @@ New type, in `src/core/types.ts`, beside `RulePack`:
 ```ts
 /** Position in the layer stack. Fixed order, lowest precedence first. */
 export type PackLayer =
-  | 'bundled'
-  | 'organisation'
-  | 'department'
-  | 'product'
-  | 'tech-stack'
-  | 'industry'
-  | 'locale';
+  'bundled' | 'organisation' | 'department' | 'product' | 'tech-stack' | 'industry' | 'locale';
 
 /** Where a contribution came from, when it did not come from a rule pack layer. */
 export type ContributionOrigin = 'pack' | 'operator-config' | 'builtin';

--- a/docs/design/64-layered-rule-packs/02-authority-trust.md
+++ b/docs/design/64-layered-rule-packs/02-authority-trust.md
@@ -1,5 +1,11 @@
 # Layered rule packs: the trust model
 
+> **Read [`00-decisions.md`](./00-decisions.md) first.** This spec is one of three produced
+> independently, and the decision record overturns part of it: conformance claims are out of scope
+> for this project stage, which removes the destination `stackPermitsConformanceClaim` was built to
+> guard, and `replace` mode — which several sections here depend on — is dropped. Nothing below has
+> been rewritten to match, on purpose — the specs are the reasoning, `00` is the conclusion.
+
 Spec owner: authority, trust, and provenance. The merge algorithm, per-field merge keys, retraction
 syntax, conflict detection and the config zod shape are **out of scope** and are referenced here as
 given. Where this spec depends on a decision the merge-algorithm spec owns, it is flagged as a
@@ -204,7 +210,13 @@ New type, in `src/core/types.ts`, beside `RulePack`:
 ```ts
 /** Position in the layer stack. Fixed order, lowest precedence first. */
 export type PackLayer =
-  'bundled' | 'organisation' | 'department' | 'product' | 'tech-stack' | 'industry' | 'locale';
+  | 'bundled'
+  | 'organisation'
+  | 'department'
+  | 'product'
+  | 'tech-stack'
+  | 'industry'
+  | 'locale';
 
 /** Where a contribution came from, when it did not come from a rule pack layer. */
 export type ContributionOrigin = 'pack' | 'operator-config' | 'builtin';
@@ -215,9 +227,10 @@ export type ContributionOrigin = 'pack' | 'operator-config' | 'builtin';
  * Written **only** by the compositor. No supplier can assert this: it does not exist in
  * `rulePackSchema`, and it lives on `ComposedRulePack`, a type no parse path produces.
  *
- * Required and deliberately not defaulted, on the same principle as `reviewerKind`
- * (`src/fixture-tools/annotation-schema.ts:80-91`): an optional origin makes "nothing produced
- * this" indistinguishable from "we forgot to record what produced this".
+ * Required and deliberately not defaulted, on the same principle as `reviewerKind` in
+ * `src/fixture-tools/annotation-schema.ts` (which arrives with #59, not in this tree): an optional
+ * origin makes "nothing produced this" indistinguishable from "we forgot to record what produced
+ * this".
  */
 export interface EntryProvenance {
   readonly origin: ContributionOrigin;
@@ -331,7 +344,9 @@ authority only, not about _which_ entry wins.
   inherited from below.
 - **A5.** Field-level merge (if the merge algorithm does any): the composite entry's
   `verifiedAuthority` is the **weakest** across every layer that contributed any surviving field,
-  under the lattice `normative > supplementary > provisional`. `packId`/`packVersion`/`layer` name
+  under the lattice `normative > supplementary > provisional` — which is a proposal, not an existing
+  fact: `ruleStatusSchema` (`schema.ts:14`) is a bare `z.enum` and declares no ordering. `01:435`
+  carries the same caveat. `packId`/`packVersion`/`layer` name
   the top contributing layer; every other contributor appears in `displaces` with
   `kind: 'field-merge'`.
 - **A6.** Operator-config contributions (`rules.*.additional` at `vocabulary.ts:55-60` and
@@ -461,7 +476,7 @@ check completely. (This is a hole in the obvious definition; it is closed here d
 
 **Consequence the merge-algorithm spec must accommodate:** the bundled provisional layer declares
 `authority: 'provisional'` and `conformanceClaim: 'none'`
-(`src/rule-pack/provisional-pack.ts:28,32`). Under unanimity, if the bundled layer contributes
+(`src/rule-pack/provisional-pack.ts:27,31`). Under unanimity, if the bundled layer contributes
 anything at all, no run-level conformance claim is ever reachable. An operator holding a licensed
 pack must therefore be able to **fully replace** the bundled layer, not merely extend it. This is a
 dependency on the merge spec's `replace` mode, flagged, not designed here. If `replace` cannot
@@ -569,7 +584,7 @@ export interface Diagnostic {
    * What put the rule data behind this finding into the run.
    *
    * Required and not defaulted, on the `reviewerKind` principle
-   * (`src/fixture-tools/annotation-schema.ts:80-91`): "record what produced a record, on the
+   * (`src/fixture-tools/annotation-schema.ts`, arriving with #59): "record what produced a record, on the
    * record". An optional field makes "this finding has no pack origin" and "we forgot to set it"
    * the same value, and the second is the one that laundered authority.
    *
@@ -608,7 +623,7 @@ Both currently take a **run-level** authority scalar: `analyse.ts:292` and `anal
 - `undecidedCandidateDiagnostics` (`analyse.ts:535-556`) sets `ruleStatus:
 candidate.provenance.verifiedAuthority` and `provenance: candidate.provenance` per candidate,
   dropping its `ruleStatus` parameter.
-- `analyseSemantically` (`analyse.ts:600-609`) likewise drops its `ruleStatus` argument and reads it
+- `analyseSemantically` (`analyse.ts:598-609`) likewise drops its `ruleStatus` argument and reads it
   off each candidate.
 
 This is strictly more correct than today even before layering: a semantic verdict on a passage raised
@@ -695,7 +710,7 @@ All three are single-pack scalars and all three become false under layering. Rep
 `retractions` appears once at the top level alongside `conformance`, since it is a stack property,
 not a per-file one.
 
-The top-level `conformance` block (`main.ts:213-217`) keeps `disclaimer` verbatim and takes
+The top-level `conformance` block (`main.ts:218-220`) keeps `disclaimer` verbatim and takes
 `claim`/`packAuthority` from the composed stack rather than `results[0]`.
 
 **Separately**: `main.ts:266` prints, unconditionally,
@@ -951,7 +966,7 @@ Two problems. The function is being replaced by `entryPermitsConformanceClaim` /
 unconditional line at `src/cli/main.ts:266` — which this spec proposes to derive rather than
 hard-code. The replacement must state the derived behaviour: the sentence is printed whenever
 `stackPermitsConformanceClaim` is false, which is every run of the shipped configuration, because the
-bundled layer declares `provisional`/`none` (`src/rule-pack/provisional-pack.ts:28,32`).
+bundled layer declares `provisional`/`none` (`src/rule-pack/provisional-pack.ts:27,31`).
 
 ### 3. "What a passing run means" (lines 44-47) — the most important change
 
@@ -1017,7 +1032,7 @@ Not my file to change, but inside the authority contract I own, so recorded:
 ## Open questions
 
 1. **Can the bundled layer be fully evacuated?** Unanimity plus the bundled layer's
-   `provisional`/`none` metadata (`provisional-pack.ts:28,32`) means no run-level conformance claim
+   `provisional`/`none` metadata (`provisional-pack.ts:27,31`) means no run-level conformance claim
    is reachable unless `replace` at the bundled layer removes it entirely. **Dependency on the merge
    spec.** If it cannot, `stackPermitsConformanceClaim` is permanently `false` and should be
    documented as such rather than weakened.

--- a/docs/design/64-layered-rule-packs/02-authority-trust.md
+++ b/docs/design/64-layered-rule-packs/02-authority-trust.md
@@ -11,7 +11,9 @@ syntax, conflict detection and the config zod shape are **out of scope** and are
 given. Where this spec depends on a decision the merge-algorithm spec owns, it is flagged as a
 dependency, not designed.
 
-All line citations are against commit `9d78a8b`.
+Line citations were written against commit `9d78a8b`, which turned out to be a sibling of this
+branch rather than an ancestor, and have since been re-checked against the branch with `main` merged
+in. Any that still name `9d78a8b` describe that commit, not this tree.
 
 ---
 
@@ -222,9 +224,9 @@ export type ContributionOrigin = 'pack' | 'operator-config' | 'builtin';
  * `rulePackSchema`, and it lives on `ComposedRulePack`, a type no parse path produces.
  *
  * Required and deliberately not defaulted, on the same principle as `reviewerKind` in
- * `src/fixture-tools/annotation-schema.ts` (which arrives with #59, not in this tree): an optional
- * origin makes "nothing produced this" indistinguishable from "we forgot to record what produced
- * this".
+ * `src/fixture-tools/annotation-schema.ts` — that file is in this tree, but the `reviewerKind` field
+ * arrives with #59, so there is no line to cite yet. An optional origin makes "nothing produced
+ * this" indistinguishable from "we forgot to record what produced this".
  */
 export interface EntryProvenance {
   readonly origin: ContributionOrigin;
@@ -339,7 +341,7 @@ authority only, not about _which_ entry wins.
 - **A5.** Field-level merge (if the merge algorithm does any): the composite entry's
   `verifiedAuthority` is the **weakest** across every layer that contributed any surviving field,
   under the lattice `normative > supplementary > provisional` — which is a proposal, not an existing
-  fact: `ruleStatusSchema` (`schema.ts:14`) is a bare `z.enum` and declares no ordering. `01:435`
+  fact: `ruleStatusSchema` (`schema.ts:14`) is a bare `z.enum` and declares no ordering. `01:441-445`
   carries the same caveat. `packId`/`packVersion`/`layer` name
   the top contributing layer; every other contributor appears in `displaces` with
   `kind: 'field-merge'`.
@@ -578,7 +580,7 @@ export interface Diagnostic {
    * What put the rule data behind this finding into the run.
    *
    * Required and not defaulted, on the `reviewerKind` principle
-   * (`src/fixture-tools/annotation-schema.ts`, arriving with #59): "record what produced a record, on the
+   * (the `reviewerKind` field `src/fixture-tools/annotation-schema.ts` gains with #59): "record what produced a record, on the
    * record". An optional field makes "this finding has no pack origin" and "we forgot to set it"
    * the same value, and the second is the one that laundered authority.
    *
@@ -704,7 +706,7 @@ All three are single-pack scalars and all three become false under layering. Rep
 `retractions` appears once at the top level alongside `conformance`, since it is a stack property,
 not a per-file one.
 
-The top-level `conformance` block (`main.ts:218-220`) keeps `disclaimer` verbatim and takes
+The top-level `conformance` block (`main.ts:218-223`) keeps `disclaimer` verbatim and takes
 `claim`/`packAuthority` from the composed stack rather than `results[0]`.
 
 **Separately**: `main.ts:266` prints, unconditionally,

--- a/docs/design/64-layered-rule-packs/03-migration-verification.md
+++ b/docs/design/64-layered-rule-packs/03-migration-verification.md
@@ -1,13 +1,27 @@
 # Layered rule packs — migration, impact and verification
 
+> **Read [`00-decisions.md`](./00-decisions.md) first.** This spec is one of three produced
+> independently. The decision record adopts its config-key proposal over `01`'s, and moves several
+> things it takes as given from the other two specs. Nothing below has been rewritten to match, on
+> purpose — the specs are the reasoning, `00` is the conclusion.
+
 **Scope owner:** landing safety. Merge algorithm, merge keys, retraction syntax, conflict semantics,
 config zod shape, and the authority/provenance model are specified by other agents and are taken as
 given here. This document answers: what breaks, what must not silently change meaning, what tests
 must exist before merge, what documentation goes stale, and in what order the PRs ship.
 
-**Baseline commit:** `9d78a8b9999c9d4b89694cc0ca154ab9292ee10f` (detached). Every line reference
-below is against that commit and was opened, not inferred. Where a claim could not be executed in
-this worktree it says so explicitly.
+**Stage 0 precondition — not yet dischargeable.** The staged rollout below assumes the tree is
+green before the first characterisation tests land. At `9d78a8b` the suite was green (545 tests).
+At `ebcc623`, which is what this branch was actually cut from, one corpus assertion was failing
+(`test/fixtures/corpus.test.ts`, `abbreviation-introduction` not firing on `VACUUM`) — a
+pre-existing failure from #56, not caused by anything here. It was fixed by #58 and the merged base
+is green again. Re-run `npm ci && npm run verify` on the tree an implementation actually starts
+from; do not take a figure from this document as the check.
+
+**Baseline commit:** authored against `9d78a8b` (detached). That commit turned out to be a
+**sibling** of this branch rather than an ancestor of it, so every line reference below was
+re-checked against the branch after `main` was merged in, and the ones that had drifted were
+corrected. Each reference was opened, not inferred, in both passes.
 
 **Verification environment caveat:** `node_modules` is **not** installed in this worktree, so
 `npm test`, `npm run typecheck` and coverage were **not** run. Zod behaviour claims below were
@@ -22,9 +36,12 @@ The single-pack assumption is narrower than it looks in the type system and wide
 the test suite.
 
 - **Narrow in code.** Exactly **three** call sites resolve a pack (`src/analysis/analyse.ts:244`,
-  `src/evaluation/evaluate.ts:227`, `scripts/build-candidate-packets.mjs:77`), and exactly **nine**
-  places read pack _content_ (`runner.ts:51`, `analyse.ts:255`, `evaluate.ts:244`, four rule files,
-  `cli/main.ts:190-197`). A composite `RulePack` that satisfies the existing `RulePack` interface
+  `src/evaluation/evaluate.ts:227`, `scripts/build-candidate-packets.mjs:77`), and **eleven**
+  places across seven files read pack _content_ — the measurement is
+  `grep -rn 'pack\.\(rules\|dictionary\|contractions\|approvedTechnicalTerms\|limits\)' src/`
+  (`runner.ts:51`, `analyse.ts:255`, `evaluate.ts:244`, and the four rule files: `vocabulary.ts` ×3,
+  `sentence-length.ts` ×3, `structure-rules.ts`, `candidate-rules.ts`). `cli/main.ts:190-196` reads
+  pack _metadata_, which is a separate surface and is treated as one in `02`. A composite `RulePack` that satisfies the existing `RulePack` interface
   (`src/core/types.ts:474-486`) would require **no change at all** to the rule layer.
 - **Wide in the test suite — dangerously so.** **Zero** tests import
   `src/rule-pack/loader.ts`. `resolveRulePack`, `loadRulePackFromFile`, `parseRulePack`,
@@ -71,7 +88,7 @@ Every row cites a file and line opened at the baseline commit.
 | A4  | `src/rule-pack/loader.ts:76-83` `packPermitsConformanceClaim(pack, trustedIds)` | Reads `pack.metadata.authority` / `.conformanceClaim` / `.id` — **a single identity**.                                                        | A merged pack has N identities and N licences. Authority agent owns the semantics; this call site must be updated in lockstep with `cli/main.ts:193-197`.                                                                                                                                                                                                                       |
 | A5  | `src/rule-pack/loader.ts:92-98` `verifiedAuthority(pack, trustedIds)`           | Same single-identity assumption; `:97` `trustedIds.includes(pack.metadata.id)`.                                                               | Same. Called from `analyse.ts:292`, `analyse.ts:607`, `cli/main.ts:190`.                                                                                                                                                                                                                                                                                                        |
 | A6  | `src/rule-pack/index.ts:1-3` + `package.json:22-25` (`"./rule-pack"` export)    | `export * from './loader.js'` makes `resolveRulePack`'s **signature a public API**.                                                           | Any signature change is a semver-visible break for external consumers, not just an internal refactor. Additive overload or a new `resolveRulePacks` beside the old one is the low-risk shape.                                                                                                                                                                                   |
-| A7  | `src/rule-pack/provisional-pack.ts:22` `provisionalRulePack`                    | The one bundled pack; `metadata.id: 'ste-ai-provisional'` (`:26`), `authority: 'provisional'`, `conformanceClaim: 'none'` (`:29`,`:32`).      | Becomes layer 0 (bundled) in the layer order. Its identity must survive merge in a form `assert-corpus-report.mjs:36` can still see as `provisional`.                                                                                                                                                                                                                           |
+| A7  | `src/rule-pack/provisional-pack.ts:22` `provisionalRulePack`                    | The one bundled pack; `metadata.id: 'ste-ai-provisional'` (`:24`), `authority: 'provisional'`, `conformanceClaim: 'none'` (`:27`,`:31`).      | Becomes layer 0 (bundled) in the layer order. Its identity must survive merge in a form `assert-corpus-report.mjs:36` can still see as `provisional`.                                                                                                                                                                                                                           |
 
 ### B. Config
 
@@ -126,7 +143,7 @@ Every row cites a file and line opened at the baseline commit.
 | #   | File:line                                                                                                                  | What it assumes                                                                           | What has to change                                                                                                                                                                                                          |
 | --- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | F1  | `src/cli/main.ts:190-197` per-file `packAuthority` / `declaredAuthority` / `conformanceClaim`                              | One pack → one authority, one declared authority, one claim.                              | Follows A4/A5. `declaredAuthority` (`:191`, `analysis.pack.metadata.authority`) has no meaning for a merged pack without a provenance model.                                                                                |
-| F2  | `src/cli/main.ts:217-219` `conformance: { claim: results[0]?.conformanceClaim, packAuthority: results[0]?.packAuthority }` | **The whole run's conformance block is taken from the first file.**                       | Latent single-pack reporting bug today (all files share one config so it happens to be right). With layers it stays right only by accident. `scripts/ci/assert-corpus-report.mjs:32-45` asserts against exactly this block. |
+| F2  | `src/cli/main.ts:218-220` `conformance: { claim: results[0]?.conformanceClaim, packAuthority: results[0]?.packAuthority }` | **The whole run's conformance block is taken from the first file.**                       | Latent single-pack reporting bug today (all files share one config so it happens to be right). With layers it stays right only by accident. `scripts/ci/assert-corpus-report.mjs:32-45` asserts against exactly this block. |
 | F3  | `src/cli/main.ts:277-296` `listRules`                                                                                      | Enumerates `deterministicRules` and reports `r.meta.status` — **never touches the pack**. | **No change required.** This is why `check-rules-provisional.sh`'s hard-coded `14` is not at risk (see Fixture & corpus impact). Do not make `rules` pack-aware in this change.                                             |
 
 ### G. Scripts and CI
@@ -234,7 +251,7 @@ state clearly I did not.
    all verified in the rule code: `pack.rules` duplicates are last-wins via `Map`
    (`runner.ts:51`, executed: `new Map([['a',1],['a',2]]).get('a') === 2`); `dictionary.unapproved`
    and `.preferred` duplicates are decided by post-sort array order plus the `claimed` first-wins
-   guard (`vocabulary.ts:63,68-70,172`); `contractions` duplicates are **not** deduplicated at all
+   guard (`vocabulary.ts:64,68-70,172`); `contractions` duplicates are **not** deduplicated at all
    and produce two diagnostics on one span (`vocabulary.ts:236-275` — no `claimed` guard).
    Only the third is loud (it changes visible output and will break `textlint-tester.test.ts`); the
    first two are silent. _Mitigation:_ merge must key `rules` by `ruleId`, `unapproved`/`approved`
@@ -260,7 +277,7 @@ principle and any signature change is semver-visible to them.
 
 ## Test strategy
 
-Conventions observed in `test/`: vitest with `globals: true` (`vitest.config.ts:8`), explicit
+Conventions observed in `test/`: vitest with `globals: true` (`vitest.config.ts:10`), explicit
 `import { describe, expect, it } from 'vitest'` in project-owned tests, `mkdtempSync(join(tmpdir(),
 ...))` + `afterEach` cleanup for filesystem cases (`shared-config-merge.test.ts:29-37`), long
 `/** … */` block comments stating _why_ a test exists and what regression it guards
@@ -268,7 +285,7 @@ Conventions observed in `test/`: vitest with `globals: true` (`vitest.config.ts:
 (`clearSharedConfigCache`, `clearAnalysisCache`).
 
 Coverage thresholds are enforced only under `--coverage` (`vitest.config.ts:15-35`: statements 91,
-branches 81, functions 91, lines 94) and CI runs `test:coverage` (`ci.yml:47`). New unreached
+branches 81, functions 91, lines 94) and CI runs `test:coverage` (`ci.yml:45`). New unreached
 branches in `src/rule-pack/` will pull these down, so tests are not optional for the thresholds
 either.
 
@@ -364,7 +381,7 @@ need of updating. State that in the PR description so a reviewer does not "fix" 
   `annotation.candidateAdjudications` (`:365-366`) — static JSON in `fixtures/annotations/*.json`,
   merged in from `fixtures/verdicts/`. **The linter is not consulted.** Layering cannot move this
   number. Same for `corpus.test.ts:376-389` (`noun-cluster-candidate` → `{violation: 0, total: 24}`)
-  and for the 105/5/100 table in `docs/provisional-rules.md:265-271`.
+  and for the 105/5/100 table in `docs/provisional-rules.md:262-268`.
 - **`scripts/ci/check-rules-provisional.sh:20`'s hard-coded `14`.** It lints the output of
   `ste-ai rules --json`, which `listRules` (`cli/main.ts:277-296`) builds from the
   `deterministicRules` registry and `r.meta.status` — **never from the pack**.
@@ -395,7 +412,7 @@ Every one of the following calls `analyseTextDeterministic(text)` **with no conf
 (`docs/fixtures.md:179-180`). The correct posture is therefore _not_ to update the fixture
 expectations, but to treat any movement in them as a stop-the-line signal.
 
-**One documentation dependency:** `docs/fixtures.md:194` ("violation count never increases after a
+**One documentation dependency:** the "Corpus tests" table in `docs/fixtures.md` ("violation count never increases after a
 rewrite") and the surrounding invariant table at `:189-201` describe corpus assertions accurately
 today. They stay accurate. No fixture, manifest, annotation or verdict file needs to change.
 
@@ -534,7 +551,7 @@ baseline commit.
 
 - `docs/fixtures.md` — no pack-dependent claim (verified by grep: the only "pack" hits are
   unrelated). No change.
-- `docs/provisional-rules.md:265-271` (the 105/5/100 table) — annotation-derived, not linter-derived.
+- `docs/provisional-rules.md:262-268` (the 105/5/100 table) — annotation-derived, not linter-derived.
   No change.
 - `docs/diagnostic-policy.md`, `docs/suppression.md`, `docs/semantic-evaluators.md`,
   `docs/llama-cpp-setup.md` — no single-pack claim.
@@ -638,7 +655,7 @@ edits into Stage 3 instead and keep only the roadmap/README prose for last.
 Things that could go wrong which the tests above would **not** catch.
 
 1. **Merge is correct but non-deterministic across platforms.** The merge output feeds
-   `vocabulary.ts:63` (`sort((a,b) => b.term.length - a.term.length)`) — a comparator with ties, and
+   `vocabulary.ts:64` (`sort((a,b) => b.term.length - a.term.length)`) — a comparator with ties, and
    `Array.prototype.sort` stability preserves _input_ order for ties. If the merge builds its output
    from a `Map`/`Set` whose insertion order varies with layer file read order (e.g. a
    `Promise.all` over layer loads), two runs can differ in which of two equal-length terms claims a
@@ -668,7 +685,7 @@ Things that could go wrong which the tests above would **not** catch.
    `licence` or `notice` in output at all (grep: no consumer outside the schema/type), so a merge
    that drops them loses an audit trail **without any test failing** — the field is validated on the
    way in and never read on the way out. Given this repo's posture on provenance
-   (`docs/DISCLAIMER.md`, `docs/fixtures.md:145-170`), silently losing per-layer licence text is a
+   (`docs/DISCLAIMER.md`, the "How the adjudication was run" section of `docs/fixtures.md`), silently losing per-layer licence text is a
    real harm that the test suite is structurally incapable of detecting. **Mitigation:** the
    provenance model must retain per-layer `licence`/`notice`, and a test must assert they survive
    the merge even though nothing consumes them yet.
@@ -680,7 +697,7 @@ Things that could go wrong which the tests above would **not** catch.
    not once per process. The adapter's analysis cache hides this for textlint, but the CLI resolves
    per file (`cli/main.ts:161-183` loops files, each calling `analyseText`). A 500-file lint would
    do 3500 file reads and 3500 schema validations. No test measures this; `testTimeout: 20_000`
-   (`vitest.config.ts:9`) is generous enough to hide it. **Mitigation:** memoise resolved layers by
+   (`vitest.config.ts:11`) is generous enough to hide it. **Mitigation:** memoise resolved layers by
    (absolute path, mtime/size) inside the loader, and say so in the docs.
 
 6. **Zod default application on every layer.** `schema.ts:41,47,54,88,97-103` apply `.default()` to

--- a/docs/design/64-layered-rule-packs/03-migration-verification.md
+++ b/docs/design/64-layered-rule-packs/03-migration-verification.md
@@ -1,0 +1,709 @@
+# Layered rule packs — migration, impact and verification
+
+**Scope owner:** landing safety. Merge algorithm, merge keys, retraction syntax, conflict semantics,
+config zod shape, and the authority/provenance model are specified by other agents and are taken as
+given here. This document answers: what breaks, what must not silently change meaning, what tests
+must exist before merge, what documentation goes stale, and in what order the PRs ship.
+
+**Baseline commit:** `9d78a8b9999c9d4b89694cc0ca154ab9292ee10f` (detached). Every line reference
+below is against that commit and was opened, not inferred. Where a claim could not be executed in
+this worktree it says so explicitly.
+
+**Verification environment caveat:** `node_modules` is **not** installed in this worktree, so
+`npm test`, `npm run typecheck` and coverage were **not** run. Zod behaviour claims below were
+executed against `/home/user/textlint-rule-preset-ste-ai/node_modules/zod` (v4.4.3) directly and are
+marked as executed. Everything else is static reading.
+
+---
+
+## Summary
+
+The single-pack assumption is narrower than it looks in the type system and wider than it looks in
+the test suite.
+
+- **Narrow in code.** Exactly **three** call sites resolve a pack (`src/analysis/analyse.ts:244`,
+  `src/evaluation/evaluate.ts:227`, `scripts/build-candidate-packets.mjs:77`), and exactly **nine**
+  places read pack _content_ (`runner.ts:51`, `analyse.ts:255`, `evaluate.ts:244`, four rule files,
+  `cli/main.ts:190-197`). A composite `RulePack` that satisfies the existing `RulePack` interface
+  (`src/core/types.ts:474-486`) would require **no change at all** to the rule layer.
+- **Wide in the test suite — dangerously so.** **Zero** tests import
+  `src/rule-pack/loader.ts`. `resolveRulePack`, `loadRulePackFromFile`, `parseRulePack`,
+  `verifiedAuthority` and `packPermitsConformanceClaim` have no direct test anywhere in `test/`
+  (verified by grep across the whole `test/` tree; the only rule-pack imports are three
+  `provisionalRulePack` imports and the module-boundary allow-list). **The back-compatibility path
+  this change must preserve is currently unpinned.** Stage 0 of the rollout exists solely to fix
+  that before anything is refactored.
+- **The dangerous silent-change class is real and it is naming.** `steAiConfigSchema`
+  (`src/core/config.ts:119`) is a plain `z.object` with no `.strict()`; zod 4.4.3 **strips** unknown
+  keys silently (executed). A _new_ config key (`rulePacks`, `packs`, `layers`…) is therefore
+  silently discarded by every already-released version, and by any half-upgraded consumer — a
+  config that says "lint against the Acme normative pack" degrades to "lint against the bundled
+  provisional pack" with no error. By contrast, `rulePack: [...]` (an array under the **existing**
+  key) is **rejected** by the current union (`z.union([z.string(), z.record(...)])`,
+  `config.ts:124`) — executed: `Invalid input`. **Recommendation: widen the existing `rulePack` key
+  rather than introduce a new one.** Old versions then fail loud instead of failing quiet.
+- **Corpus numbers are safer than they look.** The exact class balance
+  `{violation: 5, 'non-violation': 100, undecidable: 0}` (`test/fixtures/corpus.test.ts:373`) and
+  the per-rule `{violation: 0, total: 24}` (`:388`) are computed from
+  `annotation.candidateAdjudications` — static JSON in `fixtures/annotations/` — **not** from linter
+  output. Layering cannot move them. What layering _can_ break is
+  `corpus.test.ts:327-341` and `scripts/ci/check-candidate-ground-truth.sh`, which do run the
+  linter. Both are safe iff the no-config default path still resolves to exactly
+  `provisionalRulePack` (`loader.ts:53`).
+- **`check-rules-provisional.sh 14` is not at risk** from layering as such: `listRules`
+  (`src/cli/main.ts:277-296`) enumerates the `deterministicRules` code registry and reports
+  `r.meta.status`, never the pack. It becomes at risk only if the layering work makes the `rules`
+  command pack-aware — which it should not, in this change.
+
+---
+
+## Blast radius inventory
+
+Every row cites a file and line opened at the baseline commit.
+
+### A. Pack resolution (the boundary itself)
+
+| #   | File:line                                                                       | What it assumes                                                                                                                               | What has to change                                                                                                                                                                                                                                                                                                                                                              |
+| --- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | `src/rule-pack/loader.ts:49-56` `resolveRulePack(spec, baseDir): RulePack`      | Config carries **one** spec (`string \| Record \| undefined`) and the function returns **one** pack. `:53` `undefined → provisionalRulePack`. | Becomes the composition entry point. Must accept an ordered layer list, resolve each, and hand the sequence to the merge module. Must keep `undefined → provisionalRulePack` byte-identical (see back-compat).                                                                                                                                                                  |
+| A2  | `src/rule-pack/loader.ts:15-24` `parseRulePack(value, origin)`                  | Validates a **whole** pack: `metadata`, `limits`, `dictionary` all required (`schema.ts:93-104`).                                             | A non-base layer that only adds vocabulary cannot satisfy `metadata`/`limits` today. Either every layer ships full metadata+limits, or a second "fragment" parse path is needed. This is the merge agent's schema call; the _impact_ is that `parseRulePack`'s single error shape (`RulePackError`, `:21`) currently names one origin and must now name **which layer** failed. |
+| A3  | `src/rule-pack/loader.ts:26-41` `loadRulePackFromFile(path, baseDir)`           | One file, one `baseDir`, relative resolution against `resolve(baseDir, path)` (`:27`).                                                        | Called N times. Two hazards: (a) a layer path relative to _which_ base — the config file's directory or the caller's `baseDir`; (b) cycle/self-reference if a layer may itself declare layers. Neither exists today.                                                                                                                                                            |
+| A4  | `src/rule-pack/loader.ts:76-83` `packPermitsConformanceClaim(pack, trustedIds)` | Reads `pack.metadata.authority` / `.conformanceClaim` / `.id` — **a single identity**.                                                        | A merged pack has N identities and N licences. Authority agent owns the semantics; this call site must be updated in lockstep with `cli/main.ts:193-197`.                                                                                                                                                                                                                       |
+| A5  | `src/rule-pack/loader.ts:92-98` `verifiedAuthority(pack, trustedIds)`           | Same single-identity assumption; `:97` `trustedIds.includes(pack.metadata.id)`.                                                               | Same. Called from `analyse.ts:292`, `analyse.ts:607`, `cli/main.ts:190`.                                                                                                                                                                                                                                                                                                        |
+| A6  | `src/rule-pack/index.ts:1-3` + `package.json:22-25` (`"./rule-pack"` export)    | `export * from './loader.js'` makes `resolveRulePack`'s **signature a public API**.                                                           | Any signature change is a semver-visible break for external consumers, not just an internal refactor. Additive overload or a new `resolveRulePacks` beside the old one is the low-risk shape.                                                                                                                                                                                   |
+| A7  | `src/rule-pack/provisional-pack.ts:22` `provisionalRulePack`                    | The one bundled pack; `metadata.id: 'ste-ai-provisional'` (`:26`), `authority: 'provisional'`, `conformanceClaim: 'none'` (`:29`,`:32`).      | Becomes layer 0 (bundled) in the layer order. Its identity must survive merge in a form `assert-corpus-report.mjs:36` can still see as `provisional`.                                                                                                                                                                                                                           |
+
+### B. Config
+
+| #   | File:line                                                                                                | What it assumes                                                                                                   | What has to change                                                                                                                                                                                                      |
+| --- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | `src/core/config.ts:124` `rulePack: z.union([z.string(), z.record(z.string(), z.unknown())]).optional()` | Exactly one spec, string-or-object.                                                                               | Owned by the config-shape agent. **Impact note (executed):** the union currently _rejects_ an array — widening this key gives old versions a loud failure; a brand-new sibling key gives them a silent one.             |
+| B2  | `src/core/config.ts:119` `steAiConfigSchema = z.object({...})` — **no `.strict()`**                      | Unknown keys are silently stripped (executed against zod 4.4.3: `parse({a:'x', rulePacks:[...]})` → `{"a":"x"}`). | The single largest silent-meaning-change vector. Either widen `rulePack` (B1) or add `.strict()`/`.catchall(z.never())` — but note `.strict()` is itself a breaking change for any config carrying editor-comment keys. |
+| B3  | `src/core/config.ts:133` `trustedRulePackIds: z.array(z.string())`                                       | One id list matched against **one** `metadata.id`.                                                                | Authority agent's call; the _impact_ is that trust becomes per-layer and the CLI/analysis call sites (A4, A5) change together.                                                                                          |
+| B4  | `src/core/index.ts:7` `export * from './config.js'` + `package.json` `"./core"` export                   | `SteAiConfig`/`SteAiConfigInput` are public types.                                                                | A type widening on `rulePack` is source-visible to typed consumers.                                                                                                                                                     |
+
+### C. Composition roots
+
+| #   | File:line                                                                                                | What it assumes                                                             | What has to change                                                                                                                                                                                                                                              |
+| --- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | `src/analysis/analyse.ts:244` `resolveRulePack(config.rulePack, options.baseDir ?? process.cwd())`       | Single spec, single baseDir.                                                | Primary migration point.                                                                                                                                                                                                                                        |
+| C2  | `src/analysis/analyse.ts:190` doc comment: "Base directory used to resolve a relative `rulePack` path."  | Singular.                                                                   | Reword for N layers.                                                                                                                                                                                                                                            |
+| C3  | `src/analysis/analyse.ts:219`, `:238` `readonly pack: RulePack` on `AnalysisResult`                      | One pack is the public result surface.                                      | If layering is to be auditable, the result needs the layer list/provenance too. Adding a field is additive; **changing** `pack` is a public break (`package.json` `"./analysis"` export). Keep `pack` as the merged effective pack; add `packLayers` beside it. |
+| C4  | `src/analysis/analyse.ts:255` `approvedTerms: [...config.approvedTerms, ...pack.approvedTechnicalTerms]` | One flat list from one pack.                                                | Reads the merged pack; correct as long as merge produces a deduplicated `approvedTechnicalTerms`. A duplicated term here is harmless (it feeds a protected-region matcher) — worth confirming, not assuming.                                                    |
+| C5  | `src/analysis/analyse.ts:292`, `:607` `verifiedAuthority(pack, config.trustedRulePackIds)`               | Single-pack authority stamps every semantic and review-required diagnostic. | Follows A5.                                                                                                                                                                                                                                                     |
+| C6  | `src/evaluation/evaluate.ts:227` `resolveRulePack(config.rulePack)` — **no `baseDir`**                   | Relative layer paths resolve against `process.cwd()`.                       | Already a latent inconsistency with C1; N layers multiplies it. Either thread a baseDir or document cwd-relative explicitly.                                                                                                                                    |
+| C7  | `src/evaluation/evaluate.ts:244` `[...config.approvedTerms, ...pack.approvedTechnicalTerms]`             | As C4.                                                                      | As C4.                                                                                                                                                                                                                                                          |
+
+### D. Rule execution (reads pack _content_)
+
+| #   | File:line                                                                                                                                               | What it assumes                                                                                                                             | What has to change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | `src/core/runner.ts:24` `readonly pack: RulePack` on `RunOptions`                                                                                       | One pack per run.                                                                                                                           | **Nothing**, if the merge yields a value satisfying `RulePack` (`types.ts:474-486`). This is the change's biggest piece of luck and should be defended deliberately.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| D2  | `src/core/runner.ts:51` `new Map(pack.rules.map(r => [r.ruleId, r]))`                                                                                   | `pack.rules` has at most one spec per `ruleId`.                                                                                             | **Silent last-wins on duplicates** (executed: `new Map([['a',1],['a',2]]).get('a') === 2`). If merge concatenates `rules` arrays instead of keying them, the effective spec is whichever layer happens to be later — no error, no notice. Merge must key `rules` by `ruleId`; this line is the reason.                                                                                                                                                                                                                                                                  |
+| D3  | `src/core/runner.ts:57-65` `packSpec?.enabled`, `{...packSpec?.options, ...userConfig}`                                                                 | One spec supplies `enabled` and `options`.                                                                                                  | Consumes D2's output. Retraction semantics (`enabled:false` from a higher layer) land here.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D4  | `src/core/runner.ts:79` `userConfig.severity ?? packSpec?.severity`                                                                                     | One pack severity.                                                                                                                          | As D3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| D5  | `src/core/runner.ts:96-99`, `:139-146` `verifiedRuleStatus(packSpec.status, pack, trustedIds)`                                                          | The rule's status is verified against **the** pack's `metadata.id`.                                                                         | With layers, the rule spec and the identity that vouches for it come from _different_ layers. This function must take the **contributing layer's** identity, not the merged pack's. This is the sharpest coupling between my scope and the authority agent's.                                                                                                                                                                                                                                                                                                           |
+| D6  | `src/core/runner.ts:110` `sourceRef: packSpec?.sourceRef ?? ''`                                                                                         | The citation travels with the spec.                                                                                                         | Must travel with the winning layer's spec, per D5.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| D7  | `src/core/rule.ts:18` `readonly pack: RulePack` on `RuleInput`                                                                                          | Rules see one pack.                                                                                                                         | Unchanged if merge yields a `RulePack`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| D8  | `src/deterministic/rules/vocabulary.ts:54`, `:63`, `:68-70`                                                                                             | `pack.dictionary.unapproved` is deduplicated; entries sorted longest-first; `claimed` makes the **first** entry in sorted order win a span. | Duplicate `term` across layers → the survivor is decided by array order after a length sort (ties unspecified). The _other_ layer's `alternatives`/`safeSubstitution` are silently dropped. Merge must dedupe by term.                                                                                                                                                                                                                                                                                                                                                  |
+| D9  | `src/deterministic/rules/vocabulary.ts:165`, `:172`                                                                                                     | Same, for `dictionary.preferred` keyed on `from`.                                                                                           | Same.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| D10 | `src/deterministic/rules/vocabulary.ts:236-275` `noContractionsRule`                                                                                    | `pack.contractions` is deduplicated — **there is no `claimed` guard in this rule**.                                                         | **Duplicate `from` across layers emits duplicate diagnostics on the same span.** Both fixes then hit `resolveOverlappingFixes` (`runner.ts:256-262`): identical range+text is "not a conflict" but the second is still added to `conflicting`, so one diagnostic keeps its fix and the other gets `" (No automatic fix: another rule proposes an overlapping edit.)"` appended. Visible, wrong, and it will break the exact-message assertions in `test/e2e/textlint-tester.test.ts:88-108`. This is the most concrete merge-correctness requirement my scope produces. |
+| D11 | `src/deterministic/rules/sentence-length.ts:28-30` `pack.limits.proceduralMaxGradeLevel` / `descriptiveMaxGradeLevel` / `sentenceReadabilityFloorWords` | Scalars — exactly one value each.                                                                                                           | Scalars cannot "merge"; they are last-layer-wins by construction. The spec must say so, and a test must pin which layer wins.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| D12 | `src/deterministic/rules/structure-rules.ts:43` `pack.limits.maxSentencesPerProceduralStep`                                                             | As D11.                                                                                                                                     | As D11.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| D13 | `src/deterministic/rules/candidate-rules.ts:331` `pack.limits.maxNounClusterLength`                                                                     | As D11.                                                                                                                                     | As D11.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+
+### E. textlint adapter
+
+| #   | File:line                                                                                           | What it assumes                                                                     | What has to change                                                                                                                                                                                                                                                                                                                                                                  |
+| --- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| E1  | `src/textlint/adapter.ts:154-161` `{...sharedFile.config, ...shared, rules: mergedRules}`           | A **shallow** top-level spread; `rules` is the only key merged deeply.              | If the layered field is a **new** key, a `.ste-ai.json` setting `rulePack` and an inline `shared` setting `rulePacks` produce a config carrying **both**, with precedence decided by `resolveRulePack`, not by this merge — a config whose meaning depends on a resolution order nobody wrote down. Widening `rulePack` (B1) makes this a plain last-wins spread with no ambiguity. |
+| E2  | `src/textlint/adapter.ts:48-51` `cacheKey(text, '*', config, baseDir)`                              | The cache keys on config **text**, not on the _contents_ of the pack file it names. | Already true for one pack; N layers multiplies the staleness surface (edit a layer file, get a cached analysis). Not introduced by this change, but it gets N times more likely. Call it out; do not fix it in this change.                                                                                                                                                         |
+| E3  | `src/textlint/shared-config.ts:52-65` `loadSharedConfig` memoised by `baseDir`                      | One config file per baseDir, cached process-wide.                                   | Unchanged, but the same staleness note as E2 applies to layer files it references.                                                                                                                                                                                                                                                                                                  |
+| E4  | `src/textlint/adapter.ts:192` `diagnostic.ruleStatus === 'normative' ? ... : diagnostic.ruleStatus` | The `[provisional]` message tag comes straight from `ruleStatus`.                   | Unchanged if D5 keeps producing a correct per-diagnostic status. This line is what `test/e2e/textlint-tester.test.ts` asserts on.                                                                                                                                                                                                                                                   |
+
+### F. CLI
+
+| #   | File:line                                                                                                                  | What it assumes                                                                           | What has to change                                                                                                                                                                                                          |
+| --- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | `src/cli/main.ts:190-197` per-file `packAuthority` / `declaredAuthority` / `conformanceClaim`                              | One pack → one authority, one declared authority, one claim.                              | Follows A4/A5. `declaredAuthority` (`:191`, `analysis.pack.metadata.authority`) has no meaning for a merged pack without a provenance model.                                                                                |
+| F2  | `src/cli/main.ts:217-219` `conformance: { claim: results[0]?.conformanceClaim, packAuthority: results[0]?.packAuthority }` | **The whole run's conformance block is taken from the first file.**                       | Latent single-pack reporting bug today (all files share one config so it happens to be right). With layers it stays right only by accident. `scripts/ci/assert-corpus-report.mjs:32-45` asserts against exactly this block. |
+| F3  | `src/cli/main.ts:277-296` `listRules`                                                                                      | Enumerates `deterministicRules` and reports `r.meta.status` — **never touches the pack**. | **No change required.** This is why `check-rules-provisional.sh`'s hard-coded `14` is not at risk (see Fixture & corpus impact). Do not make `rules` pack-aware in this change.                                             |
+
+### G. Scripts and CI
+
+| #   | File:line                                                                                                                                                            | What it assumes                                                                                               | What has to change                                                                                                                                                                                                                                                               |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| G1  | `scripts/build-candidate-packets.mjs:51`, `:77` `const {resolveRulePack} = await distImport('rule-pack','loader.js'); const pack = resolveRulePack(config.rulePack)` | The exact `resolveRulePack` name and its `(spec)` positional signature, imported from **`dist/`** at runtime. | **This is `.mjs`, and `tsconfig.json:25` includes `scripts` but sets no `allowJs` — so it is not typechecked.** A signature change here fails at CI runtime (`scripts/ci/check-candidate-ground-truth.sh`), never at `npm run typecheck`. Highest-surprise row in the inventory. |
+| G2  | `scripts/ci/check-candidate-ground-truth.sh` (runs G1, then `merge-candidate-verdicts.mjs --check`)                                                                  | Every candidate the linter emits under the default config still has a bound reviewer verdict.                 | Safe iff the default path is byte-identical. This script is the tripwire that proves it.                                                                                                                                                                                         |
+| G3  | `scripts/ci/check-rules-provisional.sh:20` `node scripts/ci/assert-rules-provisional.mjs "$rules" 14`                                                                | Exactly 14 rules, all reporting `provisional`.                                                                | **Unchanged by layering** (see F3). Would only need reconciling if a rule is added/removed — which this change must not do.                                                                                                                                                      |
+| G4  | `scripts/ci/assert-rules-provisional.mjs:34` `rules.filter(r => r.status !== 'provisional')`                                                                         | `status` is the rule's own `meta.status`.                                                                     | As G3.                                                                                                                                                                                                                                                                           |
+| G5  | `scripts/ci/assert-corpus-report.mjs:32-45` `report.conformance.claim === 'none'` and `report.conformance.packAuthority === 'provisional'`                           | The default run reports the bundled pack's identity.                                                          | Safe iff default path unchanged **and** F1/F2 keep emitting the same two strings for a bundled-only run. If the authority model renames or restructures the conformance block, this script must be reconciled in the same PR.                                                    |
+| G6  | `scripts/ci/check-exit-codes.sh` (0/1/2 contract over `fixtures/original/*.md`)                                                                                      | Default config produces ≥1 error-severity diagnostic on the corpus and none on `Remove the cover.`            | Safe iff default path unchanged. A merge bug that duplicates diagnostics (D10) does not flip an exit code, so this script will **not** catch it — `corpus.test.ts` and the e2e message assertions will.                                                                          |
+| G7  | `.github/workflows/ci.yml:29-56` step order: typecheck → lint → `build:clean` → `test:coverage` → validate-fixtures → exit-codes → rules-provisional → ground-truth  | `dist/` freshness matters (G1 and `check-candidate-ground-truth.sh` refuse a stale build).                    | No change, but note every new `scripts/ci` assertion must be added here or it does not run.                                                                                                                                                                                      |
+
+### H. Tests that encode the current shape
+
+| #   | File:line                                                                                                                          | What it assumes                                                                                              | What has to change                                                                                                                                                                                                                                                                                                                                                       |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| H1  | `test/architecture/module-boundaries.test.ts:16-34` `ALLOWED` map; `:82-87` "every top-level module is declared in the allow list" | The set of `src/` top-level directories is fixed, and `rule-pack: ['core']` (`:23`).                         | If merge code lands in a **new** top-level module, this test fails until `ALLOWED` gains a row — and every consumer module (`deterministic`, `analysis`, `textlint`, `cli`, `evaluation`, `fixture-tools`, `semantic`) needs the new name added. **Strong argument for keeping merge inside `src/rule-pack/`**, which also keeps it restricted to importing `core` only. |
+| H2  | `test/unit/rules.test.ts:36`, `:658` `pack: provisionalRulePack`                                                                   | Tests construct `RunOptions` with a literal pack, bypassing resolution entirely.                             | No change needed — and this is exactly the seam that lets a merged pack be tested by handing `runDeterministicRules` a merge result.                                                                                                                                                                                                                                     |
+| H3  | `test/unit/rules.test.ts:678-679` "every shipped rule declares provisional status"                                                 | Rule `meta.status`, not pack status.                                                                         | No change (mirrors F3/G3).                                                                                                                                                                                                                                                                                                                                               |
+| H4  | `test/unit/fix-safety.test.ts:206`, `test/unit/pipeline-smoke.test.ts:38`                                                          | As H2.                                                                                                       | As H2.                                                                                                                                                                                                                                                                                                                                                                   |
+| H5  | `test/e2e/textlint-tester.test.ts:88-213`                                                                                          | Exact diagnostic message strings including the `[provisional]` tag and the `(No automatic fix: …)` suffixes. | **No change expected — and that is the point.** These are the highest-value regression net for D10 (duplicate contraction entries) and E4 (status tag). Any diff here during the rollout is a merge bug, not a test that needs updating.                                                                                                                                 |
+| H6  | `test/e2e/textlint-run.test.ts:104` `toContain('[deterministic-violation][provisional]')`                                          | As H5.                                                                                                       | As H5.                                                                                                                                                                                                                                                                                                                                                                   |
+| H7  | `test/e2e/example-config.test.ts:66-73` `steAiConfigSchema.safeParse(examples/.ste-ai.json)`                                       | The shipped example validates.                                                                               | Because the schema strips unknown keys (B2), this test would **pass** on an example using a mistyped layered key. If the example gains a layered config, this test must be strengthened to assert the parsed value actually _contains_ the layers, not merely that parsing succeeded.                                                                                    |
+| H8  | `test/integration/shared-config-merge.test.ts:39-63`                                                                               | Pins that `getAnalysis`'s shallow spread preserves a file-set field the inline `shared` never mentions.      | Directly relevant to E1. Gains a case: a file-set pack layer list must survive an inline `shared` that never mentions packs.                                                                                                                                                                                                                                             |
+| H9  | `test/fixtures/corpus.test.ts` (see Fixture & corpus impact)                                                                       | Default-config linter behaviour over 18 fixtures.                                                            | No change expected; it is the tripwire.                                                                                                                                                                                                                                                                                                                                  |
+
+---
+
+## Back-compatibility analysis
+
+### What each existing config does after the change
+
+| Existing config                                                                          | Today                                                                                                   | Required after                                                                                                                                                                                                                                                             |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No `rulePack` key at all (this is `examples/.ste-ai.json` — it has none)                 | `loader.ts:53` returns `provisionalRulePack` by identity                                                | **Byte-identical.** Must return `provisionalRulePack` itself, not a one-element merge of it. A merge that clones/normalises could reorder `dictionary.unapproved` and change which term wins a span at `vocabulary.ts:68-70`. Identity return is the safe contract.        |
+| `"rulePack": "./pack.json"` (`docs/configuration.md:78`, `docs/rule-pack-import.md:116`) | `loader.ts:54` → `loadRulePackFromFile(spec, baseDir)`; the file **replaces** the bundled pack entirely | Must remain a **replace**, not become "bundled + this". Turning the historical single-pack meaning into an implicit extend would change behaviour for every existing user: bundled unapproved terms would come back for someone who deliberately supplied a narrower pack. |
+| `{ rulePack: myPackObject }` programmatically (`docs/rule-pack-import.md:122`)           | `loader.ts:55` → `parseRulePack(spec, 'inline configuration')`                                          | Same: replace.                                                                                                                                                                                                                                                             |
+| `rulePack` with an invalid pack                                                          | `RulePackError` naming the origin and field paths (`loader.ts:21`)                                      | Must still throw, still name the origin. With layers the message must additionally name the layer.                                                                                                                                                                         |
+| `rulePack: ["a.json","b.json"]`                                                          | **Rejected** by the union (`config.ts:124`) — executed against zod 4.4.3: `Invalid input`               | This is the free lunch: an array under the existing key is already a loud error, so old versions reject a new-style config instead of misinterpreting it.                                                                                                                  |
+| `trustedRulePackIds: ["acme-ste-2026"]` with a single normative pack                     | `verifiedAuthority` → `normative` (`loader.ts:97`); diagnostics tagged `[normative]` (`adapter.ts:192`) | Must still reach `normative`. A one-layer config must not be capped at `supplementary` by a stricter multi-layer trust rule. This is the authority agent's contract; my requirement on them is: **single-layer trust behaviour is a fixed point.**                         |
+
+### The tests that currently pin this — and the hole
+
+**They do not exist.** Verified by grepping the entire `test/` tree for `resolveRulePack`,
+`loadRulePackFromFile`, `parseRulePack`, `RulePackError`, `rulePackSchema`, `verifiedAuthority`,
+`packPermitsConformanceClaim`: **no matches**. The only `rule-pack` references in `test/` are three
+`provisionalRulePack` imports (`rules.test.ts:7`, `fix-safety.test.ts:8`, `pipeline-smoke.test.ts:6`)
+and the module-boundary allow-list.
+
+What _indirectly_ pins the `undefined → provisionalRulePack` default:
+
+- `test/e2e/textlint-tester.test.ts:88-213` — exact messages that depend on the bundled pack's
+  `contractions`, `dictionary.unapproved` and `safeSubstitution` flags.
+- `test/fixtures/corpus.test.ts:124-177, 187-283, 327-341` — every call is
+  `analyseTextDeterministic(text)` with no config, i.e. the default pack.
+- `scripts/ci/check-exit-codes.sh` + `assert-corpus-report.mjs:36` — asserts the emitted
+  `packAuthority` is `provisional`.
+
+What pins **nothing**: the `string` branch (`loader.ts:54`), the object branch (`:55`), the JSON
+parse failure (`:38`), the read failure (`:32`), the schema failure (`:21`), and both trust
+functions (`:76-98`). Those six behaviours are what a refactor of `resolveRulePack` is most likely
+to break, and today nothing would notice.
+
+> **This is the single hardest prerequisite in this document.** Stage 0 below exists only to close
+> it, and no layering code should merge before it does.
+
+---
+
+## Silent-meaning-change risks
+
+Configs whose meaning changes _without an error_. This is the class the task asks me to find or to
+state clearly I did not.
+
+**Found — four. Ordered by severity.**
+
+1. **A new config key is silently discarded by older versions.** `steAiConfigSchema`
+   (`config.ts:119`) is a bare `z.object` with no `.strict()`; zod 4.4.3 strips unknown keys —
+   executed: `z.object({a:z.string().optional()}).parse({a:'x', rulePacks:[1,2]})` →
+   `{"a":"x"}`. So a config authored for the layered version, run against any older installed
+   version (a pinned CI image, a `npx` cache, a monorepo package that hasn't bumped), silently
+   resolves to the **bundled provisional pack** and lints clean-ish against nothing the operator
+   intended. The operator sees diagnostics, sees a `[provisional]` tag they may already be used to,
+   and has no signal. _Mitigation:_ widen the existing `rulePack` key instead of adding a sibling —
+   the existing union rejects arrays (executed), so old versions fail loud. If a new key is
+   unavoidable, ship a `.strict()`-equivalent or an explicit unknown-key notice **one release
+   before** the key exists, so the version that must reject it already can.
+
+2. **`rulePack` reinterpreted from "replace" to "extend".** No error, no diff in config text, a
+   different effective vocabulary. Every existing single-pack user who deliberately supplied a
+   _narrower_ pack silently gets the bundled unapproved list back. _Mitigation:_ the legacy
+   singular form is defined as `[{ pack: <spec>, mode: 'replace' }]`, pinned by test, and stated in
+   `docs/rule-pack-import.md`.
+
+3. **Both keys present after a shallow adapter merge.** `adapter.ts:154-161` spreads
+   `{...sharedFile.config, ...shared}` at the top level only. With a new sibling key, a
+   `.ste-ai.json` carrying `rulePack` and an inline textlint `shared` carrying the layered key
+   produce a config with **both** — and precedence is then decided inside `resolveRulePack`, not by
+   the documented option-precedence rule in `docs/configuration.md:151-159`. Nothing errors.
+   _Mitigation:_ same as (1) — one key. If two keys must coexist, `resolveRulePack` must throw when
+   both are set rather than pick.
+
+4. **Duplicate entries across layers changing which entry wins, silently.** Three distinct shapes,
+   all verified in the rule code: `pack.rules` duplicates are last-wins via `Map`
+   (`runner.ts:51`, executed: `new Map([['a',1],['a',2]]).get('a') === 2`); `dictionary.unapproved`
+   and `.preferred` duplicates are decided by post-sort array order plus the `claimed` first-wins
+   guard (`vocabulary.ts:63,68-70,172`); `contractions` duplicates are **not** deduplicated at all
+   and produce two diagnostics on one span (`vocabulary.ts:236-275` — no `claimed` guard).
+   Only the third is loud (it changes visible output and will break `textlint-tester.test.ts`); the
+   first two are silent. _Mitigation:_ merge must key `rules` by `ruleId`, `unapproved`/`approved`
+   by `term`, `preferred`/`contractions` by `from`, and must emit a `RunNotice` when a later layer
+   overrides an earlier one's entry. The notice is what turns a silent override into an auditable
+   one.
+
+**How I searched.** (a) Full-repo grep for `rulePack|RulePack|rule-pack|resolveRulePack|
+provisionalRulePack|parseRulePack|loadRulePackFromFile|trustedRulePackIds` across `*.ts/*.mjs/*.js/
+*.md/*.sh/*.yml/*.json`, excluding `node_modules`, `dist/`, `package-lock.json` — 86 hits, all
+triaged into the inventory above. (b) Full-repo grep for `pack.` field reads outside
+`src/rule-pack/` to find every content consumer (13 sites, rows D1-D13, C4, C7, F1). (c) Read every
+consumer function body rather than the grep line. (d) Executed zod 4.4.3 to check unknown-key
+stripping and array rejection rather than trusting documented defaults.
+
+**Where I stop.** I did **not** run the test suite or coverage (`node_modules` absent in this
+worktree), so I cannot state which loader branches v8 currently counts as covered — only that no
+test _names_ them. I also did not enumerate downstream consumers outside this repository; the
+`package.json` `exports` map (`./rule-pack`, `./core`, `./analysis`) means such consumers exist in
+principle and any signature change is semver-visible to them.
+
+---
+
+## Test strategy
+
+Conventions observed in `test/`: vitest with `globals: true` (`vitest.config.ts:8`), explicit
+`import { describe, expect, it } from 'vitest'` in project-owned tests, `mkdtempSync(join(tmpdir(),
+...))` + `afterEach` cleanup for filesystem cases (`shared-config-merge.test.ts:29-37`), long
+`/** … */` block comments stating _why_ a test exists and what regression it guards
+(`shared-config-merge.test.ts:7-24`), and cache-clearing seams called in `beforeEach`
+(`clearSharedConfigCache`, `clearAnalysisCache`).
+
+Coverage thresholds are enforced only under `--coverage` (`vitest.config.ts:15-35`: statements 91,
+branches 81, functions 91, lines 94) and CI runs `test:coverage` (`ci.yml:47`). New unreached
+branches in `src/rule-pack/` will pull these down, so tests are not optional for the thresholds
+either.
+
+### Must exist before ANY layering code merges (Stage 0)
+
+**New file: `test/unit/rule-pack-loader.test.ts`** — characterisation of today's behaviour, written
+against the current implementation and expected to pass unchanged at the baseline commit.
+
+1. no `rulePack` → `resolveRulePack(undefined)` **is** `provisionalRulePack` (identity, `toBe`, not
+   `toEqual`) — pins `loader.ts:53`.
+2. string spec → loads and validates a temp-dir JSON file; relative path resolves against the
+   supplied `baseDir`, absolute path ignores it — pins `loader.ts:26-27,54`.
+3. object spec → `parseRulePack(spec, 'inline configuration')`, defaults applied
+   (`alternatives: []`, `safeSubstitution: false`, `enabled: true` from `schema.ts:41,47,88`).
+4. missing file → `RulePackError` mentioning the resolved path (`loader.ts:32`).
+5. invalid JSON → `RulePackError` mentioning "not valid JSON" (`loader.ts:38`).
+6. schema failure → `RulePackError` listing the failing field path (`loader.ts:21`).
+7. **a supplied pack replaces the bundled one** — a pack with an empty `contractions` array produces
+   no `no-contractions` diagnostics on text the bundled pack flags. This is the test that makes
+   "replace, not extend" a pinned fact rather than a convention.
+8. `verifiedAuthority` / `packPermitsConformanceClaim` truth table: normative+untrusted →
+   `supplementary`/`false`; normative+trusted → `normative`/`true`; normative+trusted+claim `none`
+   → `packPermitsConformanceClaim` `false`; provisional → unchanged (`loader.ts:80-98`).
+
+**Also Stage 0:** a case in `test/e2e/example-config.test.ts` asserting the _parsed_ example config
+retains its pack configuration, not merely that `safeParse` succeeded — closing H7.
+
+### Required for the layering change itself
+
+**`test/unit/rule-pack-layers.test.ts`** (new) — pure merge behaviour, constructing packs as
+literals (the `provisionalRulePack`-as-literal convention of `rules.test.ts:36`):
+
+| Case                          | Asserts                                                                                                                                                                                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **two-layer extend**          | union of `dictionary.unapproved`; both layers' terms fire; neither layer's `safeSubstitution` is coerced                                                                                                                                                         |
+| **three-layer ordering**      | a term defined in layers 1 and 3 resolves to layer 3's `alternatives`; a scalar `limits.proceduralMaxGradeLevel` set in all three resolves to the last (pins D11-D13's last-wins)                                                                                |
+| **replace-then-extend**       | layer 2 `replace` discards layer 1 entirely; layer 3 `extend` adds only to layer 2's result — proves `replace` is not "clear then re-add bundled"                                                                                                                |
+| **retraction**                | a higher layer's retraction of a lower layer's term removes it from `pack.dictionary.unapproved` **and** from linter output; retracting a term that does not exist is an explicit error or an explicit notice, never a silent no-op (syntax per the merge agent) |
+| **conflict detection**        | two layers disagreeing on the same key produce the designed conflict outcome, and the _notice_ naming both layers is asserted — a silent winner is a failing test                                                                                                |
+| **`rules[]` keyed by ruleId** | two layers each declaring `sentence-length-procedural` yield exactly **one** spec in the merged `rules` array (guards D2's `Map` last-wins from ever being reached)                                                                                              |
+| **contractions dedup**        | two layers each declaring `don't` produce exactly **one** diagnostic on `Don't do that.` — the direct regression test for D10                                                                                                                                    |
+| **back-compat equivalence**   | `resolveRulePack(undefined)` and `resolveRulePack(<single-layer form naming only the bundled pack>)` produce deep-equal packs                                                                                                                                    |
+
+**`test/integration/rule-pack-layering.test.ts`** (new) — resolution through real files:
+
+- layers given as relative paths resolve against `baseDir` (mirrors C1); one layer relative and one
+  absolute in the same list;
+- a broken layer at position 2 of 3 throws a `RulePackError` naming **which** layer and does not
+  silently fall back (defends `docs/rule-pack-import.md:29-30`);
+- the same layer listed twice is either idempotent or an error — pinned either way, not left open;
+- deep-equal output for the same layer list resolved twice (determinism, matching the runner's own
+  determinism promise at `runner.ts:38-43`).
+
+**`test/integration/shared-config-merge.test.ts`** (existing, gains cases):
+
+- a layer list set in `.ste-ai.json` survives an inline `shared` option that never mentions packs
+  (the exact shape of the existing test at `:39-63`);
+- an inline `shared` layer list replaces the file's, and the _effective_ pack proves it — closing
+  the E1 ambiguity by making the precedence a tested fact.
+
+**`test/unit/rules.test.ts`** (existing): one case constructing `RunOptions` with a **merged** pack
+containing duplicate-keyed inputs, asserting the winning `severity`/`sourceRef`/`status` reach the
+diagnostic (D4-D6).
+
+**`test/architecture/module-boundaries.test.ts`** (existing): if merge lands outside
+`src/rule-pack/`, `ALLOWED` (`:16-34`) must gain the module and every consumer row must be updated
+in the same PR — the test at `:82-87` fails loudly otherwise. Preferred: land it inside
+`src/rule-pack/` and touch nothing.
+
+**`test/e2e/textlint-tester.test.ts` and `test/e2e/textlint-run.test.ts`: expected to be
+byte-unchanged.** Any diff to these during the rollout is evidence of a merge defect, not a test in
+need of updating. State that in the PR description so a reviewer does not "fix" them.
+
+### CI assertion scripts
+
+- If the layered config becomes the shipped example, add a `scripts/ci/` check that a
+  layered example resolves and produces the expected pack identity — CI scripts are assertions
+  separate from `npm test` (`ci.yml:50-56`), and a layering regression that only shows through the
+  CLI would otherwise go unnoticed.
+- Any new script must be added to `.github/workflows/ci.yml` explicitly; nothing globs
+  `scripts/ci/*`.
+
+---
+
+## Fixture and corpus impact
+
+**Read:** `docs/fixtures.md` (esp. `:145-196`) and `test/fixtures/corpus.test.ts` in full.
+
+### What is NOT affected (and why, precisely)
+
+- **The exact class balance.** `corpus.test.ts:363-374` asserts
+  `{violation: 5, 'non-violation': 100, undecidable: 0}`. The counts are accumulated from
+  `annotation.candidateAdjudications` (`:365-366`) — static JSON in `fixtures/annotations/*.json`,
+  merged in from `fixtures/verdicts/`. **The linter is not consulted.** Layering cannot move this
+  number. Same for `corpus.test.ts:376-389` (`noun-cluster-candidate` → `{violation: 0, total: 24}`)
+  and for the 105/5/100 table in `docs/provisional-rules.md:265-271`.
+- **`scripts/ci/check-rules-provisional.sh:20`'s hard-coded `14`.** It lints the output of
+  `ste-ai rules --json`, which `listRules` (`cli/main.ts:277-296`) builds from the
+  `deterministicRules` registry and `r.meta.status` — **never from the pack**.
+  `assert-rules-provisional.mjs:34` checks that same `meta.status`. Layering adds no rule and
+  changes no `meta.status`, so **neither the count nor the provisional assertion needs
+  reconciling**, provided the change does not make `rules` pack-aware. It should not.
+
+### What IS at risk — all of it conditional on the default path
+
+Every one of the following calls `analyseTextDeterministic(text)` **with no config**, i.e. the
+`loader.ts:53` default:
+
+| Assertion                                                     | Line                     | Breaks if                                                                              |
+| ------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------- |
+| every candidate the linter emits has a bound reviewer verdict | `corpus.test.ts:327-341` | the default pack changes at all — new/moved candidates orphan the ground truth         |
+| at least half the originals produce ≥1 diagnostic             | `:124-132`               | the default pack loses entries                                                         |
+| no diagnostic inside a code fence                             | `:134-151`               | (structural; pack-insensitive, but runs the linter)                                    |
+| every diagnostic points at non-empty source                   | `:153-161`               | duplicate/zero-width entries from a merge                                              |
+| no fix inside an admonition                                   | `:163-177`               | a merge changes `safeSubstitution`                                                     |
+| violations never increase after a rewrite                     | `:187-197`               | duplicate diagnostics (D10) inflate the _original_ and the _compliant_ count unequally |
+| accepted changes reduce the specific `(ruleId, quote)` count  | `:240-256`               | duplicates change counts on both sides                                                 |
+| annotated expected diagnostics actually fire                  | `:258-277`               | a merge drops an entry                                                                 |
+| `scripts/ci/check-candidate-ground-truth.sh`                  | (whole script)           | same as `:327-341`, via `dist/`                                                        |
+
+**Conclusion:** the corpus needs **no reconciliation** if the default path returns
+`provisionalRulePack` by identity. If a merge defect changes it, `corpus.test.ts:327-341` and
+`check-candidate-ground-truth.sh` fail — which is the design intent of both
+(`docs/fixtures.md:179-180`). The correct posture is therefore _not_ to update the fixture
+expectations, but to treat any movement in them as a stop-the-line signal.
+
+**One documentation dependency:** `docs/fixtures.md:194` ("violation count never increases after a
+rewrite") and the surrounding invariant table at `:189-201` describe corpus assertions accurately
+today. They stay accurate. No fixture, manifest, annotation or verdict file needs to change.
+
+---
+
+## Documentation reconciliation list
+
+Per `CLAUDE.md`, this list is part of the work, not a follow-up. Quoted text is verbatim at the
+baseline commit.
+
+### Must change
+
+**`docs/configuration.md`**
+
+- `:70` — "4. built-in defaults — bundled provisional pack, semantic analysis **off**."
+  → still true, but must say the bundled pack is _layer 0_, not _the_ pack.
+- `:76-78` —
+
+  > `// Path to an authorised rule pack, or an inline pack object.`
+  > `// Omit to use the bundled provisional pack. See docs/rule-pack-import.md.`
+  > `"rulePack": "./ste-rule-pack.json",`
+
+  The whole shipped snippet is single-pack. Needs a layered example plus an explicit statement that
+  the singular string form still means _replace_.
+
+- `:151-159` — the "Option precedence" section lists three layers for _rule options_ and says
+  "Layers are merged key by key". Pack layering is a **different** layering with a **different**
+  order (bundled → organisation → department → product → tech stack → industry → locale). Two
+  unrelated things called "layers" one page apart is a documentation defect waiting to happen; the
+  new section must be explicitly distinguished, exactly as `:161` already distinguishes suppression
+  ("Inline suppression is not one of these layers").
+- `:249` — "`console.log(full.pack.metadata.conformanceClaim); // 'none' for the bundled pack`" —
+  needs updating if `AnalysisResult` gains a layer list (C3).
+
+**`docs/rule-pack-import.md`**
+
+- `:3-5` —
+
+  > "This is the **only** supported route by which normative controlled-language data enters the
+  > package. No rule hard-codes vocabulary: every word list, term mapping and numeric limit is read
+  > from the active pack"
+
+  "the active pack" (singular) is the exact phrase that goes stale.
+
+- `:29-30` — "A pack that fails validation throws `RulePackError` with the failing field paths. The
+  linter never falls back to the provisional pack silently." — must be restated per **layer**: a
+  failing layer must not be silently skipped either, which is a stronger promise than the current
+  sentence makes.
+- `:113-126` — the entire "Wiring it in" section:
+
+  > `{ "rulePack": "/etc/acme/ste-rule-pack.json" }`
+  > … `await analyseText(source, { config: { rulePack: myPackObject } });`
+  > "Relative paths resolve against the textlint config base directory, or against `baseDir` for the
+  > programmatic API."
+
+  Needs the layered form beside the legacy form, and must say per-layer relative resolution.
+
+- `:129-137` — the "What changes when you supply a normative pack" table. Two problems.
+  (a) It is binary (bundled vs normative) and layering makes it a spectrum.
+  (b) **It is already stale**: the row
+
+  > `| `packPermitsConformanceClaim()` |`false`|`true`if`conformanceClaim !== 'none'` |`
+
+  omits the `trustedRulePackIds` requirement that `src/rule-pack/loader.ts:82` actually enforces.
+  Same defect at `:51`: "`// `packPermitsConformanceClaim()` returns true only for 'normative' + not
+'none'.`" Fix both while the table is open.
+
+- `:151-155` — "Extending the schema … extend `src/rule-pack/schema.ts` and the consuming rule
+  together, and add a test that the new field actually changes behaviour." — still correct, and it
+  is the standing instruction the layering change itself must satisfy.
+
+**`README.md`**
+
+- `:74-77` —
+
+  > "`rulePack` (a path to a JSON file, or an inline object) and `approvedTerms` in the shared config
+  > let a repository supply its own vocabulary on top of the bundled provisional pack"
+
+  "on top of" is **already misleading** at the baseline commit — `loader.ts:54-55` _replaces_ the
+  bundled pack; only `approvedTerms` is additive (`analyse.ts:255`). Layering is the moment to make
+  this sentence honest instead of merely updated.
+
+- `:247-249` —
+
+  > "`src/rule-pack/` is the single import boundary. No rule hard-codes vocabulary: limits, word
+  > lists, term mappings, contractions and per-rule authority all come from the active pack."
+
+  "the active pack" again.
+
+- `:251-252` — "A pack cannot add a rule, cannot bypass the autofix gate, and cannot make the linter
+  print a conformance claim." — still true for a _layer_; restate in layer terms so it is not read
+  as applying only to a single pack.
+- `:104-107` — the roadmap paragraph about "Resolving a rule pack from a package name or a URL with
+  a required integrity digest, so an organisation shares one vocabulary across repositories"
+  (issue #3) — this change partly delivers the _intent_; the paragraph must say what is now real and
+  what is still proposed, or it becomes a false roadmap.
+
+**`docs/architecture.md`**
+
+- `:10` — "`rule-pack       → core                    schema, loader, bundled provisional pack  [IMPORT BOUNDARY]`"
+  → add the merge component to the description if it lands here (and it should — see H1).
+- `:231-235` —
+
+  > "Per-document configuration that textlint cannot express per rule (rule pack, semantic service,
+  > autofix policy, protected terminology) is read from a shared file … Option layers are merged key
+  > by key, lowest first: shared file, `shared` override, the rule's own textlint options."
+
+  Same "two meanings of layer" collision as `configuration.md:151-159`; disambiguate here too.
+
+**`docs/DISCLAIMER.md`**
+
+- `:37-38` — "the active rule pack's `metadata.authority` and `metadata.conformanceClaim`, which the
+  bundled pack sets to `provisional` and `none` respectively." — "the active rule pack's" is
+  singular, and this is the _disclaimer_, where imprecision costs most. Must state what authority a
+  layered stack reports.
+- `:40` — "`packPermitsConformanceClaim()` returns `false` for the bundled pack, and the CLI prints
+  …" — follows the authority model.
+- `:62-66` — "an authorised rule pack can supply normative limits … Doing so changes the
+  `ruleStatus` on diagnostics to whatever the pack declares." — "whatever the pack declares" is
+  already loose (`runner.ts:139-146` caps an untrusted pack at `supplementary`) and gets looser with
+  layers.
+
+### Should be checked, likely a one-line touch
+
+- `docs/rule-authoring.md:94` — "| a limit or a word list | `pack.limits`, `pack.dictionary` | never
+  hard-code vocabulary |" — still correct (rules see the merged pack), but worth a sentence saying a
+  rule never sees layers, only the merged result. That is a useful invariant to write down.
+- `docs/extension-roadmap.md:92-95` — "ship such a pack **separately, under its own licence, loaded
+  via `rulePack`**, never bundled" — layering makes this _easier_ and the wording should say so.
+- `docs/implementation-report.md:45` — "| Rule pack | Zod schema, loader, bundled provisional pack —
+  the single import boundary for licensed data |" — historical record; check whether this document
+  is maintained as current or as a dated report before editing (`docs/architecture.md:238-240` shows
+  this repo does keep deliberately-historical sections, marked as such).
+
+### Explicitly **not** stale
+
+- `docs/fixtures.md` — no pack-dependent claim (verified by grep: the only "pack" hits are
+  unrelated). No change.
+- `docs/provisional-rules.md:265-271` (the 105/5/100 table) — annotation-derived, not linter-derived.
+  No change.
+- `docs/diagnostic-policy.md`, `docs/suppression.md`, `docs/semantic-evaluators.md`,
+  `docs/llama-cpp-setup.md` — no single-pack claim.
+
+---
+
+## Staged rollout plan
+
+Design constraints: main green at every step; each stage independently reviewable and revertible;
+no stage both changes behaviour _and_ changes public API. Per `CLAUDE.md`, each PR opens as a draft,
+is un-drafted for `chatgpt-codex-connector` review, and waits a real interval before merge — never
+un-draft and merge in one action.
+
+### Stage 0 — Characterisation tests only. **Ships first.**
+
+`test/unit/rule-pack-loader.test.ts` (8 cases above) + the strengthened
+`example-config.test.ts` case. **No `src/` change.**
+
+_Why first:_ the back-compat surface is currently unpinned (nothing in `test/` imports the loader).
+Every later stage's safety argument is "the characterisation tests still pass" — that sentence is
+worthless until they exist. This stage is also the only one that is trivially correct to review: if
+it passes at the baseline commit, it describes today's behaviour truthfully.
+
+_Green because:_ additive tests over unchanged code. Also lifts `src/rule-pack/loader.ts` branch
+coverage, giving headroom under `vitest.config.ts:15-35`.
+
+### Stage 1 — Merge module, unreachable from production.
+
+Add the merge implementation inside `src/rule-pack/` (deliberately, to avoid the
+`module-boundaries.test.ts:82-87` allow-list change and to keep the `rule-pack → core` restriction
+at `:23`). Add `test/unit/rule-pack-layers.test.ts` in full. **Nothing calls it.**
+
+_Why second:_ the merge algorithm is the other agent's design and the part most likely to need
+iteration. Landing it inert means its review is about correctness, not about blast radius, and a
+revert is a file deletion.
+
+_Green because:_ new code, new tests, zero production call sites. `resolveRulePack` untouched.
+
+### Stage 2 — Config shape, accepted and ignored.
+
+Widen `rulePack` in `src/core/config.ts:124` to accept the layered form **in addition to**
+string/object. Parse it. Do **not** consume it yet — or consume it only when it names exactly one
+layer, which is provably identical to today. Update `test/e2e/example-config.test.ts`.
+
+_Why third and why separate:_ this is the semver-visible surface (`package.json` `"./core"` export)
+and the silent-meaning-change epicentre. It deserves a review of its own. Splitting it from Stage 3
+also means the version that _rejects_ a malformed layered config ships before the version that
+_acts_ on a valid one — which is what protects a half-upgraded fleet.
+
+_Green because:_ a widened union accepts a strict superset of today's inputs; every existing config
+parses identically.
+
+### Stage 3 — Wire it up. **The only behaviour-changing stage.**
+
+`resolveRulePack` consumes layers; `src/analysis/analyse.ts:244` and `src/evaluation/evaluate.ts:227`
+pass them; `scripts/build-candidate-packets.mjs:51,77` updated in the **same PR** (it is `.mjs` and
+not typechecked — `tsconfig.json:25` has no `allowJs` — so nothing else will catch it);
+`test/integration/rule-pack-layering.test.ts` and the `shared-config-merge.test.ts` additions land
+here.
+
+_Green because:_ Stage 0's characterisation tests prove the legacy paths are unmoved; `corpus.test.ts`
+and `check-candidate-ground-truth.sh` prove the default path is unmoved; `textlint-tester.test.ts`
+proves the message surface is unmoved. **Reviewer instruction to state in the PR body:** a diff in
+`test/e2e/textlint-tester.test.ts` or in `test/fixtures/corpus.test.ts` expectations means a merge
+defect, not a test needing an update.
+
+_Revert:_ one PR revert restores single-pack resolution; Stages 1 and 2 remain harmlessly in place.
+
+### Stage 4 — Authority and provenance across layers.
+
+The other agent's model applied to `loader.ts:76-98`, `runner.ts:96-99,139-146`,
+`analyse.ts:292,607`, `cli/main.ts:190-197,217-219`. Reconcile
+`scripts/ci/assert-corpus-report.mjs:32-45` **in this PR** if the conformance block's shape changes.
+
+_Why after Stage 3:_ authority is where "which layer vouches for this rule" (D5) becomes unavoidable,
+and it is much easier to reason about once merged packs actually exist and are tested. Splitting it
+also keeps the highest-stakes change (what the tool is allowed to _claim_) in a PR that changes
+nothing else.
+
+### Stage 5 — Documentation reconciliation.
+
+Every item in the list above, including the two **already-stale** items found during this analysis
+(`rule-pack-import.md:51,135` omitting `trustedRulePackIds`; `README.md:74-75` saying "on top of"
+where the code replaces).
+
+_Why last, and why it is still in scope:_ `CLAUDE.md` requires docs to be reconciled as part of the
+work, not as a follow-up. Landing them as a final PR — rather than smearing them across Stages 2-4 —
+keeps each behaviour PR small and lets the docs be written once against the finished behaviour
+rather than three times against moving targets. This stage is **not optional** and the work is not
+done until it merges.
+
+_Risk of putting it last:_ main is briefly correct-but-under-documented between Stage 3 and Stage 5.
+Acceptable only if Stage 5 is opened as a draft at the same time as Stage 3, so it cannot be
+forgotten. If that discipline is doubted, fold Stage 5's `rule-pack-import.md` and `configuration.md`
+edits into Stage 3 instead and keep only the roadmap/README prose for last.
+
+---
+
+## Residual risks
+
+Things that could go wrong which the tests above would **not** catch.
+
+1. **Merge is correct but non-deterministic across platforms.** The merge output feeds
+   `vocabulary.ts:63` (`sort((a,b) => b.term.length - a.term.length)`) — a comparator with ties, and
+   `Array.prototype.sort` stability preserves _input_ order for ties. If the merge builds its output
+   from a `Map`/`Set` whose insertion order varies with layer file read order (e.g. a
+   `Promise.all` over layer loads), two runs can differ in which of two equal-length terms claims a
+   span at `:68-70`. The corpus tests would only catch this if a fixture happens to contain such a
+   tie. **Mitigation:** merge must sort its outputs by a total order (term, then source layer index)
+   before returning, and a test must assert deep equality across two independent resolutions.
+
+2. **Cache staleness multiplied.** `adapter.ts:48-51` keys the analysis cache on config _text_, not
+   on the _contents_ of the pack files it names. Editing a layer file in an editor's long-lived
+   textlint server yields stale diagnostics with no signal. True today for one file; N times more
+   likely with N layers, and much harder for a user to diagnose ("I edited the department pack and
+   nothing changed"). No test can catch it — the tests each start a fresh process. **Mitigation:**
+   document it; consider hashing resolved pack content into the cache key in a later change. Do not
+   fix it in this rollout.
+
+3. **`baseDir` divergence becomes a correctness bug.** `analyse.ts:244` passes
+   `options.baseDir ?? process.cwd()`; `evaluate.ts:227` passes **nothing**, so it uses
+   `process.cwd()`. With one pack an operator notices immediately ("file not found"). With layers,
+   a _partially_ resolvable list could plausibly be designed to skip or warn — at which point the
+   evaluation harness silently measures against a different pack stack than the linter uses, and
+   every number it reports is wrong in a way no assertion checks. **Mitigation:** a failing layer
+   must be fatal, never skipped (this is the strengthened reading of
+   `docs/rule-pack-import.md:29-30`), and `evaluate.ts` should take an explicit baseDir.
+
+4. **Licence and trust aggregation across layers.** Each `RulePack` carries one `licence` and one
+   `notice` (`schema.ts:26,30`). A merged pack has N. Nothing in the codebase currently surfaces
+   `licence` or `notice` in output at all (grep: no consumer outside the schema/type), so a merge
+   that drops them loses an audit trail **without any test failing** — the field is validated on the
+   way in and never read on the way out. Given this repo's posture on provenance
+   (`docs/DISCLAIMER.md`, `docs/fixtures.md:145-170`), silently losing per-layer licence text is a
+   real harm that the test suite is structurally incapable of detecting. **Mitigation:** the
+   provenance model must retain per-layer `licence`/`notice`, and a test must assert they survive
+   the merge even though nothing consumes them yet.
+
+5. **Performance and the `readFileSync` path.** `loadRulePackFromFile:30` is synchronous, and
+   `analyseTextDeterministic` is documented as "Never performs I/O beyond reading the rule pack"
+   (`analyse.ts:279`). Seven layers means seven synchronous reads plus seven zod parses per
+   resolution — and `resolveRulePack` is called **per `analyseText` invocation** (`analyse.ts:244`),
+   not once per process. The adapter's analysis cache hides this for textlint, but the CLI resolves
+   per file (`cli/main.ts:161-183` loops files, each calling `analyseText`). A 500-file lint would
+   do 3500 file reads and 3500 schema validations. No test measures this; `testTimeout: 20_000`
+   (`vitest.config.ts:9`) is generous enough to hide it. **Mitigation:** memoise resolved layers by
+   (absolute path, mtime/size) inside the loader, and say so in the docs.
+
+6. **Zod default application on every layer.** `schema.ts:41,47,54,88,97-103` apply `.default()` to
+   `alternatives`, `safeSubstitution`, `enabled` and every array. A layer that _omits_ a field gets
+   the default **as if it had stated it**. A merge that treats "present" as "wins" therefore lets a
+   higher layer silently reset a lower layer's `safeSubstitution: true` to `false` merely by
+   mentioning the term. Post-parse, "omitted" and "explicitly default" are indistinguishable. This
+   is a genuine information loss at the schema boundary that a merge test written against
+   _post-parse_ objects cannot detect, because both inputs look identical. **Mitigation:** the merge
+   must operate on pre-default input where it matters, or the schema must drop defaults for
+   layer-fragment parsing. Flag to the merge and config-shape agents — this is the one place where
+   my scope and theirs genuinely cannot be separated.
+
+7. **Nobody is a real multi-layer user yet.** Every layer beyond "bundled + one org pack" will be
+   exercised first by tests written by the people who designed it. The corpus contains no layered
+   fixture and there is no dogfooding path — this repo lints its own docs with the default config.
+   The first real seven-layer stack will find things this plan did not. **Mitigation:** ship the
+   layered form as documented-but-new for one release, and add a real layered example under
+   `examples/` (covered by `example-config.test.ts`) so at least one non-trivial stack is executed
+   by CI on every commit.
+
+8. **An unverified claim I am deliberately flagging.** I did not execute the test suite, so
+   "main is green at the baseline commit" is an assumption, not a measurement. If it is not green,
+   the Stage 0 argument ("characterisation tests pass unchanged") is unsound and the whole plan
+   needs re-basing. **First action for whoever implements this: run `npm ci && npm run verify` at
+   `9d78a8b` and confirm.**

--- a/docs/design/64-layered-rule-packs/03-migration-verification.md
+++ b/docs/design/64-layered-rule-packs/03-migration-verification.md
@@ -412,9 +412,8 @@ Every one of the following calls `analyseTextDeterministic(text)` **with no conf
 (`docs/fixtures.md:179-180`). The correct posture is therefore _not_ to update the fixture
 expectations, but to treat any movement in them as a stop-the-line signal.
 
-**One documentation dependency:** the "Corpus tests" table in `docs/fixtures.md` ("violation count never increases after a
-rewrite") and the surrounding invariant table at `:189-201` describe corpus assertions accurately
-today. They stay accurate. No fixture, manifest, annotation or verdict file needs to change.
+**One documentation dependency:** the "Corpus tests" table in `docs/fixtures.md` ("violation count
+never increases after a rewrite", `:159-171`) describes corpus assertions accurately today. They stay accurate. No fixture, manifest, annotation or verdict file needs to change.
 
 ---
 
@@ -685,8 +684,8 @@ Things that could go wrong which the tests above would **not** catch.
    `licence` or `notice` in output at all (grep: no consumer outside the schema/type), so a merge
    that drops them loses an audit trail **without any test failing** — the field is validated on the
    way in and never read on the way out. Given this repo's posture on provenance
-   (`docs/DISCLAIMER.md`, the "How the adjudication was run" section of `docs/fixtures.md`), silently losing per-layer licence text is a
-   real harm that the test suite is structurally incapable of detecting. **Mitigation:** the
+   (`docs/DISCLAIMER.md`, and the "How the adjudication was run" section `docs/fixtures.md` gains with
+   #59), silently losing per-layer licence text is a real harm that the test suite is structurally incapable of detecting. **Mitigation:** the
    provenance model must retain per-layer `licence`/`notice`, and a test must assert they survive
    the merge even though nothing consumes them yet.
 


### PR DESCRIPTION
Docs only. No source file touched, no behaviour changed. Based on `main` so it can merge independently of #58 and #59.

Adds `docs/design/64-layered-rule-packs/` — three specs produced independently against `9d78a8b`, plus a consolidated decision record.

| File | Scope |
|---|---|
| `00-decisions.md` | Consolidated record: agreements, resolved disagreements, open decisions |
| `01-merge-core.md` | Config shape, per-field merge algorithm, retraction, conflict detection, ordering |
| `02-authority-trust.md` | Per-entry authority, the trust boundary under composition, provenance |
| `03-migration-verification.md` | Blast radius, back-compatibility, test strategy, staged rollout |

Each spec was scoped so it would not design across the others, and each was required to cite a file and line for claims about current behaviour and to state uncertainty rather than guess. Claims reproduced in `00-decisions.md` were re-verified directly before being recorded.

## Framing correction

`README.md:74-75` already says a supplied pack layers **"on top of the bundled provisional pack"**. `resolveRulePack` (`loader.ts:49-56`) substitutes instead. Documented and implemented behaviour already disagree, so #64 is a defect rather than a new feature.

## Two disagreements, resolved on evidence

**Composed output type.** `01` wanted the output to satisfy `RulePack` exactly, so no consumer would change. `02` requires per-entry provenance, which `RulePack` cannot carry — `approvedTechnicalTerms` is `readonly string[]` (`types.ts:484`). `02` wins, on the attack it documents: an untrusted layer adds a technical term, that term is protected before any rule runs (`analyse.ts:254-257`), and a normative dictionary entry then never matches.

**Config key.** `01` proposed a new `rulePacks` key; `03` proposed widening the existing `rulePack`. Measured against the schema at this commit:

```
new key `rulePacks` on current schema → ACCEPTED, and the key is SILENTLY STRIPPED
array passed to existing `rulePack`  → REJECTED (fails loud)
```

A new key drops a whole layer stack with no signal when a config outruns the linter version; widening turns that same skew into a loud parse failure. `03` wins.

## Open, deliberately not settled here

- **`limits` merge policy** — last-wins (recommended, with its cost stated) against an organisation floor lower layers cannot loosen.
- **Conformance under mixed authority** — whether run-level claims require unanimity across contributing layers.

## Defects found while specifying, both independent of layering

Filed separately:

- `runner.ts:110` copies an untrusted pack's `sourceRef` citation onto diagnostics verbatim. `verifiedRuleStatus` caps the *status*; the citation *string* is not checked.
- No test imports `src/rule-pack/loader.ts` — `grep -rln "authority\|conformance\|rulePack" test/` returns zero files.

## Documentation already inaccurate before any of this lands

- `rule-pack-import.md:51` and `:135` describe `packPermitsConformanceClaim()` with two conditions; `loader.ts:76-83` enforces three, the third being membership in `trustedRulePackIds`.
- `DISCLAIMER.md:64-65` states a pack changes `ruleStatus` "to whatever the pack declares", which holds only once an operator has trusted it.

## Verification

`npm run lint` passes. No source changed, so the test suite is unaffected; it was run separately at `9d78a8b` — 545 passing — which also confirms the one assumption `03` flagged as unverified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1Bg1SjrchCc626brHRACM)_