### PR TITLE
test(rules): fix mutation survivors in rules.test.ts, delete cross-file duplicate

### DIFF
--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -132,18 +132,6 @@ describe('sentence-length-procedural', () => {
       result.text.slice(result.forRule(id)[0]?.range.start, result.forRule(id)[0]?.range.end),
     ).toContain('Torque each of the four');
   });
-
-  it('counts a quantity as one word rather than dropping it', () => {
-    const text = 'Torque each bolt to 25 Nm.\n';
-    const doc = analyseDocument({ id: 't', format: 'markdown', text });
-    expect(doc.sentences[0]?.words.map((w) => w.text)).toEqual([
-      'Torque',
-      'each',
-      'bolt',
-      'to',
-      '25 Nm',
-    ]);
-  });
 });
 
 describe('sentence-length-descriptive', () => {
@@ -266,7 +254,10 @@ describe('punctuation-constraints', () => {
   const id = 'punctuation-constraints';
 
   it('flags a semicolon', () => {
-    expect(run('Stop the pump; close the valve.\n').quotesFor(id)).toContain(';');
+    // `toContain` alone would also pass if the rule over-flagged every punctuation character in
+    // the sentence (e.g. the trailing period too), so assert the flagged set is exactly the
+    // semicolon.
+    expect(run('Stop the pump; close the valve.\n').quotesFor(id)).toEqual([';']);
   });
 
   it('flags a slash between words but not a path', () => {
@@ -294,11 +285,14 @@ describe('punctuation-constraints', () => {
   });
 
   it('respects disabling individual checks', () => {
+    // The semicolon is this sentence's only punctuation violation, so disabling it should leave
+    // no diagnostics at all — a plain `not.toContain(';')` would also pass on an unrelated bug
+    // that emptied every diagnostic array regardless of which check fired.
     expect(
       run('Stop the pump; close the valve.\n', {
         rules: { [id]: { forbidSemicolon: false } },
-      }).quotesFor(id),
-    ).not.toContain(';');
+      }).forRule(id),
+    ).toHaveLength(0);
   });
 });
 
@@ -582,7 +576,8 @@ describe('candidate rules never assert violations', () => {
       rules: { 'passive-voice-candidate': { adjudicate: false } },
     });
     const passive = result.forRule('passive-voice-candidate');
-    expect(passive.length).toBeGreaterThan(0);
+    expect(passive).toHaveLength(1);
+    expect(result.text.slice(passive[0]?.range.start, passive[0]?.range.end)).toBe('be replaced');
     expect(passive.every((d) => d.category === 'review-required')).toBe(true);
   });
 
@@ -608,7 +603,9 @@ describe('candidate rules never assert violations', () => {
     const result = run('The value is known.\n', {
       rules: { 'passive-voice-candidate': { adjudicate: false } },
     });
-    expect(result.forRule('passive-voice-candidate').length).toBeGreaterThan(0);
+    const passive = result.forRule('passive-voice-candidate');
+    expect(passive).toHaveLength(1);
+    expect(result.text.slice(passive[0]?.range.start, passive[0]?.range.end)).toBe('is known');
   });
 
   it('passive-voice-candidate no longer flags the exact adjectival case the corpus reviewer named', () => {
@@ -650,6 +647,7 @@ describe('candidate rules never assert violations', () => {
       rules: { 'noun-cluster-candidate': { adjudicate: false } },
     });
     const clusters = result.forRule('noun-cluster-candidate');
+    expect(clusters.length).toBeGreaterThan(0);
     for (const cluster of clusters) {
       const text = result.text.slice(cluster.range.start, cluster.range.end);
       expect(text.toLowerCase().split(/\s+/)).not.toContain('no');
@@ -710,11 +708,19 @@ describe('runner invariants', () => {
     expect(a).toEqual(a.toSorted((x, y) => Number(x.split(':')[0]) - Number(y.split(':')[0])));
   });
 
-  it('every diagnostic range points at real, non-empty source', () => {
+  it('every diagnostic range points at exactly the flagged substring, not a shifted one', () => {
+    // A `>0`-length check alone is satisfied even by a range shifted by a fixed offset (wrong
+    // start/end, but still non-empty), so this asserts the sliced text equals the exact expected
+    // substring for every diagnostic the sentence produces.
     const text = "Prior to installation, don't utilise the the old bracket; stop now!\n";
-    for (const d of run(text).diagnostics) {
-      expect(text.slice(d.range.start, d.range.end).length).toBeGreaterThan(0);
-    }
+    expect(run(text).diagnostics.map((d) => text.slice(d.range.start, d.range.end))).toEqual([
+      'Prior to',
+      "don't",
+      'utilise',
+      'the the',
+      ';',
+      '!',
+    ]);
   });
 
   it('every shipped rule declares provisional status', () => {


### PR DESCRIPTION
## Objective

Another item from #77's "Still to come": `test/unit/rules.test.ts` had several assertions that
survive named mutations — they'd pass even if the production code they're supposed to guard were
broken. Found during #77's audit but not fixed in that PR, since it only covered other files.

## Changes, each mutation-verified

- **`punctuation-constraints`** ("flags a semicolon" / "respects disabling individual checks"):
  `toContain(';')` / `not.toContain(';')` let any punctuation-flagging behavior survive (flag every
  punctuation char, or flag none regardless of which check fired). Changed to `toEqual([';'])` and
  `forRule(id)).toHaveLength(0)`.
- **Candidate-rule count assertions** (×2): `passive.length > 0` is satisfied by one
  whole-sentence candidate or five duplicates — it doesn't verify count or span precision. Changed
  to `toHaveLength(1)` plus the exact flagged substring.
- **`noun-cluster-candidate` length guard**: the coverage loop had no assertion that `clusters` is
  non-empty — a rule returning `[]` unconditionally left the loop body simply not executing, so the
  test passed regardless. Added the missing length assertion.
- **Offset-correctness gap** ("every diagnostic range points at real, non-empty source"): a `>0`
  length check survives every range being shifted by a fixed offset. Replaced with the exact
  expected substring for each of the six diagnostics the test sentence produces.

I independently re-verified the length-guard fix rather than trusting the agent's report (it died
mid-task before writing one): mutated `candidate-rules.ts`'s `flush()` to always take its early
"discard the run" branch (equivalent to the rule returning no candidates). The old test (no length
assertion) would pass silently — the loop body just never executes on an empty array. The new
assertion fails: `expected 0 to be greater than 0`. Reverted after confirming.

## Also removed

Deleted `"counts a quantity as one word rather than dropping it"` — it runs no rule at all, just
checks tokenisation. Confirmed `protected-regions.test.ts`'s `word tokenisation` describe block
(`"counts a content-bearing protected region as exactly one word"`) asserts the identical property
(a quantity counts as one word, not split or dropped) against an equivalent sentence, so no coverage
is lost by deleting the duplicate here.

## Verification

- `vp test test/unit/rules.test.ts` — 81/81 passing.
- `vp check` — clean.
- `vp test` (full suite) — 638/638 passing (one fewer than the post-#77 baseline of 639, from the
  duplicate deletion — expected).
- Rebases cleanly on post-#77 `main` (`b6d23ec`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVxydRFLKJVt6L6TYaxiK)_