### PR TITLE
docs: rewrite README for STE rule compliance and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ network.
 ## Who this serves, and how
 
 The intended audience is an AI agent generating text. The goal: keep that agent's vocabulary
-consistent with the project's own approved, preferred, and unapproved terms. A repository can also
-layer its own list on top of the bundled provisional pack.
+consistent with the project's own approved, preferred, and unapproved terms. A repository can
+supply its own `approvedTerms` list on top of whichever pack is active. A repository can also
+replace the bundled provisional pack entirely with its own `rulePack`.
 
 That serves three distinct consumer surfaces, at different stages of readiness. They are not the same
 shape, and should not be conflated.
@@ -77,17 +78,17 @@ invoke this via `npx`. Each can lint documentation files before a commit lands. 
 are real today, not proposed:
 
 - `rulePack` (a path to a JSON file, or an inline object) and `approvedTerms` are both shared-config
-  options. They let a repository supply its own vocabulary on top of the bundled provisional pack.
-  See [`docs/configuration.md`](docs/configuration.md) and
+  options. `approvedTerms` layers on top of whichever pack is active. `rulePack` replaces the
+  bundled provisional pack entirely, not just adds to it. See
+  [`docs/configuration.md`](docs/configuration.md) and
   [`docs/rule-pack-import.md`](docs/rule-pack-import.md).
 - The CLI's exit codes are the ones a hook needs.
   - `0` — clean
   - `1` — errors present (or review-required, with `--fail-on-review`)
   - `2` — usage error
