### PR TITLE
test: include src/cli in coverage and re-tune thresholds to the honest number

### DIFF
--- a/docs/design/64-layered-rule-packs/03-migration-verification.md
+++ b/docs/design/64-layered-rule-packs/03-migration-verification.md
@@ -285,8 +285,8 @@ Conventions observed in `test/`: vitest with `globals: true` (`vitest.config.ts:
 (`shared-config-merge.test.ts:7-24`), and cache-clearing seams called in `beforeEach`
 (`clearSharedConfigCache`, `clearAnalysisCache`).
 
-Coverage thresholds are enforced only under `--coverage` (`vitest.config.ts:15-35`: statements 91,
-branches 81, functions 91, lines 94) and CI runs `test:coverage` (`ci.yml:45`). New unreached
+Coverage thresholds are enforced only under `--coverage` (see the `coverage.thresholds` block in
+`vite.config.ts` for current values) and CI runs `test:coverage` (`ci.yml:45`). New unreached
 branches in `src/rule-pack/` will pull these down, so tests are not optional for the thresholds
 either.
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,13 +84,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],
-      exclude: ['src/**/index.ts', 'src/cli/**'],
+      exclude: ['src/**/index.ts'],
       reporter: ['text-summary', 'lcov'],
       thresholds: {
-        statements: 91,
-        branches: 81,
-        functions: 91,
-        lines: 94,
+        statements: 90,
+        branches: 79,
+        functions: 90,
+        lines: 92,
       },
     },
   },


### PR DESCRIPTION
## Objective

Another item from #77's "Still to come": `vite.config.ts` excluded `src/cli/**` from coverage
entirely, even though `test/integration/cli-output.test.ts` does exercise it. The exclusion was
discarding real signal.

## Change

Removed `src/cli/**` from `coverage.exclude`, and re-tuned the four global thresholds down to keep
a working gate:

| | Old threshold | New measured | New threshold |
|---|---|---|---|
| Statements | 91 | 91.09% | 90 |
| Branches | 81 | 80.39% | 79 |
| Functions | 91 | 91.68% | 90 |
| Lines | 94 | 93.66% | 92 |

## The drop is not noise — it's a real gap

`src/cli/main.ts` itself is genuinely under-tested. From the lcov detail with the exclusion
removed, these are entirely uncalled (0 invocations across the whole suite):

- `listRules`
- `listEvaluators`
- `isSeverityKey`
- the constructor's error path

Lowering the threshold makes the coverage gate honest about what's actually covered today; it does
**not** close that gap. I considered writing tests for these as part of this change and decided
against it — that's real, separate work (a CLI test file, not a config tweak), and folding it in
here would hide a config change inside a test-writing task. Flagging it here instead: `listRules`
and `listEvaluators` in particular look like they'd be cheap, high-value additions to
`cli-output.test.ts` if someone wants to pick that up next.

## Verification

- `vp check` — clean.
- `vp test --coverage` — 639/639 passing, coverage report above, all four thresholds pass.
- Rebases cleanly on post-#77 `main` (`b6d23ec`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVxydRFLKJVt6L6TYaxiK)_