### PR TITLE
docs(claude): require independent review before every merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,28 @@ Un-drafting a PR is what makes it visible to automated review (`chatgpt-codex-co
 repo — see PR #32). Un-draft, then wait a real interval before merging — never merge in the same
 action as un-drafting, even on a change that looks obviously safe.
 
+**If the automated reviewer cannot review, substitute a subagent review — never skip the review.**
+Codex declines when the account is over its usage limit, replying "You have reached your Codex usage
+limits for code reviews" instead of a review; it can also stay silent. Either way the PR has had no
+independent look, and merging it means merging unreviewed work.
+
+When that happens, dispatch a subagent to review it before merging:
+
+- **Code changes** — the `dh:code-reviewer` agent, which detects the stack and loads the matching
+  `dh:code-review-{stack}` skill (`dh:code-review-typescript` here).
+- **Docs and design changes** — a fact-check instead of a code review. Documents in this repo cite
+  files and line numbers, and a design doc that misdescribes the code is worse than none, because
+  implementers trust it. Ask for every citation to be opened and verified.
+
+Dispatch with `isolation: "worktree"` per the section above, tell the agent to `git checkout --detach`
+the PR head commit first, give it the base commit so it can diff, and tell it explicitly that it is
+the review of record so it reviews critically rather than confirming. Require the same evidence
+discipline the rest of this file demands: cite the file and line, state uncertainty rather than
+guessing, and say what was checked when nothing was found — otherwise an empty review is
+indistinguishable from no review.
+
+Then address the findings, the same as for a human or Codex review.
+
 ## Local verification tools
 
 Use `npx tsx` (not bare `tsx` — not a project dependency) for ad hoc TypeScript checks, or rebuild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,12 +108,16 @@ Use `npx tsx` (not bare `tsx` — not a project dependency) for ad hoc TypeScrip
 
 **In a fresh worktree, run the repo's own binaries from `node_modules/.bin/`, not `npx`.** A worktree
 created by `git worktree add` or by `isolation: "worktree"` has no `node_modules`, so `npx <tool>`
-silently downloads the _latest_ published version instead of the pinned one. That is not a
-hypothetical: `npx prettier --write` in such a worktree reformatted two embedded TypeScript blocks
-the way prettier 4 wants them, reported the tree clean, and CI — which runs the pinned 3.9.6 — failed
-on exactly those two files. Either `npm ci` in the worktree first, or invoke the main checkout's
-binary by path. A tool that reports success against a version the project does not use has verified
-nothing.
+silently resolves some _other_ version — whatever it fetches or already has cached — rather than the
+pinned one. Do not assume that is the newest: measured here, `npx prettier --version` outside the
+project reports **3.8.1** while the project pins **3.9.6**, so the drift can go backwards.
+
+That is not a hypothetical. `npx prettier --write` in such a worktree reformatted two embedded
+TypeScript blocks the way its version wanted them, then `npx prettier --check` in the same worktree
+pronounced the tree clean; CI, running the pinned version, failed on exactly those two files. Either
+`npm ci` in the worktree first, or invoke the main checkout's binary by path. A tool that reports
+success against a version the project does not use has verified nothing — and the check that
+confirms it is clean is running the same wrong version, so it agrees.
 
 ## `send_later` (self-scheduled check-ins)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,18 +70,27 @@ Un-drafting a PR is what makes it visible to automated review (`chatgpt-codex-co
 repo — see PR #32). Un-draft, then wait a real interval before merging — never merge in the same
 action as un-drafting, even on a change that looks obviously safe.
 
-**If the automated reviewer cannot review, substitute a subagent review — never skip the review.**
-Codex declines when the account is over its usage limit, replying "You have reached your Codex usage
-limits for code reviews" instead of a review; it can also stay silent. Either way the PR has had no
-independent look, and merging it means merging unreviewed work.
+**Independent review is required before every merge.** Not a courtesy, and not conditional on the
+external reviewer being available. Two routes satisfy the requirement equally: the automated external
+reviewer, or a local subagent review. What is never acceptable is merging with neither.
 
-When that happens, dispatch a subagent to review it before merging:
+The external reviewer fails in two ways, and one of them is quiet. It declines when the account is
+over its usage limit, replying "You have reached your Codex usage limits for code reviews" instead of
+a review — that one is visible. It can also simply stay silent, which is easy to read as approval.
+Treat both as "no review has happened", and check for a real review rather than for the absence of
+complaints.
+
+When the external reviewer has not produced one, dispatch a subagent before merging:
 
 - **Code changes** — the `dh:code-reviewer` agent, which detects the stack and loads the matching
   `dh:code-review-{stack}` skill (`dh:code-review-typescript` here).
 - **Docs and design changes** — a fact-check instead of a code review. Documents in this repo cite
   files and line numbers, and a design doc that misdescribes the code is worse than none, because
   implementers trust it. Ask for every citation to be opened and verified.
+- **Substantial or risky changes** — a set of reviewers rather than one, via
+  `dh:multi-perspective-review`, which runs security, quality, performance and accessibility
+  perspectives in parallel and returns a verdict per perspective. One reviewer sees one way; several
+  reviewing independently is the point of review, and is what the external reviewer cannot offer.
 
 Dispatch with `isolation: "worktree"` per the section above, tell the agent to `git checkout --detach`
 the PR head commit first, give it the base commit so it can diff, and tell it explicitly that it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,15 @@ Then address the findings, the same as for a human or Codex review.
 Use `npx tsx` (not bare `tsx` — not a project dependency) for ad hoc TypeScript checks, or rebuild
 `dist/` immediately before using it. Never run stale `dist/` output with plain `node`.
 
+**In a fresh worktree, run the repo's own binaries from `node_modules/.bin/`, not `npx`.** A worktree
+created by `git worktree add` or by `isolation: "worktree"` has no `node_modules`, so `npx <tool>`
+silently downloads the _latest_ published version instead of the pinned one. That is not a
+hypothetical: `npx prettier --write` in such a worktree reformatted two embedded TypeScript blocks
+the way prettier 4 wants them, reported the tree clean, and CI — which runs the pinned 3.9.6 — failed
+on exactly those two files. Either `npm ci` in the worktree first, or invoke the main checkout's
+binary by path. A tool that reports success against a version the project does not use has verified
+nothing.
+
 ## `send_later` (self-scheduled check-ins)
 
 Works without approval friction in this environment — verified: a call this session registered


### PR DESCRIPTION
Addition to `CLAUDE.md`, under the existing "Draft PRs and automated review" section. No code.

## Why

Codex declined review on both #59 and #65:

> You have reached your Codex usage limits for code reviews.

Both had just been un-drafted specifically to obtain that review. Without a substitute they would have been merged with no independent look — the un-drafting would have been ceremony rather than a gate.

## The rule

**Independent review is required before every merge** — not a courtesy, and not conditional on the external reviewer being available. Two routes satisfy it equally: the automated external reviewer, or a local subagent review. Merging with neither is what is never acceptable.

The first draft of this framed subagent review as a *fallback*. That was wrong in a way worth recording: it makes the requirement contingent on a third party's quota. The requirement is the review; the routes are interchangeable.

**One failure mode is quiet.** Codex declining over quota is visible. Codex staying silent is not, and silence reads as approval. Both mean no review has happened, so the check is for a real review rather than for the absence of complaints.

## Routing

| Change | Reviewer |
|---|---|
| Code | `dh:code-reviewer` — detects the stack, loads `dh:code-review-{stack}` (`dh:code-review-typescript` here) |
| Docs / design | A fact-check, not a code review. Docs here cite files and line numbers; a design doc that misdescribes the code is worse than none, because implementers trust it |
| Substantial or risky | `dh:multi-perspective-review` — security, quality, performance and accessibility in parallel, verdict per perspective |

That third row is the point of the whole thing. One reviewer sees one way; several reviewing independently is what review is *for*, and is the one thing a single external reviewer cannot provide.

## Dispatch discipline

Carries over what this file already requires — worktree isolation, `git checkout --detach` the PR head first, supply the base commit for diffing — and adds two requirements specific to review:

- Tell the agent it is **the review of record**, so it reviews critically instead of confirming.
- Require it to **state what it checked when it finds nothing**. An empty review that does not state its coverage is indistinguishable from no review, which is the failure this rule exists to prevent.

## Already in use

Applied before being written down: subagent reviews of #59 (code review) and #65 (citation fact-check) are running now, and their findings will be addressed on those PRs.

## Verification

`npm run lint` passes. Markdown only; no source or test touched.