-  - `3` — any `error`-level run notice: a protection mechanism itself failing (the semantic
-    service, or an `extraProtectedPatterns` entry refused by the screen in
-    [`docs/configuration.md`](docs/configuration.md#protected-patterns-are-screened-before-they-run)),
-    or a configured rule skipped for invalid options
+  - `3` — any `error`-level run notice. See
+    [`docs/configuration.md`](docs/configuration.md#protected-patterns-are-screened-before-they-run)
+    for the full list: a protection mechanism failing, or a rule skipped for invalid options
 
 ```yaml
 # .pre-commit-config.yaml — works with prek too, same config format
@@ -215,16 +216,9 @@ is never autofixed.)` See [`docs/diagnostic-policy.md`](docs/diagnostic-policy.m
 
 ## Optional semantic adjudication
 
-Eight bounded evaluators exist, each with a versioned prompt asset in `prompts/v1/`:
-
-- `approved-word-sense`
-- `permitted-part-of-speech`
-- `one-instruction-per-sentence`
-- `passive-voice-adjudication`
-- `pronoun-antecedent-ambiguity`
-- `noun-cluster-comprehension`
-- `technical-term-legitimacy`
-- `rewrite-equivalence`
+A fixed set of bounded evaluators exist, each with a versioned prompt asset in `prompts/v1/`. Run
+`npx ste-ai evaluators` for the current list. This list reads from the live registry, so it stays
+correct as evaluators are added or removed.
 
 One broker mediates every request. It handles:
 
@@ -254,7 +248,8 @@ npx ste-ai rules --json
 npx ste-ai evaluators
 ```
 
-Exit codes: `0` clean, `1` errors, `2` usage, `3` semantic-service failure under the `error` policy.
+Exit codes: `0` clean, `1` errors, `2` usage, `3` any `error`-level run notice. See "Who this
+serves, and how" above for the full list of triggers.
 
 ## Programmatic API
 
@@ -273,20 +268,15 @@ console.log(full.notices, full.traces, full.pack.metadata.conformanceClaim);
 
 ## Fixture corpus
 
-The corpus has 18 excerpts of real licensed documentation, drawn from these sources:
+The corpus is real licensed documentation. Each excerpt has a rewritten counterpart and an
+adjudication record. `fixtures/manifest.json` is the source of truth for the excerpt count and the
+source organisations:
 
-- SQLite
-- PostgreSQL
-- Apache httpd
-- Zephyr
-- LLVM
-- Kubernetes
-- Django
-- Curl
-- Node.js
-- The U.S. Occupational Safety and Health Administration (OSHA)
-
-Each excerpt has a rewritten counterpart and an adjudication record.
+```bash
+node -e "const m = require('./fixtures/manifest.json'); \
+  console.log(m.fixtures.length, 'excerpts from', new Set(m.fixtures.map(f => f.sourceOrganisation)).size, 'sources'); \
+  console.log([...new Set(m.fixtures.map(f => f.sourceOrganisation))].join('\n'))"
+```
 
 Provenance is machine-checkable. A fetch script records the real HTTP status and `SHA-256` checksum of
 every source. The validator cross-checks the manifest against it.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,44 @@
 # textlint-rule-preset-ste-ai
 
-A linter that lets an AI agent gate the documents it writes for clarity, readability, and vocabulary
-consistency — checked against a checkable, per-project-approved vocabulary, not just a generic style
-guide. "Write following ASD-STE100 guidelines" is already a prompt pattern agents respond well to,
-producing shorter, clearer text; this package turns that pattern into something enforceable and
-gateable instead of a hope. It ships deterministic textlint rules, plus an **optional**
-semantic-adjudication subsystem that calls a small model served locally by llama.cpp for the checks
-that genuinely need judgement. It is meant to run inside a pre-commit hook — Husky, prek, or the
-Python `pre-commit` framework, invoked via `npx` — most often checking documentation an AI agent has
-just drafted, so the agent's vocabulary stays consistent with the project's before the commit lands.
+This is a linter for an AI (artificial intelligence) agent's own writing. It gates the documents an
+agent drafts for clarity, readability, and vocabulary consistency. It checks against a
+per-project-approved vocabulary. That is a checkable target. A generic style guide is not.
 
-> **This package does not implement ASD-STE100 and makes no claim of conformance with it.** The
-> standard and its dictionary are proprietary and were not available to this repository. ASD-STE100
+"Write following ASD-STE100 guidelines" is already a prompt pattern that agents respond well to. It
+produces shorter, clearer text. This package turns that pattern into something enforceable and
+gateable, not just a hope. It ships deterministic textlint rules. It also ships an **optional**
+semantic-adjudication subsystem. That subsystem calls a small model, served locally by llama.cpp, for
+the checks that genuinely need judgement.
+
+It is meant to run inside a pre-commit hook. Husky, prek, and the Python `pre-commit` framework all
+work, invoked via `npx`. It most often checks documentation an agent has just drafted. That way, the
+agent's vocabulary stays consistent with the project's own, before the commit lands.
+
+> **This package does not implement ASD-STE100 and makes no claim of conformance with it**. The
+> standard and its dictionary are proprietary. Neither was available to this repository. ASD-STE100
 > is referenced here as a known target agents already understand, not as a specification this
-> package reproduces. Every rule shipped here is an authored plain-English heuristic marked
+> package reproduces. Every rule shipped here is an authored plain-English heuristic, marked
 > `provisional`. Read [`docs/DISCLAIMER.md`](docs/DISCLAIMER.md) before using this anywhere it
 > matters.
 
 ## The idea
 
 Deterministic rules stay deterministic. A model only adjudicates the things that genuinely depend on
-syntax, context, meaning or technical-domain interpretation — and when it does, its output is
-schema-validated, threshold-gated, span-anchored and traced.
+syntax, context, meaning, or technical-domain interpretation. Only then is its output
+schema-validated, threshold-gated, span-anchored, and traced.
 
 ```
                     ┌────────────────────────────────┐
-  markdown / text → │ pluggable document reader →    │ → deterministic rules → violations
+  markdown / text → │ document reader →              │ → deterministic rules → violations
                     │ text units → sentences → words │ ↘
                     │ (offsets preserved throughout) │   candidates → broker → evaluator → verdict
                     └────────────────────────────────┘        (optional, local, off by default)
 ```
 
-Document structure is read through a real parser (`@textlint/markdown-to-ast` for Markdown today) via
-a pluggable `DocumentReader` interface, not hand-written regex over masked text; see
-[`docs/architecture.md`](docs/architecture.md) for the reasoning and
-[issue #25](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/25) for the history.
+Markdown structure is read through a real parser, [`@textlint/markdown-to-ast`](https://www.npmjs.com/package/@textlint/markdown-to-ast),
+not hand-written regex over masked text. See [`docs/architecture.md`](docs/architecture.md) for the
+reasoning and [issue #25](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/25)
+for the history.
 
 ## Install
 
@@ -56,27 +60,31 @@ npx textlint docs/**/*.md
 npx textlint --fix docs/**/*.md     # applies only gated fixes
 ```
 
-No model is needed. Semantic analysis is off by default and the deterministic rules never touch the
+No model is needed. Semantic analysis is off by default. The deterministic rules never touch the
 network.
 
 ## Who this serves, and how
 
-The intended audience is an AI agent generating text, and the goal is keeping that agent's vocabulary
-consistent with the project's own approved/preferred/unapproved terms — plus any further list a
-specific repository wants layered on top of the bundled provisional pack. That serves three distinct
-consumer surfaces, at different stages of readiness. They are not the same shape and should not be
-conflated:
+The intended audience is an AI agent generating text. The goal: keep that agent's vocabulary
+consistent with the project's own approved, preferred, and unapproved terms. A repository can also
+layer its own list on top of the bundled provisional pack.
 
-**1. Pre-commit hooks — works today.** Husky, prek, or the Python `pre-commit` framework, invoked via
-`npx`, linting documentation files before a commit lands. Both pieces this needs are real today, not
-proposed:
+That serves three distinct consumer surfaces, at different stages of readiness. They are not the same
+shape, and should not be conflated.
 
-- `rulePack` (a path to a JSON file, or an inline object) and `approvedTerms` in the shared config let
-  a repository supply its own vocabulary on top of the bundled provisional pack — see
-  [`docs/configuration.md`](docs/configuration.md) and
+**1. Pre-commit hooks — works today**. Husky, prek, and the Python `pre-commit` framework can all
+invoke this via `npx`. Each can lint documentation files before a commit lands. Both pieces this needs
+are real today, not proposed:
+
+- `rulePack` (a path to a JSON file, or an inline object) and `approvedTerms` are both shared-config
+  options. They let a repository supply its own vocabulary on top of the bundled provisional pack.
+  See [`docs/configuration.md`](docs/configuration.md) and
   [`docs/rule-pack-import.md`](docs/rule-pack-import.md).
-- The CLI's exit codes are the ones a hook needs: `0` clean, `1` errors present (or review-required
-  with `--fail-on-review`), `2` usage error, `3` semantic-service failure under the `error` policy.
+- The CLI's exit codes are the ones a hook needs.
+  - `0` — clean
+  - `1` — errors present (or review-required, with `--fail-on-review`)
+  - `2` — usage error
+  - `3` — semantic-service failure, under the `error` policy
 
 ```yaml
 # .pre-commit-config.yaml — works with prek too, same config format
@@ -95,26 +103,32 @@ repos:
 npx ste-ai lint docs/**/*.md --fail-on-review
 ```
 
-**2. An authoring agent consulting the vocabulary in-loop — proposed, not built.** The agent checks
-its own draft voluntarily, mid-composition, rather than being checked after the fact: exporting the
-merged vocabulary as a machine-readable artefact to consult _before_ drafting
-([issue #2](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/2)), and an MCP server —
-`check_text`, `lookup_term`, `list_vocabulary` — so the agent can check text and look up terms in-loop
-instead of shelling out to the CLI per iteration
-([issue #5](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/5)). Resolving a rule pack from
-a package name or a URL with a required integrity digest, so an organisation shares one vocabulary
-across repositories instead of copying a JSON file into each, matters to this surface too
-([issue #3](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/3)).
+**2. An authoring agent consulting the vocabulary in-loop — proposed, not built**. The agent would
+check its own draft voluntarily, during composition, not just after the fact:
 
-**3. A blocking Claude Code hook gating live agent/user communication — proposed, not built, and
-currently blocked.** Checking that outgoing messages — assistant to user, or between sub-agents and
-an orchestrator — stay on the same agreed vocabulary, before they are sent. This is a different
-integration shape from surface 2: a hook is invoked by the harness, not by the agent's own choice, and
-it conventionally receives text on stdin and reports pass/fail through its exit code, not through MCP.
-It cannot be wired up yet: `lint` only reads files, via `readFileSync`, and exits `2` with no file
-arguments — there is no stdin path. The programmatic API
-(`analyseTextDeterministic`/`analyseText`) already accepts an arbitrary string with no file
-dependency, so this is a gap in the CLI surface only, not in the underlying analysis. Tracked as
+- Exporting the merged vocabulary as a machine-readable artefact would let the agent consult it
+  before drafting. Tracked as [issue #2](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/2).
+- A Model Context Protocol (MCP) server would expose `check_text`, `lookup_term`, and
+  `list_vocabulary`. The agent could then check text and look up terms in-loop. It would no longer
+  need to shell out to the CLI on every iteration. Tracked as
+  [issue #5](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/5).
+- A rule pack could also resolve from a package name or a URL, with a required integrity digest. That
+  would let an organisation share one vocabulary across every repository, instead of copying a JSON
+  file into each. Tracked as [issue #3](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/3).
+
+**3. A blocking Claude Code hook gating live agent or user communication — proposed, not built, and
+currently blocked**. The goal is to check outgoing messages before they are sent. That covers
+assistant-to-user messages, and messages between sub-agents and an orchestrator. All of them must stay
+on one agreed vocabulary.
+
+This is a different integration shape from surface 2. A hook is invoked by the harness, not by the
+agent's own choice. It conventionally receives text on stdin, and reports pass or fail through its
+exit code, not through MCP.
+
+It cannot be wired up yet. `lint` only reads files, via `readFileSync`, and exits `2` with no file
+arguments. There is no stdin path. The programmatic API (`analyseTextDeterministic`/`analyseText`)
+already accepts an arbitrary string, with no file dependency. This gap is in the CLI surface only, not
+in the underlying analysis. Tracked as
 [issue #26](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/26).
 
 ## The 14 rules
@@ -136,64 +150,89 @@ dependency, so this is a gap in the CLI surface only, not in the underlying anal
 | `noun-cluster-candidate`       | **no** — candidate | –                                    |
 | `ambiguous-pronoun-candidate`  | **no** — candidate | –                                    |
 
-Candidate rules never assert a violation. They detect a shape that cannot be decided lexically and
-hand it to a named evaluator; with semantic analysis off they report `review-required`. Each rule's
-trigger, rationale and **observed failure modes** are in
+Candidate rules never assert a violation. Each one detects a shape that cannot be decided lexically,
+and hands it to a named evaluator. With semantic analysis off, each reports `review-required` instead.
+Each rule's trigger, rationale, and **observed failure modes** are in
 [`docs/provisional-rules.md`](docs/provisional-rules.md).
 
 ## Five diagnostic categories
 
 | Category                      | Meaning                                                                                              |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `deterministic-violation`     | an exact trigger fired; no inference                                                                 |
+| `deterministic-violation`     | an exact trigger fired — no inference                                                                |
 | `probable-semantic-violation` | a model said `violation` at or above your threshold                                                  |
 | `review-required`             | undecidable: unadjudicated heuristic, `uncertain` verdict, or a passage the service could not decide |
 | `suppressed-low-confidence`   | a `violation` below threshold, discarded                                                             |
 | `infrastructure-failure`      | the tooling failed — never a statement about the document                                            |
 
-**A model outage is never converted into compliance.** Affected passages become `review-required` and
+**A model outage is never converted into compliance.** Affected passages become `review-required`, and
 a run notice records how many. See [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md).
 
 ## Inline suppression
 
 `<!-- ste-ai-ignore-next-line rule-id -- reason -->` withholds one finding instead of disabling a
-provisional rule everywhere; the reason is required, the withheld finding is still recorded in
-`suppressions` and in `--json`, and a claim inside a danger, warning or caution admonition is
-refused by default. See [`docs/suppression.md`](docs/suppression.md).
+provisional rule everywhere. The reason is required. The withheld finding is still recorded in
+`suppressions` and in `--json`. A claim inside a danger, warning, or caution admonition is refused by
+default. See [`docs/suppression.md`](docs/suppression.md).
 
 ## What is protected
 
-Code fences, inline code, shell commands, configuration fragments, URLs, email addresses, file paths,
-identifiers, API and field names, constants, placeholders, quoted UI literals, quantities and units,
-version strings, table markup, front matter, HTML, and any terminology you declare in `approvedTerms`.
+Protected content is masked before segmentation and matching, so it is never checked against a
+vocabulary list. A content-bearing literal still counts toward sentence-length word counts, because a
+reader still has to read `25 Nm`. Masking **preserves length exactly**, so every offset a rule produces
+is a valid offset into your original file.
 
-Protected content is masked before segmentation and matching, and masking **preserves length exactly** —
-so every offset a rule produces is a valid offset into your original file. Content-bearing literals
-still count as one word toward sentence-length limits (a reader has to read `25 Nm`) but are never
-matched against a vocabulary list.
+What counts as protected:
+
+- code fences, inline code, and shell commands
+- configuration fragments, file paths, and URLs or email addresses
+- identifiers, API and field names, constants, and placeholders
+- quoted user interface (UI) literals
+- quantities, units, and version strings
+- table markup, front matter, and raw HTML
+- any terminology you declare in `approvedTerms`
 
 ## Autofix, and why it usually refuses
 
-A fix must be either a closed deterministic substitution that cannot change meaning, or a model
-rewrite that passed an **independent** meaning-preservation gate. Never autofixed: anything in a
-warning, caution, danger or note; anything that changes a digit, a negation, a modal verb or an
-ordering word; anything overlapping a protected region. Two rules proposing overlapping edits causes
-both to be refused.
+A fix needs one of two things to exist at all:
 
-When a fix is withheld the diagnostic says why: `(No automatic fix: content in a warning admonition is
-never autofixed.)` See [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md#autofix-policy).
+- a closed, deterministic substitution that cannot change meaning
+- a model rewrite that passed an **independent** meaning-preservation gate
+
+Several things are never autofixed:
+
+- content in a warning, caution, danger, or note admonition
+- anything that changes a digit, a negation, a modal verb, or an ordering word
+- anything overlapping a protected region
+
+When two rules propose overlapping edits, both are refused.
+
+When a fix is withheld, the diagnostic says why: `(No automatic fix: content in a warning admonition
+is never autofixed.)` See [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md#autofix-policy).
 
 ## Optional semantic adjudication
 
-Eight bounded evaluators, each with a versioned prompt asset in `prompts/v1/`:
-`approved-word-sense`, `permitted-part-of-speech`, `one-instruction-per-sentence`,
-`passive-voice-adjudication`, `pronoun-antecedent-ambiguity`, `noun-cluster-comprehension`,
-`technical-term-legitimacy`, `rewrite-equivalence`.
+Eight bounded evaluators exist, each with a versioned prompt asset in `prompts/v1/`:
 
-One broker mediates every request: bounded concurrency, deterministic ordering, content-hash caching
-and de-duplication, timeouts, cancellation, schema validation, retry for transport faults only, and at
-most one bounded repair re-ask. Model confidence is recorded verbatim as `modelReportedConfidence` and
-compared against operator-owned thresholds — it is not treated as a calibrated probability.
+- `approved-word-sense`
+- `permitted-part-of-speech`
+- `one-instruction-per-sentence`
+- `passive-voice-adjudication`
+- `pronoun-antecedent-ambiguity`
+- `noun-cluster-comprehension`
+- `technical-term-legitimacy`
+- `rewrite-equivalence`
+
+One broker mediates every request. It handles:
+
+- bounded concurrency and deterministic ordering
+- content-hash caching and de-duplication
+- timeouts and cancellation
+- schema validation
+- retry for transport faults only, and at most one bounded repair re-ask
+
+Model confidence is recorded verbatim as `modelReportedConfidence`, and compared against
+operator-owned thresholds. It is not treated as a calibrated probability.
 
 ```json
 { "semantic": { "enabled": true, "endpoint": "http://127.0.0.1:8080", "model": "my-model" } }
@@ -231,10 +270,23 @@ console.log(full.notices, full.traces, full.pack.metadata.conformanceClaim);
 
 ## Fixture corpus
 
-18 excerpts of real licensed documentation — SQLite, PostgreSQL, Apache httpd, Zephyr, LLVM,
-Kubernetes, Django, curl, Node.js, OSHA — each with a rewritten counterpart and an adjudication
-record. Provenance is machine-checkable: a fetch script records the real HTTP status and SHA-256 of
-every source, and the validator cross-checks the manifest against it.
+The corpus has 18 excerpts of real licensed documentation, drawn from these sources:
+
+- SQLite
+- PostgreSQL
+- Apache httpd
+- Zephyr
+- LLVM
+- Kubernetes
+- Django
+- Curl
+- Node.js
+- The U.S. Occupational Safety and Health Administration (OSHA)
+
+Each excerpt has a rewritten counterpart and an adjudication record.
+
+Provenance is machine-checkable. A fetch script records the real HTTP status and `SHA-256` checksum of
+every source. The validator cross-checks the manifest against it.
 
 ```bash
 vp run fixtures:validate
@@ -244,11 +296,18 @@ See [`docs/fixtures.md`](docs/fixtures.md).
 
 ## Supplying authorised material
 
-`src/rule-pack/` is the single import boundary. No rule hard-codes vocabulary: limits, word lists,
-term mappings, contractions and per-rule authority all come from the active pack. Supply a licensed
-pack and diagnostics report its authority and citations instead of `provisional`.
+`src/rule-pack/` is the single import boundary. No rule hard-codes vocabulary. The active pack
+supplies:
 
-A pack cannot add a rule, cannot bypass the autofix gate, and cannot make the linter print a
+- limits
+- word lists
+- term mappings
+- contractions
+- per-rule authority
+
+Supply a licensed pack, and diagnostics report its authority and citations instead of `provisional`.
+
+A pack cannot add a rule. A pack cannot bypass the autofix gate. A pack cannot make the linter print a
 conformance claim. See [`docs/rule-pack-import.md`](docs/rule-pack-import.md).
 
 ## Development
@@ -263,25 +322,25 @@ vp run verify             # all of the above
 vp run eval:semantic -- --split heldout --endpoint http://127.0.0.1:8080   # needs a model
 ```
 
-| Document                                                         | Contents                                        |
-| ---------------------------------------------------------------- | ----------------------------------------------- |
-| [`docs/DISCLAIMER.md`](docs/DISCLAIMER.md)                       | why this is not ASD-STE100                      |
-| [`docs/architecture.md`](docs/architecture.md)                   | modules, the offset contract, the rule contract |
-| [`docs/provisional-rules.md`](docs/provisional-rules.md)         | every rule, with its observed failure modes     |
-| [`docs/rule-authoring.md`](docs/rule-authoring.md)               | writing a rule                                  |
-| [`docs/publishing.md`](docs/publishing.md)                       | publishing releases to npm with trusted OIDC    |
-| [`docs/semantic-evaluators.md`](docs/semantic-evaluators.md)     | evaluators, prompt contract, measurement        |
-| [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md)         | categories, outage policy, autofix policy       |
-| [`docs/suppression.md`](docs/suppression.md)                     | inline directives, and what they record         |
-| [`docs/configuration.md`](docs/configuration.md)                 | every option                                    |
-| [`docs/rule-pack-import.md`](docs/rule-pack-import.md)           | supplying licensed material                     |
-| [`docs/llama-cpp-setup.md`](docs/llama-cpp-setup.md)             | running the model service                       |
-| [`docs/fixtures.md`](docs/fixtures.md)                           | the corpus and its provenance                   |
-| [`docs/implementation-report.md`](docs/implementation-report.md) | what was built and verified                     |
-| [`docs/extension-roadmap.md`](docs/extension-roadmap.md)         | where this goes next, and what is blocked       |
+| Document                                                         | Contents                                                       |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`docs/DISCLAIMER.md`](docs/DISCLAIMER.md)                       | why this is not ASD-STE100                                     |
+| [`docs/architecture.md`](docs/architecture.md)                   | modules, the offset contract, the rule contract                |
+| [`docs/provisional-rules.md`](docs/provisional-rules.md)         | every rule, with its observed failure modes                    |
+| [`docs/rule-authoring.md`](docs/rule-authoring.md)               | writing a rule                                                 |
+| [`docs/publishing.md`](docs/publishing.md)                       | publishing releases to npm, with trusted OpenID Connect (OIDC) |
+| [`docs/semantic-evaluators.md`](docs/semantic-evaluators.md)     | evaluators, prompt contract, measurement                       |
+| [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md)         | categories, outage policy, autofix policy                      |
+| [`docs/suppression.md`](docs/suppression.md)                     | inline directives, and what they record                        |
+| [`docs/configuration.md`](docs/configuration.md)                 | every option                                                   |
+| [`docs/rule-pack-import.md`](docs/rule-pack-import.md)           | supplying licensed material                                    |
+| [`docs/llama-cpp-setup.md`](docs/llama-cpp-setup.md)             | running the model service                                      |
+| [`docs/fixtures.md`](docs/fixtures.md)                           | the corpus and its provenance                                  |
+| [`docs/implementation-report.md`](docs/implementation-report.md) | what was built and verified                                    |
+| [`docs/extension-roadmap.md`](docs/extension-roadmap.md)         | where this goes next, and what is blocked                      |
 
 ## Licence
 
-MIT. Fixture excerpts retain their upstream licences — see `fixtures/LICENSES.md`.
-"ASD-STE100" and "Simplified Technical English" are trademarks of ASD, Brussels, Belgium; this project
-is not affiliated with or endorsed by ASD or the ASD STEMG.
+MIT. Fixture excerpts retain their upstream licences — see `fixtures/LICENSES.md`. "ASD-STE100" and
+"Simplified Technical English" are trademarks of ASD, Brussels, Belgium. This project is not
+affiliated with or endorsed by ASD or the ASD Simplified Technical English Maintenance Group (STEMG).


### PR DESCRIPTION
## Summary

README.md failed the preset's own linter against its default rules — 62 `deterministic-violation` errors (blocking) plus 62 `review-required` notices. A document telling operators to run this linter on their own prose while failing it itself undercuts the pitch. This rewrite brings it into compliance without contorting the prose to dodge the semantic-review-required findings, which stayed roughly flat by design.

- `deterministic-violation`: **62 → 3** (the 3 remaining are deliberate, justified abbreviation judgment calls — see below, not oversights)
- `review-required`: 62 → 65 (flat by design; task explicitly avoided rewriting prose just to dodge these)

Baseline breakdown: `sentence-length-descriptive` (28), `punctuation-constraints` (23), `abbreviation-introduction` (10), `sentence-length-procedural` (1). All of `sentence-length-*` and `punctuation-constraints` are now zero.

## Abbreviation judgment calls (3 left unexpanded)

- **ASD** — left as-is. The project's own `docs/DISCLAIMER.md` uses "ASD" throughout as a proprietary trademark-holder name without ever expanding it; the full name isn't documented anywhere in this repo, and expanding only in the README would be inconsistent with established project convention.
- **LLVM** — left as-is. It appears in a plain list of documentation-source project names; the LLVM project itself no longer treats "LLVM" as an acronym (it dropped the "Low Level Virtual Machine" backronym), so expanding it would be stylistically stilted and arguably inaccurate.
- **MIT** — left as-is (Licence section). It's a standard SPDX license identifier; expanding to "Massachusetts Institute of Technology License" is not standard practice and adds no value.

Expanded (genuinely helped a first-time reader): AI → "AI (artificial intelligence)", MCP → "Model Context Protocol (MCP)", UI → "user interface (UI)", OIDC → "OpenID Connect (OIDC)", OSHA → "The U.S. Occupational Safety and Health Administration (OSHA)", STEMG → "the ASD Simplified Technical English Maintenance Group (STEMG)" (full form taken verbatim from `docs/DISCLAIMER.md`).

## Structural/content changes

- Split every long/compound sentence the linter flagged, verified against `src/deterministic/rules/sentence-length.ts`'s thresholds (grade 7 procedural / grade 8 descriptive, 20-word floor).
- Converted several comma-heavy or semicolon-joined runs into bullet lists (protected-content list, autofix "never autofixed" list, evaluator names, broker responsibilities, fixture-corpus sources, exit codes) — genuinely more scannable, not just rule-dodging.
- Found and fixed a real sentence-splitter quirk: a period placed *inside* `**bold**` markup right before more prose silently merges with the following sentence, inflating its word count. Fixed throughout by moving the closing `**` before the period. Verified in isolation with the built CLI.
- Fixed a stale accuracy claim: "The idea" section no longer says structure is read via a "pluggable `DocumentReader` interface" — that interface was removed (per `docs/architecture.md`). Reworded to describe the actual current mechanism (`@textlint/markdown-to-ast` via synchronous `readMarkdownUnitsSync`/`readPlainTextUnitsSync`).
- Verified all other technical claims against source: rule count (14, `src/deterministic/rules/*.ts`), evaluator count (8, `src/semantic/evaluators.ts`), fixture count (18 files matching the 10 listed sources), CLI flags/exit codes (`src/cli/main.ts`), `vp run` task names (`vite.config.ts`), `examples/.textlintrc.json` snippet, default well-known abbreviation list (matches `mechanics.ts` exactly, unchanged).
- Preserved section order and overall information architecture; only reorganized within sections where compliance/clarity required it.

## Test plan

- [x] `vp check` — passes clean (format + lint + typecheck)
- [x] Verified before/after lint counts against the built CLI (`node dist/cli/main.js lint README.md --json`)
- [x] All technical claims re-verified against current source, not carried over from the prior README
- [ ] `vp test` — not run in this worktree; the sandbox's globally-installed `vp` resolves a different vitest version (4.1.11) than the repo's pinned one (4.1.10 in `node_modules`), producing an unrelated dual-instance failure across the whole suite. Confirmed via `git stash` that this reproduces identically against unmodified `main` — this change touches only `README.md`, so it cannot be the cause. Real CI uses a pinned `setup-vp` action, not this sandbox's global install.

Only `README.md` is touched by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ukt8p4f3K9mX7FHWbMK17)_