### PR TITLE
test: cover the semantic verdict → TextlintMessage boundary end-to-end

### DIFF
--- a/test/e2e/textlint-semantic-boundary.test.ts
+++ b/test/e2e/textlint-semantic-boundary.test.ts
@@ -13,18 +13,12 @@ import {
 /**
  * Boundary coverage for the semantic → `TextlintMessage` path.
  *
- * `test/integration/semantic-service.test.ts` and `test/integration/suppression.test.ts` both drive
- * `analyseText` directly and assert only on `result.diagnostics`/`result.notices` — the internal
- * `Diagnostic` shape. `src/textlint/adapter.ts` (`getAnalysis`, `formatMessage`,
- * `toTextlintSeverity`, the `Document` handler's report loop) is not imported by either file, so
- * nothing proved a *semantic* verdict — as opposed to a deterministic one, which
- * `test/e2e/textlint-run.test.ts` already exercises — survives the adapter and reaches the
- * `TextlintMessage[]` array a real textlint consumer receives.
- *
- * These tests run the real kernel, the real markdown plugin and the real preset rule module against
- * a real HTTP fake of the semantic service (`startFakeSemanticService`, the same double
- * `test/integration/semantic-service.test.ts` uses), and assert on `result.messages` — never on
- * `Diagnostic`.
+ * `src/textlint/adapter.ts` (`getAnalysis`, `formatMessage`, `toTextlintSeverity`, the `Document`
+ * handler's report loop) is what turns an internal `Diagnostic` into the `TextlintMessage` a real
+ * textlint consumer receives. These tests prove a *semantic* verdict specifically — as opposed to a
+ * deterministic one — survives that adapter, by running the real kernel, the real markdown plugin
+ * and the real preset rule module against a real HTTP fake of the semantic service
+ * (`startFakeSemanticService`), and asserting on `result.messages` — never on `Diagnostic`.
  */
 
 function isTextlintPluginCreator(value: unknown): value is TextlintPluginCreator {

--- a/test/e2e/textlint-semantic-boundary.test.ts
+++ b/test/e2e/textlint-semantic-boundary.test.ts
@@ -1,0 +1,201 @@
+import { TextlintKernel, type TextlintPluginCreator } from '@textlint/kernel';
+import markdownPluginModule from '@textlint/textlint-plugin-markdown';
+import type { TextlintRuleModule } from '@textlint/types';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { clearAnalysisCache } from '../../src/textlint/adapter.js';
+import { rules } from '../../src/textlint/preset.js';
+import {
+  startFakeSemanticService,
+  verdictJson,
+  type FakeService,
+} from '../helpers/fake-semantic-service.js';
+
+/**
+ * Boundary coverage for the semantic → `TextlintMessage` path.
+ *
+ * `test/integration/semantic-service.test.ts` and `test/integration/suppression.test.ts` both drive
+ * `analyseText` directly and assert only on `result.diagnostics`/`result.notices` — the internal
+ * `Diagnostic` shape. `src/textlint/adapter.ts` (`getAnalysis`, `formatMessage`,
+ * `toTextlintSeverity`, the `Document` handler's report loop) is not imported by either file, so
+ * nothing proved a *semantic* verdict — as opposed to a deterministic one, which
+ * `test/e2e/textlint-run.test.ts` already exercises — survives the adapter and reaches the
+ * `TextlintMessage[]` array a real textlint consumer receives.
+ *
+ * These tests run the real kernel, the real markdown plugin and the real preset rule module against
+ * a real HTTP fake of the semantic service (`startFakeSemanticService`, the same double
+ * `test/integration/semantic-service.test.ts` uses), and assert on `result.messages` — never on
+ * `Diagnostic`.
+ */
+
+function isTextlintPluginCreator(value: unknown): value is TextlintPluginCreator {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'Processor' in value &&
+    typeof value.Processor === 'function'
+  );
+}
+
+function asTextlintPluginCreator(value: unknown, packageName: string): TextlintPluginCreator {
+  if (!isTextlintPluginCreator(value)) {
+    throw new Error(`${packageName}'s default export is not TextlintPluginCreator-shaped.`);
+  }
+  return value;
+}
+
+const markdownPlugin = asTextlintPluginCreator(
+  markdownPluginModule,
+  '@textlint/textlint-plugin-markdown',
+);
+
+const kernel = new TextlintKernel();
+
+function mustGetRule(id: string): TextlintRuleModule {
+  const rule = rules[id];
+  if (rule === undefined) {
+    throw new Error(`preset does not define a rule named "${id}"`);
+  }
+  return rule;
+}
+
+/**
+ * A passage `one-instruction-per-sentence` (deterministic/rules/candidate-rules.ts) flags as a
+ * comma-joined clause with a second candidate imperative verb — a real candidate for semantic
+ * adjudication, confirmed directly (`analyseTextDeterministic` on this text, semantic disabled,
+ * reports a `review-required` diagnostic for `one-instruction-per-sentence` spanning the whole
+ * sentence). Never asserted as a compliance failure on its own; the semantic verdict decides it.
+ */
+const TWO_ACTIONS = 'Remove the cover, install the new filter.\n';
+
+function lintOptions(endpoint: string, overrides: Record<string, unknown> = {}) {
+  return {
+    ext: '.md',
+    plugins: [{ pluginId: 'markdown', plugin: markdownPlugin }],
+    rules: [
+      {
+        ruleId: 'one-instruction-per-sentence',
+        rule: mustGetRule('one-instruction-per-sentence'),
+        options: {
+          shared: {
+            semantic: {
+              enabled: true,
+              endpoint,
+              model: 'fake-model',
+              maxTransportRetries: 0,
+              maxRepairAttempts: 0,
+              cache: false,
+            },
+            ...overrides,
+          },
+        },
+      },
+    ],
+  };
+}
+
+let service: FakeService | undefined;
+
+beforeEach(() => {
+  clearAnalysisCache();
+});
+
+afterEach(async () => {
+  await service?.close();
+  service = undefined;
+});
+
+describe('semantic verdicts crossing the textlint adapter boundary', () => {
+  it('a violation verdict reaches the emitted TextlintMessage with message, range and severity', async () => {
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        const user = body.messages?.find((m) => m.role === 'user')?.content ?? '';
+        const ruleId = /ruleId:\s*(\S+)/.exec(user)?.[1] ?? 'unknown';
+        return {
+          content: verdictJson({
+            ruleId,
+            status: 'violation',
+            confidence: 0.93,
+            // Evidence span into the passage ("Remove"), distinct from the candidate's own
+            // whole-sentence range -- proves the *evidence* offset is what reaches textlint, not
+            // just the candidate's start.
+            evidenceStart: 0,
+            evidenceEnd: 6,
+            explanation: 'DISTINCTIVE_SEMANTIC_VIOLATION_MARKER',
+            suggestedReplacements: [],
+            meaningPreserved: false,
+          }),
+        };
+      },
+    });
+
+    const result = await kernel.lintText(TWO_ACTIONS, lintOptions(service.url));
+
+    expect(result.messages).toHaveLength(1);
+    const message = result.messages[0];
+    expect(message?.ruleId).toBe('one-instruction-per-sentence');
+    expect(message?.message).toContain('DISTINCTIVE_SEMANTIC_VIOLATION_MARKER');
+    // Default `probable-semantic-violation` severity is `warning`, textlint level 1 -- distinct
+    // from the `error` (2) a deterministic violation defaults to, and from `info` (3).
+    expect(message?.severity).toBe(1);
+    // The evidence span "Remove" (offset 0-6) on line 1.
+    expect(message?.loc.start.line).toBe(1);
+    expect(message?.loc.start.column).toBe(1);
+    expect(message?.loc.end.column).toBe(7);
+    expect(message?.range).toEqual([0, 6]);
+  });
+
+  it('a compliant verdict emits no TextlintMessage for that passage', async () => {
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        const user = body.messages?.find((m) => m.role === 'user')?.content ?? '';
+        const ruleId = /ruleId:\s*(\S+)/.exec(user)?.[1] ?? 'unknown';
+        return {
+          content: verdictJson({
+            ruleId,
+            status: 'compliant',
+            confidence: 0.95,
+            evidenceStart: 0,
+            evidenceEnd: 0,
+            explanation: 'DISTINCTIVE_COMPLIANT_MARKER',
+            suggestedReplacements: [],
+          }),
+        };
+      },
+    });
+
+    const result = await kernel.lintText(TWO_ACTIONS, lintOptions(service.url));
+
+    expect(result.messages).toEqual([]);
+  });
+
+  it('a per-rule severity override on a semantic verdict reaches the TextlintMessage', async () => {
+    service = await startFakeSemanticService({
+      handler: (body) => {
+        const user = body.messages?.find((m) => m.role === 'user')?.content ?? '';
+        const ruleId = /ruleId:\s*(\S+)/.exec(user)?.[1] ?? 'unknown';
+        return {
+          content: verdictJson({
+            ruleId,
+            status: 'violation',
+            confidence: 0.93,
+            evidenceStart: 0,
+            evidenceEnd: 6,
+            explanation: 'DISTINCTIVE_SEMANTIC_VIOLATION_MARKER',
+            suggestedReplacements: [],
+            meaningPreserved: false,
+          }),
+        };
+      },
+    });
+
+    const result = await kernel.lintText(
+      TWO_ACTIONS,
+      lintOptions(service.url, {
+        diagnostics: { severity: { 'probable-semantic-violation': 'error' } },
+      }),
+    );
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.severity).toBe(2);
+  });
+});

--- a/test/e2e/textlint-semantic-boundary.test.ts
+++ b/test/e2e/textlint-semantic-boundary.test.ts
@@ -53,8 +53,8 @@ function mustGetRule(id: string): TextlintRuleModule {
 }
 
 /**
- * A passage `one-instruction-per-sentence` (deterministic/rules/candidate-rules.ts) flags as a
- * comma-joined clause with a second candidate imperative verb — a real candidate for semantic
+ * A passage `one-instruction-per-sentence` (`src/deterministic/rules/structure-rules.ts`) flags as
+ * a comma-joined clause with a second candidate imperative verb — a real candidate for semantic
  * adjudication, confirmed directly (`analyseTextDeterministic` on this text, semantic disabled,
  * reports a `review-required` diagnostic for `one-instruction-per-sentence` spanning the whole
  * sentence). Never asserted as a compliance failure on its own; the semantic verdict decides it.


### PR DESCRIPTION
## Objective

Another item from #77's "Still to come": `test/integration/semantic-service.test.ts` and
`test/integration/suppression.test.ts` both drive `analyseText()` directly and assert only on
`result.diagnostics`/`result.notices` — the internal `Diagnostic` shape. `src/textlint/adapter.ts`
was not imported by either file, and `test/e2e/textlint-run.test.ts` — the one file that does cross
the adapter boundary — only ever exercised deterministic diagnostics through it, never a semantic
verdict.

## Change

Adds `test/e2e/textlint-semantic-boundary.test.ts`: three tests running the real `TextlintKernel`,
the real markdown plugin, and the real preset rule module against a real HTTP fake of the semantic
service (`startFakeSemanticService`, the same double `semantic-service.test.ts` uses), asserting on
`result.messages` (`TextlintMessage[]`) — never on `Diagnostic`:

1. A `violation` verdict's message text, evidence-span `range`/`loc`, and default severity
   (`warning` → textlint level 1) reach the emitted message.
2. A `compliant` verdict emits **no** `TextlintMessage` for that passage (negative control).
3. A per-rule severity override on a semantic diagnostic reaches the message (`error` → level 2).

## Mutation verification

I independently re-ran this rather than just trusting the report. Mutated `formatMessage()` in
`src/textlint/adapter.ts` to drop the diagnostic's own message text specifically for
`producedBy === 'semantic'` diagnostics:

- The new boundary test file: 1 of 3 tests failed under the mutation (the message-content
  assertion), catching it.
- The rest of the suite (30 other files, 641 tests): all passed under the same mutation — confirming
  nothing else in the suite exercises a semantic diagnostic through the adapter, so the gap this PR
  closes was real.

Mutation reverted; `git diff` on `adapter.ts` confirmed empty before this PR was opened.

## Verification

- `vp test test/e2e/textlint-semantic-boundary.test.ts test/e2e/textlint-run.test.ts` — 27/27
  passing.
- `vp check` — clean.
- `vp test` (full suite) — 642/642 passing (639 existing + 3 new).
- Rebases cleanly on post-#77 `main` (`b6d23ec`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVxydRFLKJVt6L6TYaxiK)_