### PR TITLE
docs: fix this repo's own documentation against its own linter

### DIFF
--- a/.ste-ai.json
+++ b/.ste-ai.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "abbreviation-introduction": {
+      "additionalWellKnown": ["ASD", "MIT", "SHA", "CRLF"]
+    }
+  }
+}

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -1,0 +1,13 @@
+{
+  "plugins": {
+    "@textlint/markdown": true,
+    "@textlint/text": true
+  },
+  "rules": {
+    "preset-ste-ai": {
+      "abbreviation-introduction": {
+        "additionalWellKnown": ["ASD", "MIT", "SHA", "CRLF"]
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,35 @@
-1. Do not document derivable values (for example, test totals, coverage percentages, file counts, or generated inventories) as manually maintained facts; include them only when they are generated or displayed from the live source of truth so they remain accurate automatically.
-2. When a human guide needs a derivable value, document the command or procedure that derives it instead of the current result; omit both the value and derivation instructions from AI-facing documentation unless the derivation itself is required for the agent's task.
-3. Before pushing code, review the README, docs, comments, examples, and agent instructions affected by the change; update stale behavior descriptions and replace or remove manually maintained derivable data, commands, paths, and claims that the change invalidates.
+# Agent instructions
+
+This file lists instructions for AI (artificial intelligence) agents in this repository.
+
+## Documentation hygiene
+
+1. Do not document derivable values as manually maintained facts.
+   - Examples include test totals, coverage percentages, file counts, and generated inventories.
+   - Include a derivable value only when a live source generates or displays it.
+   - This keeps the value accurate automatically.
+2. When a human guide needs a derivable value, document the command or procedure that derives it.
+   - Do not document the current result.
+   - Omit the value and the derivation instructions from documentation for AI agents.
+   - Include the derivation only when the agent's task requires it.
+3. Before pushing code, review the readme file, project docs, and code comments affected by the change.
+   - Also review examples and agent instructions affected by the change.
+   - Update stale behavior descriptions.
+   - Replace or remove commands, paths, and claims that the change invalidates.
+   - Also replace or remove any manually maintained, derivable data that the change invalidates.
+
+## Delegation gotchas
+
+Learned from repeated multi-agent dispatch failures in this session. Read this before dispatching `isolation: "worktree"` agents in bulk.
+
+**Gitignored files do not reach a worktree**. `isolation: "worktree"` builds each worktree from a real git ref. Anything not committed stays in the orchestrator's own checkout, including every file under `.tmp/`. Give a dispatched agent an absolute path back to the orchestrator's checkout instead. That works, because both directories sit on the same host filesystem. A committed file also works, if every dispatch checks out that commit.
+
+**Scratch files must stay inside the repo**. A path outside the repo root needs harness permission. A dispatched agent does not have that permission. Such a path fails, or blocks the task partway through. Use a repo-relative, gitignored path instead, for example `.tmp/scratch/`.
+
+**The concurrent-subagent cap is a hard ceiling**. The default is 20 (`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`). A dispatch past the cap fails immediately, with an explicit "do not retry" instruction. Queue the remaining dispatches instead. Send the queued dispatches once a slot frees.
+
+**A session-limit failure is shared and retryable**. The account's session limit applies across the orchestrator and every dispatched agent together, not per agent. A dispatched agent can fail mid-task from this, purely because the account is over budget at that moment. This shared-budget failure can hit many parallel agents in the same wave at once. Resume the agent by name through `SendMessage`, once budget returns. Do not redo its work directly. Do not redispatch a fresh agent over one that already made progress.
+
+**The permission classifier can deny a dispatch before it starts**. No agent ID returns in that case. The reason given does not always track the task's actual content. Retrying the identical dispatch has worked in practice.
+
+**A worktree with zero file changes can be cleaned up mid-session**. This auto-cleanup is not limited to an agent's very first stop. The same cleanup can also fire when a resumed but still unedited agent's session ends again. One example is hitting the session limit before the agent's first `Write` or `Edit` call. The agent's own conversation and analysis survive and stay resumable by name. Its worktree directory is gone and needs rebuilding. Run `git worktree add --detach <same-path> <same-commit>` before the agent continues. This differs from a worktree that has real uncommitted edits destroyed outright. Here, there is nothing to lose but the empty directory. The fix is a simple orchestrator-side rebuild, not a recovery problem.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,145 +1,160 @@
 # Working on this repo
 
-## Discover docs and tests before a functional change; reconcile both after — no confirmation needed
+## Discover docs and tests before a functional change, then reconcile both after — no confirmation needed
 
-Before changing behavior, find what already describes or covers the system being touched: search
-`README.md`, `docs/`, and doc comments for references, and search `test/` **and `scripts/ci/`** for
-coverage of the same code paths — `.github/workflows/ci.yml` runs `scripts/ci/*.sh` as assertions
-separate from `npm test` (e.g. `check-rules-provisional.sh` hard-codes the expected rule count), so
-a change that only reconciles `test/` can still leave one of those scripts stale and fail CI. Do
-this before writing the change, not after — the discovery is what the post-change reconciliation
-checks against.
+Before changing behavior, find what already describes or covers the system being touched. Search
+`README.md`, `docs/`, and doc comments for references. Search `test/` **and `scripts/ci/`** for
+coverage of the same code paths. `.github/workflows/ci.yml` runs `scripts/ci/*.sh` as assertions
+separate from `npm test`. For example, `check-rules-provisional.sh` hard-codes the expected rule
+count. A change that only reconciles `test/` can still leave one of those scripts stale. A stale
+script then fails continuous integration (CI). Do this discovery before writing the change, not
+after. The discovery is what the post-change reconciliation checks against.
 
-After the change, treat that discovery list as part of the work, not a follow-up: update or remove
-whichever of those docs actually describe the changed behavior, and update or remove whichever of
-those tests or CI assertion scripts now assert the old behavior — not every file discovery turned up
-regardless of relevance. Definition of done includes removing or updating stale tests, CI assertion
-scripts, and documentation, not just adding new ones; a task that changes behavior but leaves a doc,
-a test, or a `scripts/ci/*.sh` check describing the old behavior in place is incomplete, not
+After the change, treat that discovery list as part of the work, not as a follow-up. Update or
+remove whichever of those docs actually describe the changed behavior. Update or remove whichever
+of those tests or CI assertion scripts now assert the old behavior. Do not update every file the
+discovery turned up — update only the ones the change actually affects. Definition of done includes
+removing or updating stale tests, CI assertion scripts, and documentation. Definition of done is not
+just adding new ones. A task might change behavior. It might still leave a doc, a test, or a
+`scripts/ci/*.sh` check describing the old behavior. That task is incomplete. It is not
 finished-with-a-follow-up.
 
-## Agents share this session's rate limit — retry, don't substitute
+## Agents share this session's rate limit — retry, do not substitute
 
-A subagent's session/token-limit failure is retryable, not a real task failure — it shares this
-session's budget. If the orchestrator can still run tool calls, resume the agent (`SendMessage` to
-its agent id) rather than redoing the work directly. The orchestrator has no capability advantage
-over an agent, only a higher cost per action — absorbing an agent's work is strictly worse than
-retrying it.
+A subagent's session-limit or token-limit failure is retryable, not a real task failure. The
+subagent shares this session's overall budget. If the orchestrator can still run tool calls, resume the agent instead of
+redoing the work directly. Resume it with `SendMessage` to its agent id. The orchestrator has no
+capability advantage over an agent. The orchestrator only has a higher cost per action. Absorbing an
+agent's work is strictly worse than retrying it.
 
 ## Parallel agents: use `isolation: "worktree"`, never a manually-managed directory
 
 Dispatch every `Agent`-tool call with `isolation: "worktree"`. Do not manually `git worktree add` a
-directory and reuse it across separate dispatches — that caused a real incident (misattributed
-agent behavior, a wrongful `TaskStop`, real work destroyed by a reset while another agent was still
-active in the same directory). `isolation: "worktree"` makes that failure class structurally
-impossible, since each dispatch gets its own directory. Reserve manual `git worktree add` for work
-the orchestrator does directly, not through `Agent`.
+directory. Do not reuse that directory across separate dispatches. That mistake caused a real
+incident. The incident misattributed agent behavior, issued a wrongful `TaskStop`, and destroyed
+real work. A reset ran while another agent was still active in the same directory. Setting
+`isolation: "worktree"` makes that failure class structurally impossible. Each dispatch gets its own
+directory. Reserve manual `git worktree add` for work the orchestrator does directly. Do not use manual
+`git worktree add` through `Agent`.
 
-Exception: if the agent needs to see the orchestrator's own current uncommitted (staged or unstaged)
-changes, commit them (or otherwise transfer them) before dispatching — an isolated worktree is built
-from a real ref, so uncommitted state does not travel into it on its own, and the agent would
+Exception: if the agent needs to see the orchestrator's own current uncommitted changes, commit them
+before dispatching. The uncommitted changes can be staged or unstaged. You can also transfer them
+another way instead of committing. An isolated worktree is built from a real ref. Uncommitted state
+does not travel into a new worktree on its own. Without transferring it first, the agent would
 silently evaluate stale code.
 
-A fresh worktree does not necessarily already sit on the branch or commit the work is meant to build
-on — it can default to the repository's default branch. Unless the agent is meant to work directly
-off the default branch, its first instruction must be to check out the specific source commit the
-task is being distributed from — in detached-HEAD state, or on a new branch created at that commit.
-Do not tell it to switch to the source branch by name: Git refuses to check out a branch that is
-already checked out in another worktree (including the orchestrator's own), which is the common
-case when work is being distributed off a branch the orchestrator is actively using.
+A fresh worktree does not necessarily sit on the branch or commit the work is meant to build on. It
+can default to the repository's default branch instead. Unless the agent is meant to work directly
+off the default branch, give it one first instruction. That instruction must be to check out the
+specific source commit the task is being distributed from. Git's pointer to the current commit
+(HEAD) can be detached from any branch. Check out that commit in a detached HEAD state, or on a new
+branch created at that commit. Do not tell the agent to switch to the source branch by name. Git refuses to check
+out a branch that is already checked out in another worktree. That includes the orchestrator's own
+worktree. This is the common case when work is distributed off a branch the orchestrator is actively
+using.
 
 ## Verifying what an agent did: query its session log, not git state
 
-When a decision depends on knowing exactly what an agent did (stop it? discard its work? believe a
-disputed claim?), check its session transcript (the `.output` JSONL path from its dispatch/notification
-result), not git state — a diff shows only the end result, not the sequence. The "don't read/tail
-this file" warning on that path is about full-file ingestion overflowing context, not the file being
-off-limits: query it with `Grep` (pattern match) or `jq` (structured fields — `.type`/`.name`/`.input`)
-instead of reading it whole.
+Some decisions depend on knowing exactly what an agent did. Should you stop it? Should you discard
+its work? Should you believe a disputed claim? For those decisions, check its session transcript,
+not git state. The session transcript is the `.output` JSON Lines (JSONL) path from its dispatch
+result or notification result. A diff shows only the end result, not the sequence of actions.
 
-A positive match is strong evidence (the literal input string is right there). An absent match is
-not proof of a negative: indirect access — a shell variable, a glob, a helper script, a child
-process — may never put the literal filename in the recorded tool input. Treating "no match" as "did
-not happen" can reproduce the same false-negative mistake this section exists to prevent. If a
-negative claim actually matters, read the relevant tool calls in full rather than trusting an absent
-pattern match.
+The warning that says not to read or tail this file is about full-file ingestion overflowing
+context. It is not about the file being off-limits. Query it with `Grep` for pattern matching, or
+with `jq` for structured fields such as `.type`, `.name`, and `.input`. Use either instead of
+reading the whole file.
 
-## Draft PRs and automated review
+A positive match is strong evidence. The literal input string is right there. An absent match is
+not proof of a negative. Indirect access can hide the literal filename from the recorded tool
+input. Examples of indirect access include a shell variable, a glob, a helper script, or a child
+process. Treating a "no match" result as "did not happen" can reproduce a false-negative mistake.
+This section exists to prevent that mistake. If a negative claim actually matters, read the relevant
+tool calls in full. Do not trust an absent pattern match alone.
 
-Un-drafting a PR is what makes it visible to automated review (`chatgpt-codex-connector` on this
-repo — see PR #32). Un-draft, then wait a real interval before merging — never merge in the same
-action as un-drafting, even on a change that looks obviously safe.
+## Draft pull requests and automated review
 
-**Independent review is required before every merge.** Not a courtesy, and not conditional on the
-external reviewer being available. Two routes satisfy the requirement equally: the automated external
-reviewer, or a local subagent review. What is never acceptable is merging with neither.
+Un-drafting a pull request (PR) is what makes it visible to automated review. The reviewer on this
+repo is `chatgpt-codex-connector`. See PR #32 for an example. Un-draft the PR, then wait a real
+interval before merging. Never merge in the same action as un-drafting. Do this even on a change
+that looks obviously safe.
 
-The external reviewer fails in two ways, and one of them is quiet. It declines when the account is
-over its usage limit, replying "You have reached your Codex usage limits for code reviews" instead of
-a review — that one is visible. It can also simply stay silent, which is easy to read as approval.
-Treat both as "no review has happened", and check for a real review rather than for the absence of
-complaints.
+**Independent review is required before every merge.** It is not a courtesy. It is not conditional
+on the external reviewer being available. Two routes satisfy the requirement equally: the automated
+external reviewer, or a local subagent review. Merging with neither review is never acceptable.
+
+The external reviewer fails in two ways. One of those ways is quiet. The visible failure happens
+when the account is over its usage limit. In that case, the external
+reviewer sends a reply. That reply reads "You have reached your Codex usage limits for code
+reviews" instead of an actual review. The quiet failure happens
+when the external reviewer simply stays silent. Silence is easy to misread as approval. Treat both failures as "no review has happened."
+Check for a real review rather than for the absence of complaints.
 
 When the external reviewer has not produced one, dispatch a subagent before merging:
 
-- **Code changes** — the `dh:code-reviewer` agent, which detects the stack and loads the matching
-  `dh:code-review-{stack}` skill (`dh:code-review-typescript` here).
-- **Docs and design changes** — a fact-check instead of a code review. Documents in this repo cite
-  files and line numbers, and a design doc that misdescribes the code is worse than none, because
-  implementers trust it. Ask for every citation to be opened and verified.
-- **Substantial or risky changes** — a set of reviewers rather than one, via
-  `dh:multi-perspective-review`, which runs security, quality, performance and accessibility
-  perspectives in parallel and returns a verdict per perspective. One reviewer sees one way; several
-  reviewing independently is the point of review, and is what the external reviewer cannot offer.
+- **Code changes**: use the `dh:code-reviewer` agent. It detects the stack and loads the matching
+  `dh:code-review-{stack}` skill. In this repo, that skill is `dh:code-review-typescript`.
+- **Docs and design changes**: use a fact-check instead of a code review. Documents in this repo
+  cite files and line numbers. A design doc that misdescribes the code is worse than no design doc,
+  because implementers trust the design doc. Ask for every citation to be opened and verified.
+- **Substantial or risky changes**: use a set of reviewers rather than one. Run
+  `dh:multi-perspective-review`. It runs security, quality, performance, and accessibility
+  perspectives in parallel. It returns a verdict for each perspective. One reviewer sees one way.
+  Several reviewers reviewing independently is the point of review. That is what the external
+  reviewer cannot offer.
 
-Dispatch with `isolation: "worktree"` per the section above, tell the agent to `git checkout --detach`
-the PR head commit first, give it the base commit so it can diff, and tell it explicitly that it is
-the review of record so it reviews critically rather than confirming. Require the same evidence
-discipline the rest of this file demands: cite the file and line, state uncertainty rather than
-guessing, and say what was checked when nothing was found — otherwise an empty review is
-indistinguishable from no review.
+Dispatch the review with `isolation: "worktree"`, per the section above. Tell the agent to
+`git checkout --detach` the PR head commit first. Give the agent the base commit, so it can diff
+the PR head commit against the base commit. Tell the agent explicitly that it is the review of record. Being the review of record
+means it must review critically, not confirm. Require the same evidence discipline the rest of this
+file demands. Cite the file name and the line number for every finding. State uncertainty rather than guessing. Say
+what was checked when nothing was found. Without that, an empty review is indistinguishable from no
+review.
 
 Then address the findings, the same as for a human or Codex review.
 
 ## Local verification tools
 
-Use `npx tsx` (not bare `tsx` — not a project dependency) for ad hoc TypeScript checks, or rebuild
-`dist/` immediately before using it. Never run stale `dist/` output with plain `node`.
+Use `npx tsx` for ad hoc TypeScript checks. Do not use bare `tsx` — it is not a project dependency.
+As an alternative, rebuild `dist/` immediately before using it. Never run stale `dist/` output with
+plain `node`.
 
-**Use the repository-pinned Vite+ toolchain, not standalone formatter, linter, compiler, or test
-commands.** Once `node_modules/.bin/vp` exists, use `vp check`, `vp test`, and `vp pack` — never a
-bare `vitest`/`oxlint`/`tsc`, and never `npm test` (this repo defines no such script). Bare `vitest`
-can also discover `vite.config.ts` and run the suite; the rule is not that it can't, it's that `vp`
-is the supported wrapper the toolchain is pinned around, and going around it forfeits whatever `vp`
-adds on top (its own bundled Vitest version resolution, the `check`/`pack` integration, `vp staged`).
-A fresh worktree has no `node_modules`; run `vp install --frozen-lockfile` there, or invoke the main
-checkout's pinned `vp` binary by path instead of installing a second copy.
+**Use the repository-pinned Vite+ toolchain.** Do not use a standalone formatter, linter, compiler,
+or test command. Once `node_modules/.bin/vp` exists, use `vp check`, `vp test`, and `vp pack`. Never
+use a bare `vitest`, `oxlint`, or `tsc` command. Never use `npm test` — this repo defines no such
+script. Bare `vitest` can also discover `vite.config.ts` and run the suite. The rule is not that it
+cannot do this. The rule is that `vp` is the supported wrapper the toolchain is pinned around. Going
+around `vp` forfeits whatever it adds on top. That includes its own bundled Vitest version
+resolution, the integration between `check` and `pack`, and `vp staged`. A fresh worktree has no
+`node_modules`. In a fresh worktree, run `vp install --frozen-lockfile`. Or invoke the main
+checkout's pinned `vp` binary by path, instead of installing a second copy.
 
-**Bootstrapping `vp` itself, from nothing.** `vp install` is the `vp` CLI's own subcommand — it
-cannot run before `node_modules/.bin/vp` exists, and this environment has no global `vp`. The one
-correct use of `npx` in this repo is to fetch that first binary: read the pinned version from
-`package.json`'s `devDependencies.vite-plus`, then run
-`npx -p vite-plus@<that version> vp install --frozen-lockfile` from the repo root. That installs
-through `vp`'s own resolver into the real `node_modules` — verify with `git diff package-lock.json`
-(must be empty under `--frozen-lockfile`) and `node_modules/.bin/vp toolchain`. Do not fall back to
-`npm ci` or `npm install` for this step, even though they produce a working `node_modules`: they
-skip whatever `vp install` does beyond dependency resolution (see `vp config`, below), and using them
-is exactly the "standalone command" this rule exists to prevent.
+**Bootstrapping `vp` itself, from nothing.** `vp install` is the `vp` CLI's own subcommand. It
+cannot run before `node_modules/.bin/vp` exists. This environment also has no global `vp`. The one
+correct use of `npx` in this repo is to fetch that first binary. Read the pinned version from
+`package.json`'s `devDependencies.vite-plus`. Then run
+`npx -p vite-plus@<that version> vp install --frozen-lockfile` from the repo root. That command
+installs through `vp`'s own resolver into the real `node_modules`. Verify the install with
+`git diff package-lock.json`. That diff must be empty under `--frozen-lockfile`. Also verify with
+`node_modules/.bin/vp toolchain`. Do not fall back to `npm ci` or `npm install` for this step. They
+produce a working `node_modules`, but they skip whatever `vp install` does beyond dependency
+resolution. See `vp config`, below, for what that extra step covers. Using `npm ci` or `npm install`
+here is exactly the standalone command this rule exists to prevent.
 
-**Pre-commit formatting and linting run through `vp`'s own hook dispatcher, not Husky** — this repo
-has no Husky dependency. `vite.config.ts`'s `staged` block defines what runs; `.vite-hooks/pre-commit`
-(committed) invokes `vp staged`, which reads that block. The generated dispatcher itself
-(`.vite-hooks/_`) is gitignored and machine-local — `npm install`'s `prepare` lifecycle script runs
-`vp config` to (re)install it, so a fresh clone activates hooks automatically. Never hand-edit
-`.vite-hooks/_`; change `.vite-hooks/pre-commit` or the `staged` block instead, and run
-`vp hooks status` to confirm `core.hooksPath` actually points at the dispatcher before trusting that
-a commit was checked.
+**Pre-commit formatting and linting run through `vp`'s own hook dispatcher, not Husky.** This repo
+has no Husky dependency. `vite.config.ts`'s `staged` block defines what runs. `.vite-hooks/pre-commit`
+is committed. It invokes `vp staged`, which reads that block. The generated dispatcher itself,
+`.vite-hooks/_`, is gitignored and machine-local. `npm install`'s `prepare` lifecycle script runs
+`vp config` to reinstall it. That way, a fresh clone activates hooks automatically. Never hand-edit
+`.vite-hooks/_`. Change `.vite-hooks/pre-commit` or the `staged` block instead. Then run
+`vp hooks status` to confirm `core.hooksPath` actually points at the dispatcher. Do this before
+trusting that a commit was checked.
 
 ## `send_later` (self-scheduled check-ins)
 
-Works without approval friction in this environment — verified: a call this session registered
-immediately, confirmed via `list_triggers`. Confirm registration via `list_triggers` whenever a
-schedule matters, regardless.
+`send_later` works without approval friction in this environment. This was verified: a call this
+session registered immediately, confirmed via `list_triggers`. Confirm registration via
+`list_triggers` whenever a schedule matters, regardless.
 
 ## Chat tone
 

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ npx ste-ai lint docs/**/*.md --fail-on-review
 check its own draft voluntarily, during composition, not just after the fact:
 
 - Exporting the merged vocabulary as a machine-readable artefact would let the agent consult it
-  before drafting. Tracked as [issue #2](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/2).
+  before drafting. Tracked as [issue #2](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/2).
 - A Model Context Protocol (MCP) server would expose `check_text`, `lookup_term`, and
   `list_vocabulary`. The agent could then check text and look up terms in-loop. It would no longer
   need to shell out to the CLI on every iteration. Tracked as
-  [issue #5](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/5).
+  [issue #5](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/5).
 - A rule pack could also resolve from a package name or a URL, with a required integrity digest. That
   would let an organisation share one vocabulary across every repository, instead of copying a JSON
-  file into each. Tracked as [issue #3](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/3).
+  file into each. Tracked as [issue #3](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/3).
 
 **3. A blocking Claude Code hook gating live agent or user communication — proposed, not built, and
 currently blocked**. The goal is to check outgoing messages before they are sent. That covers
@@ -133,9 +133,12 @@ It cannot be wired up yet. `lint` only reads files, via `readFileSync`, and exit
 arguments. There is no stdin path. The programmatic API (`analyseTextDeterministic`/`analyseText`)
 already accepts an arbitrary string, with no file dependency. This gap is in the CLI surface only, not
 in the underlying analysis. Tracked as
-[issue #26](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/26).
+[issue #26](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/26).
 
-## The 14 rules
+## The rules
+
+Run `npx ste-ai rules --json` for the current list and count. It reads from the live registry, so it
+stays correct as rules are added or removed.
 
 | Rule                           | Decides?           | Fix                                  |
 | ------------------------------ | ------------------ | ------------------------------------ |

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -6,51 +6,51 @@ conformance with it.**
 ## What was available, and what was not
 
 ASD-STE100 Simplified Technical English is published by the ASD Simplified Technical English
-Maintenance Group. Its specification text and its Dictionary are proprietary. The official site
-states, verbatim:
+Maintenance Group (STEMG). Its specification text and its Dictionary are proprietary. The official
+site states, verbatim:
 
 > Simplified Technical English, ASD-STE100, is a Copyright and a Trademark of ASD, Brussels,
 > Belgium. All rights reserved. European Union Trade Mark No. 017966390.
 
-— <https://asd-ste100.org/>, retrieved 2026-07-26.
+— <https://asd-ste100.org/>, retrieved 26 July 2026.
 
 No licensed copy, machine-readable rule pack, or dictionary was available to this repository at the
 time of writing. Consequently:
 
 - **No Writing Rule text is reproduced, paraphrased, summarised, or reconstructed here.**
 - **No part of the controlled Dictionary is reproduced or reconstructed here.**
-- Nothing in this package was derived from memory of the standard or from secondary summaries of it.
+- **Nothing in this package was derived from memory of the standard or from secondary summaries of it.**
 
 ## What the shipped rules actually are
 
 Every rule this package ships is classified `provisional`. A provisional rule is an ordinary
-plain-English and controlled-language editing heuristic authored for this project — the sort of
-guidance found in many public technical-writing style guides. Provisional rules are documented in
+plain-English and controlled-language editing heuristic authored for this project. It is the sort
+of guidance found in many public technical-writing style guides. Provisional rules are documented in
 [`provisional-rules.md`](./provisional-rules.md), each with its rationale and its known failure
 modes.
 
-`provisional` status is not cosmetic. It is carried in:
+`provisional` status is not cosmetic:
 
-- each rule's `meta.status` and `meta.sourceRef`;
-- every diagnostic, as the `[provisional]` tag in the message and the `ruleStatus` field in the
-  programmatic and JSON output;
-- the active rule pack's `metadata.authority` and `metadata.conformanceClaim`, which the bundled
-  pack sets to `provisional` and `none` respectively.
+- It appears in each rule's `meta.status` and `meta.sourceRef`.
+- It appears in every diagnostic as the `[provisional]` tag in the message. It also appears as the
+  `ruleStatus` field in the programmatic and JSON output.
+- It appears in the active rule pack's `metadata.authority` and `metadata.conformanceClaim`, which
+  the bundled pack sets to `provisional` and `none` respectively.
 
 `packPermitsConformanceClaim()` returns `false` for the bundled pack, and the CLI prints
 `Provisional rules only; no conformance claim.` on every run.
 
 ## What a passing run means
 
-A clean run means: _this document did not trigger the provisional checks that were enabled._ It does
-not mean the document is Simplified Technical English, and it does not mean the document is correct,
+A clean run means: _this document did not trigger the provisional checks that were enabled_. It does
+not mean the document is Simplified Technical English. It does not mean the document is correct,
 safe, or complete.
 
 ## What a semantic verdict means
 
 When the optional semantic subsystem is enabled, a diagnostic in the
-`probable-semantic-violation` category reflects a **model's** judgement, recorded with the model's
-own self-reported confidence. That number is not a calibrated probability. Decision thresholds are
+`probable-semantic-violation` category reflects a **model's** judgement. The diagnostic records the
+model's own self-reported confidence. That number is not a calibrated probability. Decision thresholds are
 separate, operator-owned configuration. A semantic verdict is evidence for a human reviewer, not a
 finding of non-compliance.
 
@@ -59,15 +59,15 @@ run-level notice is emitted. **A service failure is never converted into complia
 
 ## Supplying authorised material
 
-If you hold a licence that permits it, an authorised rule pack can supply normative limits, a
-controlled dictionary, and per-rule authority through the documented import boundary — see
-[`rule-pack-import.md`](./rule-pack-import.md). Doing so changes the `ruleStatus` on diagnostics to
-whatever the pack declares. Whether that constitutes conformance is a determination for you and your
-licensor; this package makes no such determination and adds no conformance wording of its own.
+If you hold a licence that permits it, an authorised rule pack can supply normative limits. It can
+also supply a controlled dictionary and per-rule authority, through the documented import boundary —
+see [`rule-pack-import.md`](./rule-pack-import.md). Doing so changes the `ruleStatus` on diagnostics
+to whatever the pack declares. Whether that constitutes conformance is a determination for you and
+your licensor. This package makes no such determination and adds no conformance wording of its own.
 
 ## Trademarks
 
 "ASD-STE100" and "Simplified Technical English" are trademarks of ASD, Brussels, Belgium. They are
-used here only to describe what this package is _not_, and to name the standard a licensee might
-supply through the import boundary. This project is not affiliated with, endorsed by, or approved by
-ASD or the ASD STEMG.
+used here only to describe what this package is _not_. They are also used to name the standard a
+licensee might supply through the import boundary. This project is not affiliated with, endorsed by,
+or approved by ASD or the ASD STEMG.

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -9,6 +9,8 @@ ASD-STE100 Simplified Technical English is published by the ASD Simplified Techn
 Maintenance Group (STEMG). Its specification text and its Dictionary are proprietary. The official
 site states, verbatim:
 
+<!-- ste-ai-ignore-next-line punctuation-constraints -- verbatim quotation, not our prose -->
+
 > Simplified Technical English, ASD-STE100, is a Copyright and a Trademark of ASD, Brussels,
 > Belgium. All rights reserved. European Union Trade Mark No. 017966390.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,9 +17,9 @@
 ```
 
 Or select and tune individual rules. Per-rule options are **nested under the preset key**, not
-written as `"preset-ste-ai/<rule-id>"`: textlint resolves anything beginning with `preset-` as a
-package name, so a slashed key is looked up as a package called `preset-ste-ai/<rule-id>`, is not
-found, and the whole configuration silently loads no rules at all.
+written as `"preset-ste-ai/<rule-id>"`. textlint resolves anything beginning with `preset-` as a
+package name. A slashed key is therefore looked up as a package called `preset-ste-ai/<rule-id>`.
+That package is not found, and the whole configuration silently loads no rules at all.
 
 ```json
 {
@@ -43,9 +43,10 @@ found, and the whole configuration silently loads no rules at all.
 
 ### Severity
 
-Each diagnostic carries the severity of its category (see [diagnostic-policy.md](diagnostic-policy.md))
-and the adapter maps that onto textlint's own severity levels, so `error`, `warning` and `info`
-findings are distinguishable in textlint output and to `--max-warnings`.
+Each diagnostic carries the severity of its category (see
+[diagnostic-policy.md](diagnostic-policy.md)). The adapter maps that severity onto textlint's own
+severity levels. As a result, `error`, `warning`, and `info` findings are distinguishable in
+textlint output and to `--max-warnings`.
 
 A per-rule `severity` overrides the category default for that rule:
 
@@ -64,10 +65,10 @@ To move a whole category, set it in the shared configuration file instead:
 Several settings apply to the whole document and would otherwise have to be repeated on every rule.
 They are read once from a shared file, resolved in this order (first hit wins):
 
-1. `$STE_AI_CONFIG` — an explicit path;
-2. `.ste-ai.json`, `.ste-ai.jsonc` or `ste-ai.config.json` in the textlint config base directory;
-3. the same names in `process.cwd()`;
-4. built-in defaults — bundled provisional pack, semantic analysis **off**.
+1. `$STE_AI_CONFIG` — an explicit path.
+2. `.ste-ai.json`, `.ste-ai.jsonc`, or `ste-ai.config.json` in the textlint config base directory.
+3. The same names in `process.cwd()`.
+4. Built-in defaults: bundled provisional pack, semantic analysis **off**.
 
 `.ste-ai.json`:
 
@@ -158,20 +159,20 @@ Invalid ste-ai configuration:
   diagnostics.severity: Unrecognized key: "style-preference"
 ```
 
-Unknown keys used to be dropped instead. That is the worst available outcome for a policy file: the
-config parsed, the setting was discarded, and the operator's own file read as evidence of a policy
-the linter had never applied. A misspelt diagnostic category applied no severity, a mistyped
-`semantic` key left the timeout or threshold at its default, and nothing said so.
+Unknown keys used to be dropped instead. That is the worst available outcome for a policy file. The
+config parsed, and the setting was discarded. The operator's own file then read as evidence of a
+policy the linter had never applied. A misspelt diagnostic category applied no severity. A mistyped
+`semantic` key left the timeout or threshold at its default. Nothing said so.
 
-The one deliberate exception is `rules.<id>`, which accepts arbitrary keys: each rule declares its
-own option schema, and the rule — not this file — is the only thing that can judge its own options.
-Options that no rule recognises are therefore still dropped quietly, and an option that a rule
-recognises but rejects produces a `rule-options-invalid` notice and skips that rule.
+The one deliberate exception is `rules.<id>`, which accepts arbitrary keys. Each rule declares its
+own option schema. Only the rule itself, not this file, can judge whether its own options are
+valid. Options that no rule recognises are therefore still dropped quietly. If a rule recognises an
+option but rejects it, the run gets a `rule-options-invalid` notice, and that rule is skipped.
 
 Rule _ids_ are checked even though their options are not. A `rules` key naming no rule the preset
-exports produces a `warning`-level `unknown-rule-id` run notice (`detail: { ruleId }`) and the run
-continues, so a configuration written for a newer version of this package degrades instead of
-failing:
+exports produces a `warning`-level `unknown-rule-id` run notice (`detail: { ruleId }`). The run
+continues. A configuration written for a newer version of this package therefore degrades instead
+of failing:
 
 ```
 Configuration names rule "sentance-length-procedural", which is not a known rule,
@@ -181,10 +182,10 @@ so those options were not applied
 ### Protected patterns are screened before they run
 
 Every `extraProtectedPatterns` entry is checked once per run, before any of them is matched against
-a document. An entry that fails the check does not run, and each failure produces an
-`invalid-protected-pattern` run notice at `error` level — reported in `--json`, in the CLI's text
-output, in `AnalysisResult.notices`, and by the textlint adapter anchored at the document start.
-`detail.reason` names the specific ground:
+a document. An entry that fails the check does not run. Each failure produces an
+`invalid-protected-pattern` run notice at `error` level. That notice is reported in `--json`, in
+the CLI's text output, and in `AnalysisResult.notices`. It is also reported by the textlint
+adapter, anchored at the document start. `detail.reason` names the specific ground:
 
 | `detail.reason`         | Refused because                                                                                   | Example      |
 | ----------------------- | ------------------------------------------------------------------------------------------------- | ------------ |
@@ -194,32 +195,32 @@ output, in `AnalysisResult.notices`, and by the textlint adapter anchored at the
 | `analysis-inconclusive` | ReDoS analysis could not determine whether the expression is safe                                 | —            |
 | `matches-only-empty`    | every possible match is zero-length, so nothing is ever protected                                 | `^`          |
 
-A refused entry is never silently ignored, because the consequence is not local: the literals it
-named are matched as ordinary words by every vocabulary rule, **and** they are no longer masked out
-of the passages sent to the semantic service. Silence there would look exactly like a clean run.
+A refused entry is never silently ignored, because the consequence is not local. The literals it
+named are matched as ordinary words by every vocabulary rule. They are also no longer masked out of
+the passages sent to the semantic service. Silence there would look exactly like a clean run.
 
-`invalid-syntax` and `source-too-long` are gates checked before analysis. Valid sources are parsed by
-`@eslint-community/regexpp`; `recheck` classifies their ReDoS complexity; and
-`regexp-ast-analysis` determines whether every possible match is empty. An inconclusive ReDoS result
-is refused rather than run. This package does not maintain a second regular-expression parser or a
-fallback set of hand-written complexity rules.
+`invalid-syntax` and `source-too-long` are gates checked before analysis. Valid sources are parsed
+by `@eslint-community/regexpp`. `recheck` classifies their ReDoS complexity. `regexp-ast-analysis`
+determines whether every possible match is empty. An inconclusive ReDoS result is refused rather
+than run. This package does not maintain a second regular-expression parser or a fallback set of
+hand-written complexity rules.
 
 ### Option precedence
 
 For a rule's options, lowest first:
 
-1. `rules.<id>` in the shared file;
-2. `rules.<id>` inside a `shared` object in the rule's textlint options;
+1. `rules.<id>` in the shared file.
+2. `rules.<id>` inside a `shared` object in the rule's textlint options.
 3. the rule's own textlint options.
 
-Layers are merged key by key, so a lower layer's `enabled: false` is not lost when a higher layer sets
-an unrelated key.
+Layers are merged key by key. A lower layer's `enabled: false` is therefore not lost when a higher
+layer sets an unrelated key.
 
 ### Inline suppression is not one of these layers
 
-`suppressions` is read only from the shared file; there is no per-rule or per-textlint-options form
+`suppressions` is read only from the shared file. There is no per-rule or per-textlint-options form
 of it. Inline `ste-ai-ignore-*` directives are applied after every rule has run, to the diagnostics
-the run produced, so they cannot change a rule's options and a rule cannot see them.
+the run produced. They cannot change a rule's options, and a rule cannot see them.
 
 A suppressed finding is withheld from `diagnostics` but recorded in `AnalysisResult.suppressions`,
 in `--json`, and in a `suppressions-applied` notice. See
@@ -230,10 +231,10 @@ in `--json`, and in a `suppressions-applied` notice. See
 This is the default. With `semantic.enabled` false, no network call is made at all — proven by
 `test/integration/semantic-service.test.ts`, which asserts the fake server received zero requests.
 
-Passages that would have needed adjudication are reported as `review-required`, and a
+Passages that would have needed adjudication are reported as `review-required`. A
 `semantic-disabled` run notice records how many there were. Nothing is silently treated as compliant.
 
-To be explicit in CI:
+To be explicit in continuous integration (CI):
 
 ```bash
 npx ste-ai lint docs/**/*.md --deterministic-only
@@ -241,31 +242,31 @@ npx ste-ai lint docs/**/*.md --deterministic-only
 
 ## Per-rule options
 
-| Rule                           | Options                                                                                                                           |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| `sentence-length-procedural`   | `maxGradeLevel`, `floorWords`, `includeHeadings`, `includeTableCells`                                                             |
-| `sentence-length-descriptive`  | `maxGradeLevel`, `floorWords`, `includeHeadings`, `includeTableCells`                                                             |
-| `unapproved-vocabulary`        | `additional` (`{term: [alternatives]}`), `allow`, `adjudicateSense`                                                               |
-| `preferred-terminology`        | `additional` (`{from: to}`), `allow`                                                                                              |
-| `no-contractions`              | `allow`                                                                                                                           |
-| `punctuation-constraints`      | `forbidSemicolon`, `forbidSlashBetweenWords`, `forbidExclamation`, `forbidEllipsis`, `forbidParenthesesInProcedural`, `maxCommas` |
-| `no-repeated-words`            | `allow` (default `["had","that"]`)                                                                                                |
-| `abbreviation-introduction`    | `minLength`, `maxLength`, `wellKnown` (replaces), `additionalWellKnown` (adds)                                                    |
-| `number-unit-format`           | `unitSpacing` (`required`\|`forbidden`\|`off`), `noSpaceUnits`, `forbidDecimalComma`                                              |
-| `list-instruction-structure`   | `checkTerminalPunctuation`, `checkInitialCapital`, `maxSentencesPerStep`                                                          |
-| `one-instruction-per-sentence` | `conjunctions`, `adjudicate`                                                                                                      |
-| `passive-voice-candidate`      | `requireByAgent`, `adjudicate`                                                                                                    |
-| `noun-cluster-candidate`       | `maxClusterLength`, `adjudicate`                                                                                                  |
-| `ambiguous-pronoun-candidate`  | `minAntecedents`, `adjudicate`                                                                                                    |
+| Rule                           | Options                                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sentence-length-procedural`   | `maxGradeLevel`, `floorWords`, `includeHeadings`, `includeTableCells`                                                                       |
+| `sentence-length-descriptive`  | `maxGradeLevel`, `floorWords`, `includeHeadings`, `includeTableCells`                                                                       |
+| `unapproved-vocabulary`        | `additional` (`{term: [alternatives]}`), `allow`, `adjudicateSense`                                                                         |
+| `preferred-terminology`        | `additional` (`{from: to}`), `allow`                                                                                                        |
+| `no-contractions`              | `allow`                                                                                                                                     |
+| `punctuation-constraints`      | `forbidSemicolon`<br>`forbidSlashBetweenWords`<br>`forbidExclamation`<br>`forbidEllipsis`<br>`forbidParenthesesInProcedural`<br>`maxCommas` |
+| `no-repeated-words`            | `allow` (default `["had","that"]`)                                                                                                          |
+| `abbreviation-introduction`    | `minLength`, `maxLength`, `wellKnown` (replaces), `additionalWellKnown` (adds)                                                              |
+| `number-unit-format`           | `unitSpacing` (`required`\|`forbidden`\|`off`), `noSpaceUnits`, `forbidDecimalComma`                                                        |
+| `list-instruction-structure`   | `checkTerminalPunctuation`, `checkInitialCapital`, `maxSentencesPerStep`                                                                    |
+| `one-instruction-per-sentence` | `conjunctions`, `adjudicate`                                                                                                                |
+| `passive-voice-candidate`      | `requireByAgent`, `adjudicate`                                                                                                              |
+| `noun-cluster-candidate`       | `maxClusterLength`, `adjudicate`                                                                                                            |
+| `ambiguous-pronoun-candidate`  | `minAntecedents`, `adjudicate`                                                                                                              |
 
 Setting `adjudicate: false` on a candidate rule makes it report `review-required` locally instead of
 producing a semantic candidate.
 
-`abbreviation-introduction` requires `minLength` to be less than or equal to `maxLength`; the two
-bounds become the length range of the abbreviation-shaped token it looks for, and an inverted pair
-describes no token at all. An inverted pair is rejected when the options are validated, so the rule
-is skipped with a `rule-options-invalid` notice naming it and the rest of the run still reports.
-Options that fail validation never abort a run — every rule's options are validated before it runs,
+`abbreviation-introduction` requires `minLength` to be less than or equal to `maxLength`. The two
+bounds become the length range of the abbreviation-shaped token it looks for. An inverted pair
+describes no token at all. An inverted pair is rejected when the options are validated. The rule is
+then skipped with a `rule-options-invalid` notice naming it, and the rest of the run still reports.
+Options that fail validation never abort a run. Every rule's options are validated before it runs,
 and a rule whose options are invalid is skipped this way.
 
 ## CLI
@@ -285,12 +286,21 @@ npx ste-ai rules --json
 npx ste-ai evaluators
 ```
 
-Exit codes: `0` clean, `1` errors present (or review-required with `--fail-on-review`), `2` usage
-error, `3` any `error`-level run notice — the run has less protection, or fewer of its configured
-rules ran, than the operator's configuration asked for, not that the document itself has a finding.
-Current examples: a semantic-service failure under the `error` policy, a refused
-`extraProtectedPatterns` entry (see "Protected patterns are screened before they run" above), or a
-rule skipped over invalid options (`rule-options-invalid`, just above).
+Exit codes:
+
+- `0` — clean.
+- `1` — errors present. This also includes review-required findings when `--fail-on-review` is set.
+- `2` — usage error.
+- `3` — any `error`-level run notice. This means one of two things. The run had less protection
+  than the operator's configuration asked for. Alternatively, fewer of its configured rules ran
+  than the operator asked for. It does not mean the document itself has a finding.
+
+Current examples of an `error`-level run notice:
+
+- A semantic-service failure under the `error` policy.
+- A refused `extraProtectedPatterns` entry. See the "Protected patterns are screened before they
+  run" section above.
+- A rule skipped over invalid options (`rule-options-invalid`, described above).
 
 ## Programmatic API
 
@@ -317,5 +327,5 @@ console.log(full.traces); // per-request prompt version, model id, content hash,
 console.log(full.pack.metadata.conformanceClaim); // 'none' for the bundled pack
 ```
 
-`AnalysisResult.document` is the `AnalysedDocument`: protected regions, blocks, sentences, words and
-`positionAt()` for converting an offset to line/column.
+`AnalysisResult.document` is the `AnalysedDocument`. It exposes protected regions, blocks,
+sentences, words and `positionAt()` for converting an offset to a line and column position.

--- a/docs/design/64-layered-rule-packs/00-decisions.md
+++ b/docs/design/64-layered-rule-packs/00-decisions.md
@@ -1,42 +1,49 @@
 # Layered rule packs — consolidated design and open decisions
 
 Design record for [issue #64](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/64).
-Three specs were produced independently against commit `9d78a8b`, each with a scope boundary so they
-would not design across each other:
+Three specs were produced independently against commit `9d78a8b`. Each spec had a scope boundary, so
+they would not design across each other:
 
-| Spec                                                             | Scope                                                                             |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [`01-merge-core.md`](./01-merge-core.md)                         | Config shape, per-field merge algorithm, retraction, conflict detection, ordering |
-| [`02-authority-trust.md`](./02-authority-trust.md)               | Per-entry authority, the trust boundary under composition, provenance             |
-| [`03-migration-verification.md`](./03-migration-verification.md) | Blast radius, back-compatibility, test strategy, staged rollout                   |
+| Spec                                                             | Scope                                                                                     |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [`01-merge-core.md`](./01-merge-core.md)                         | Config shape<br>Per-field merge algorithm<br>Retraction<br>Conflict detection<br>Ordering |
+| [`02-authority-trust.md`](./02-authority-trust.md)               | Per-entry authority, the trust boundary under composition, provenance                     |
+| [`03-migration-verification.md`](./03-migration-verification.md) | Blast radius, back-compatibility, test strategy, staged rollout                           |
 
 This file records what the three agree on, where two of them disagreed, and what remains for a human
-to decide. The specs hold the detail and the citations, and they are **not** rewritten to match this
-record — so where the two differ, this file wins. Four things it overturns, each still asserted
+to decide. The specs hold the detail and the citations. They are **not** rewritten to match this record. Where
+the two differ, this file wins. Four things it overturns, each still asserted
 unqualified in the spec that proposed it:
 
 | Overturned                                   | Still asserted in                       |
 | -------------------------------------------- | --------------------------------------- |
 | `rulePacks` as a new config key              | `01:186`, the config table, conflict C1 |
 | Composed output satisfies `RulePack` exactly | `01:22-23`, its opening premise         |
-| `replace` mode, and replace-only-at-index-0  | `01` (C2, C6); depended on by `02`      |
+| `replace` mode, and replace-only-at-index-0  | `01` (C2, C6) — depended on by `02`     |
 | Conformance claims are in scope              | most of `02`                            |
 
-Each spec carries a banner pointing here, so a reader who opens one directly is not led into an
+Each spec carries a banner pointing here. A reader who opens one directly is not led into an
 overturned design.
 
 ## Framing correction: this is a defect, not a feature
 
-`README.md:74-75` already states that `rulePack` and `approvedTerms` let a repository supply its own
-vocabulary **"on top of the bundled provisional pack"**. `resolveRulePack` (`loader.ts:49-56`)
-substitutes instead — its three branches each return one pack, and none combines them.
+At `9d78a8b`, `README.md:74-75` stated that `rulePack` and `approvedTerms` let a repository supply its
+own vocabulary. The exact phrase was **"on top of the bundled provisional pack"**. `resolveRulePack`
+(`loader.ts:49-56`) substitutes instead — its three branches each return one pack, and none combines
+them.
 
-So the documented behaviour and the implemented behaviour already disagree — with one qualifier that
-sentence conjoins two keys and only one of them layers today: `config.approvedTerms` really is spread
-together with `pack.approvedTechnicalTerms` at `analyse.ts:255`. `rulePack` is the half that
-substitutes. `03:494-495` states this precisely; the claim here is the same one, narrowed to the key it
-actually applies to. Layering closes that gap rather than adding something new. `03` found a second instance of the same drift: `README.md` is not
-alone, and the reconciliation list in that spec names the rest.
+So the documented behaviour and the implemented behaviour disagreed at that commit. One qualifier
+applied: that `README.md` sentence named two keys, but only one of them layered. `config.approvedTerms`
+really is spread together with `pack.approvedTechnicalTerms` at `analyse.ts:264`. `rulePack` is the
+half that substitutes. `03:494-495` states this precisely. The claim there is the same one, narrowed
+to the key it actually applies to. Layering closes that gap rather than adding something new.
+
+**This part is now fixed.** `README.md` was corrected by commit `17b5ce7`, which fixed the `rulePack`
+layering claim. It now says `rulePack` replaces the bundled provisional pack entirely, rather than
+adding to it. It separately says `approvedTerms` layers on top of whichever pack is active. Both
+statements now match the implementation described above. `resolveRulePack` still substitutes. Only the
+documentation claim has changed. `03` found a second instance of the same drift in a different file.
+The reconciliation list in that spec names the rest. That part is unverified here.
 
 ## Resolved: the two places the specs disagreed
 
@@ -47,12 +54,12 @@ or consumer would change. `02` requires a distinct `ComposedRulePack` in which e
 required `EntryProvenance`.
 
 These cannot both hold. `RulePack` has nowhere to put per-entry authority — `approvedTechnicalTerms`
-is `readonly string[]` (`types.ts:484`), and a string cannot carry provenance.
+is `readonly string[]` (`types.ts:489`), and a string cannot carry provenance.
 
-**Decision: `02` wins; `01`'s zero-consumer-change property is what gives.**
+**Decision: `02` wins — `01`'s zero-consumer-change property is what gives.**
 
-The reason is the concrete attack `02` documents: an untrusted layer adds a technical term, that term
-is protected before any rule runs (`analyse.ts:254-257`), and a normative dictionary entry then never
+The reason is the concrete attack `02` documents. An untrusted layer adds a technical term. That term
+is protected before any rule runs (`analyse.ts:263-266`). A normative dictionary entry then never
 matches. Without per-entry provenance nothing distinguishes that entry from a trusted one. The cost —
 a breaking type change and a wider blast radius — is real and belongs to `03`'s inventory.
 
@@ -61,63 +68,77 @@ a breaking type change and a wider blast radius — is real and belongs to `03`'
 `01` proposed a new `rulePacks` key alongside `rulePack`. `03` proposed widening the existing
 `rulePack` key to accept an array.
 
-**Decision: `03` wins, on measured behaviour.** Executed against the config schema at this commit:
+**Decision: `03` wins, on measured behaviour.** Executed against the config schema at `9d78a8b`:
 
 ```
-new key `rulePacks` on current schema → ACCEPTED, and the key is SILENTLY STRIPPED
-array passed to existing `rulePack`  → REJECTED (fails loud)
+new key `rulePacks` on schema at `9d78a8b` → ACCEPTED, and the key is SILENTLY STRIPPED
+array passed to existing `rulePack`        → REJECTED (fails loud)
 ```
 
-`steAiConfigSchema` (`config.ts:119`) is a plain `z.object`, so it strips unknown keys. A config
-written for a newer linter and run against an older one would therefore lose its entire layer stack
-and lint against the bundled pack with no signal. Widening the existing key converts that same
-version skew into a loud parse failure.
+At that commit, `steAiConfigSchema` was a plain `z.object`, so it stripped unknown keys. Consider a
+config written for a newer linter and then run against an older one. It would therefore lose its
+entire layer stack. It would then lint against the bundled pack with no signal. Widening the existing
+key converted that same version skew into a loud parse failure.
 
-This is a design decision that surfaced only from asking a migration question, which is the argument
+**This measurement is now stale.** Commit `6667a02` changed `steAiConfigSchema` (`config.ts:144`) to
+`z.strictObject`, so it now rejects an unrecognised key instead of stripping it. Re-running the same
+test today gives a different result:
+
+```
+new key `rulePacks` on the current schema → REJECTED (fails loud)
+array passed to existing `rulePack`       → REJECTED (fails loud)
+```
+
+Both paths now fail loud. The silent-strip risk that drove this decision no longer distinguishes the
+two options. This record does not revisit the decision. It flags the drift so a reader does not treat
+the first command block as still current.
+
+This is a design decision that surfaced only from asking a migration question. That is the argument
 for having produced `03` at all.
 
 ## Agreed across specs
 
 - **The bundled pack becomes layer 0**, rather than a fallback used when nothing is configured.
   ~~present unless displaced by a `replace` entry~~ — struck: `replace` is removed by "Superseded by
-  project stage" below, so nothing displaces it.
+  project stage" below. As a result, nothing displaces it.
 - ~~**`replace` is legal only as the first layer.**~~ Struck for the same reason. The specs agreed on
-  this validation rule, and it has no subject once the mode is gone; it is recorded here because the
-  agreement was real and would need reinstating with the mode.
-- **Merge keys are per-field, not global.** Verified: `termPattern` (`helpers.ts:10`) matches with
-  flags `giu` and collapses whitespace, while `approvedTerms` protection (`approvedTermPass` in
-  `protected-regions.ts`) matches with flags `gu`, case-sensitively and without folding. A single
-  normaliser would therefore be wrong for one of them.
+  this validation rule. It has no subject now that the mode is gone. It is recorded here because the
+  agreement was real, and it would need reinstating along with the mode.
+- **Merge keys are per-field, not global.** Verified: `termPattern` matches with flags `giu` and
+  collapses whitespace. This is confirmed at `helpers.ts:10`. `approvedTerms` protection matches with
+  flags `gu`, case-sensitively and without folding. This is confirmed by `approvedTermPass` in
+  `protected-regions.ts`. A single normaliser would therefore be wrong for one of them.
 - **Override direction is one-way.** The overriding layer owns the resulting entry's provenance
-  entirely; it is never inherited from the layer being overridden.
+  entirely. That provenance is never inherited from the layer being overridden.
 - **Retraction needs its own syntax.** Union alone cannot express a locale layer un-banning a term an
   organisation layer banned. `01` specifies a `retract` block and records why `options.allow` is not
   the mechanism.
 - **Characterisation tests come first.** Both `02` and `03` found independently that no test imports
-  `src/rule-pack/loader.ts`; `grep -rln "authority\|conformance\|rulePack" test/` returns zero files.
-  Nothing else should merge before that gap is closed.
+  `src/rule-pack/loader.ts`. Running `grep -rln "authority\|conformance\|rulePack" test/` returns zero
+  files. Nothing else should merge before that gap is closed.
 
 ## Decided by the maintainer
 
 ### A. `limits` merge policy — last-wins
 
 **Decided: last-wins**, matching how ESLint and Ruff resolve overlapping configuration. A later
-layer's limit replaces an earlier one; there is no organisation-set floor that lower layers cannot
+layer's limit replaces an earlier one. There is no organisation-set floor that lower layers cannot
 loosen.
 
-This follows `01`'s recommendation. Its argument stands: `limits` is required in `rulePackSchema`, so
-a most-restrictive-wins rule would pin the bundled pack's values (procedural grade level 7) as a
-ceiling no organisation could raise.
+This follows `01`'s recommendation. Its argument stands: `limits` is required in `rulePackSchema`. A
+most-restrictive-wins rule would therefore pin the bundled pack's values (procedural grade level 7) as
+a ceiling. No organisation could raise that ceiling.
 
-Accepted cost, recorded so it is not rediscovered as a surprise: a product or locale layer can loosen
-an organisation's limit. The conventional-tooling behaviour was preferred over enforcement.
+This is an accepted cost, recorded here so it is not rediscovered as a surprise. A product or locale
+layer can loosen an organisation's limit. The conventional-tooling behaviour was preferred over
+enforcement.
 
 ### B. Conformance under mixed authority — not in scope
 
 **Decided: the product does not make conformance claims, so there is nothing to protect here.**
 
-The maintainer's framing: this is a configurable linter that flags prose exceeding a threshold and
-suggests it could be tighter. It is a per-repository capability that may import organisation-level
+The maintainer's framing: this is a configurable linter. It flags prose that exceeds a threshold and
+suggests the prose could be tighter. It is a per-repository capability that may import organisation-level
 dictionaries, stay local-only, or mix the two. Conformance standing for a supplied pack is not a
 goal.
 
@@ -126,10 +147,10 @@ larger change than the decision it settles.
 
 #### What this decision cascades into
 
-The authority machinery exists to guard one path: a supplied pack declaring `normative` authority and
-having that claim honoured after an operator names it in `trustedRulePackIds`. With conformance out
-of scope, that path has no destination. The surface is 35 references across 8 files, counted by this
-exact command so the number can be re-derived rather than trusted:
+The authority machinery exists to guard one path. A supplied pack can declare `normative` authority.
+That claim is honoured only after an operator names the pack in `trustedRulePackIds`. With conformance out
+of scope, that path has no destination. The surface is 35 references across 8 files. This exact command counts them, so the number can be
+re-derived rather than trusted:
 
 ```bash
 grep -vE '^\s*(//|\*|/\*)' <file> \
@@ -137,10 +158,10 @@ grep -vE '^\s*(//|\*|/\*)' <file> \
   | wc -l
 ```
 
-That is occurrences of the removal candidates, with comment-only lines excluded — a rule worth
-stating, because counting matching _lines_ instead, or leaving comments in, gives materially
-different totals, and the scope of the proposed removal is argued from this table. The `| wc -l` is
-the load-bearing part: `grep -c` counts matching **lines** and ignores `-o`, which yields 28 rather
+That count is occurrences of the removal candidates, with comment-only lines excluded. This
+distinction is worth stating: counting matching _lines_ instead, or leaving comments in, gives a
+materially different total. The scope of the proposed removal is argued from this table. The `| wc -l`
+is the load-bearing part: `grep -c` counts matching **lines** and ignores `-o`, which yields 28 rather
 than 35 on the same files.
 
 | File                                | References |
@@ -154,9 +175,13 @@ than 35 on the same files.
 | `src/core/types.ts`                 |          1 |
 | `src/core/config.ts`                |          1 |
 
-Candidates for removal, each serving only the conformance path: `packPermitsConformanceClaim`,
-`verifiedAuthority`, `verifiedRuleStatus`, the `trustedRulePackIds` config key, and
-`metadata.authority` / `metadata.conformanceClaim` in the pack schema.
+Candidates for removal, each serving only the conformance path:
+
+- `packPermitsConformanceClaim`
+- `verifiedAuthority`
+- `verifiedRuleStatus`
+- the `trustedRulePackIds` config key
+- `metadata.authority` / `metadata.conformanceClaim` in the pack schema
 
 **What is kept, and what each protects when working correctly:**
 
@@ -169,33 +194,34 @@ Candidates for removal, each serving only the conformance path: `packPermitsConf
   would need reconciling.
 - **The disclaimer line in CLI output** — states plainly that the tool certifies nothing.
 
-This also shrinks the `sourceRef` defect (#66). Without an authority-elevation path there is no
-trusted-versus-untrusted distinction for a citation to cross; attributing a `sourceRef` to the pack
-that supplied it is then the same work as per-entry provenance, rather than a separate fix.
+This also shrinks the `sourceRef` defect (#66). Without an authority-elevation path, there is no
+trusted-versus-untrusted distinction for a citation to cross. Attributing a `sourceRef` to the pack
+that supplied it is then the same work as per-entry provenance. It is not a separate fix.
 
 ## Superseded by project stage
 
 The maintainer has confirmed the repository is a prototype with no users. Two conclusions recorded
 above lose their supporting argument:
 
-- **The `rulePack` versus `rulePacks` decision.** The measured version-skew argument — a config
-  written for a newer linter silently losing its layer stack on an older one — requires users on old
-  versions. The weaker argument for widening the existing key (one key is less confusing than two)
-  is unaffected.
+- **The `rulePack` versus `rulePacks` decision.** The measured version-skew argument requires users on
+  old versions. It describes a config written for a newer linter that silently loses its layer stack
+  on an older one. The weaker argument for widening the existing key (one key is less confusing than
+  two) is unaffected.
 - **`replace` mode.** It was specified to preserve the current substituting behaviour for configs
-  already in use. Without such configs to preserve, packs can always compose, which removes a config
+  already in use. Without such configs to preserve, packs can always compose. That removes a config
   mode, the "`replace` only at index 0" validation rule, and its test cases.
 
 Spec `03`'s back-compatibility analysis should be read with this in mind. Its blast-radius inventory,
-test strategy and staged rollout remain applicable; its back-compat reasoning does not.
+test strategy, and staged rollout remain applicable. Its back-compat reasoning does not.
 
 ## Related defects found while specifying
 
 Both are independent of layering and are tracked separately:
 
-- **`sourceRef` passes through untrusted.** `runner.ts:110` assigns `meta.sourceRef` from the pack
-  unconditionally. `verifiedRuleStatus` caps an untrusted pack's _status_, and the citation _string_
-  is copied verbatim, so an untrusted pack can print a fabricated standard citation on a diagnostic.
+- **`sourceRef` passes through untrusted.** `runner.ts:112` assigns `meta.sourceRef` from the pack
+  unconditionally. `verifiedRuleStatus` caps an untrusted pack's _status_. The citation _string_,
+  however, is copied verbatim. An untrusted pack can therefore print a fabricated standard citation on
+  a diagnostic.
 - **The rule-pack loader has no test coverage**, as above.
 
 ## Documentation already inaccurate, before any of this lands
@@ -205,20 +231,19 @@ Both are independent of layering and are tracked separately:
 - `rule-pack-import.md:51` and `:135` describe `packPermitsConformanceClaim()` with two conditions.
   `loader.ts:76-83` enforces three — the third being membership in `trustedRulePackIds`. The docs
   describe the gate as more permissive than the code.
-- `DISCLAIMER.md:64-65` states a pack "changes the `ruleStatus` on diagnostics to whatever the pack
-  declares", which holds only once an operator has trusted it.
-- `README.md:74-75`, as above.
+- `DISCLAIMER.md:64-65` states that a pack "changes the `ruleStatus` on diagnostics to whatever the
+  pack declares." That statement holds only once an operator has trusted the pack.
+- `README.md:74-75` — this one is fixed now. See "Framing correction" above.
 
 ## Method note
 
-The specs were produced by three agents working in isolated worktrees from `9d78a8b`, each instructed
-to cite a file and line for every claim about current behaviour and to state uncertainty rather than
-guess. Claims reproduced in this file were re-verified directly before being recorded here. Where a
-spec labelled something as its own proposal rather than an existing fact — `01` does this for
-"weakest authority wins", since `ruleStatusSchema` declares no ordering — that label is preserved.
+The specs were produced by three agents, each working in an isolated worktree from `9d78a8b`. Each
+agent was instructed to cite a file and line for every claim about current behaviour. It was also
+instructed to state uncertainty rather than guess. Claims reproduced in this file were re-verified directly before being recorded here. Sometimes a
+spec labelled something as its own proposal rather than an existing fact. `01` does this for "weakest
+authority wins", since `ruleStatusSchema` declares no ordering. That label is preserved here.
 
 `03` recorded that it could not run the test suite (no `node_modules` in its worktree) and flagged
 "main is green at `9d78a8b`" as unconfirmed. Confirmed since, and the answer needs its commit
-naming: at `9d78a8b` the suite is green (545 tests). At `ebcc623` — the commit this branch was cut
-from, and a different tree — one corpus assertion was failing, pre-existing from #56 and fixed by
-#58. `03`'s Stage 0 precondition is therefore discharged only against a tree that has #58 in it.
+naming: at `9d78a8b` the suite is green (545 tests). At `ebcc623` — the commit this branch was cut from, and a different tree — one corpus assertion was
+failing. That assertion was pre-existing from #56, and it was fixed by #58. `03`'s Stage 0 precondition is therefore discharged only against a tree that has #58 in it.

--- a/docs/diagnostic-policy.md
+++ b/docs/diagnostic-policy.md
@@ -2,8 +2,8 @@
 
 ## Five categories
 
-A reader needs to know how much weight a finding carries before acting on it, so the categories are
-distinguished rather than flattened into "error/warning".
+A reader needs to know how much weight a finding carries before acting on it. That is why the
+categories stay distinguished, rather than flattened into "error" or "warning".
 
 | Category                      | What it means                                                                                                                         | Default severity |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
@@ -13,9 +13,9 @@ distinguished rather than flattened into "error/warning".
 | `suppressed-low-confidence`   | A `violation` below threshold, discarded. Not reported unless `reportSuppressed`.                                                     | `info`           |
 | `infrastructure-failure`      | The tooling failed. Never a statement about the document.                                                                             | `warning`        |
 
-Every diagnostic also carries `ruleStatus` (`provisional` for everything this package ships), and
-semantic diagnostics carry `modelReportedConfidence` **and** `decisionThreshold` so the reason a
-verdict was kept or suppressed is visible.
+Every diagnostic also carries `ruleStatus` (`provisional` for everything this package ships).
+Semantic diagnostics also carry `modelReportedConfidence` **and** `decisionThreshold`. A reader can
+use these to see why the tool kept or suppressed a given verdict.
 
 In textlint output both facts appear as a message prefix: `[deterministic-violation][provisional] …`.
 Full structure is available from the programmatic API and from `ste-ai lint --json`.
@@ -41,7 +41,7 @@ that passed.
 
 Under every policy the notice states `No compliance conclusion was drawn about them` and reports how
 many of how many passages were affected. `silent` exists for programmatic callers that inspect
-`result.notices` themselves; it does not delete the information.
+`result.notices` themselves. It does not delete the information.
 
 Deterministic diagnostics are unaffected by an outage. `test/integration/semantic-service.test.ts`
 asserts that the deterministic finding set under a 503 is byte-identical to an offline run.
@@ -49,30 +49,31 @@ asserts that the deterministic finding set under a 503 is byte-identical to an o
 When semantic analysis is simply **disabled**, candidates become `review-required` and a
 `semantic-disabled` notice records the count. Again: not compliance.
 
-All of the above is testable and tested — the outage-policy block in the integration suite covers
-`notice`, `error`, `silent`, malformed replies, and the deterministic-set invariant.
+All of the above is testable, and it is tested. The outage-policy block in the integration suite
+covers three policy values: `notice`, `error`, and `silent`. It also covers malformed replies and
+the deterministic-set invariant.
 
 ## A suppression is an authored claim
 
-An inline `ste-ai-ignore-*` directive does not delete a finding. It records that a person read the
-finding and decided it does not apply, and it carries their reason — a directive without a reason is
-inert and reported as `suppression-reason-missing`.
+An inline `ste-ai-ignore-*` directive does not delete a finding. The directive records that a
+person read the finding and decided it does not apply. It also carries their reason — a directive
+without a reason is inert and reported as `suppression-reason-missing`.
 
-The rule above governs this too. A withheld finding leaves `diagnostics` and does not leave the
-result: it appears in `AnalysisResult.suppressions`, in `ste-ai lint --json`, in the CLI's
-`suppressed` lines, and in a `suppressions-applied` notice carrying the count. A file that is clean
-because of six suppressions is not the same file as one that is clean, and the output says which it
-is.
+The rule above governs suppression too. A withheld finding leaves `diagnostics`, but it does not
+leave the result. It appears in `AnalysisResult.suppressions`, in `ste-ai lint --json`, and in the
+CLI's `suppressed` lines. It also appears in a `suppressions-applied` notice carrying the count. A
+file that is clean because of six suppressions is not the same as a file that needs no suppressions
+at all. The output states which kind of clean a given file is.
 
-Inside a `danger`, `warning` or `caution` admonition a claim is **refused** by default: the
-diagnostic is kept and `suppression-refused-in-admonition` is emitted at `warning`. Setting
-`suppressions.allowInAdmonitions: true` permits it. That option exists at all — while
-`autofix.allowInAdmonitions` is typed `z.literal(false)` and cannot — because rewriting the source
-of a safety notice and withholding a report about one are different acts. The first changes what a
-reader in front of the equipment is told. The second is an operator's decision about the linter's
-output, permitted when taken explicitly and always recorded.
+Inside a `danger`, `warning` or `caution` admonition, a claim is **refused** by default. The
+diagnostic is kept, and `suppression-refused-in-admonition` is emitted at `warning`. Setting
+`suppressions.allowInAdmonitions: true` permits it. That option exists for a reason.
+`autofix.allowInAdmonitions` is typed `z.literal(false)`, so it cannot be set the same way.
+Rewriting the source of a safety notice, and withholding a report about one, are different acts. The
+first act changes what a reader in front of the equipment is told. The second act is an operator's
+decision about the linter's own output, permitted when taken explicitly and always recorded.
 
-Suppression is applied to candidates as well as to diagnostics, before adjudication: a suppressed
+Suppression is applied to candidates, as well as to diagnostics, before adjudication. A suppressed
 passage is never sent to a semantic service. Full syntax and semantics are in
 [`suppression.md`](./suppression.md).
 
@@ -80,45 +81,55 @@ passage is never sent to a semantic service. Full syntax and semantics are in
 
 A fix may exist only if one of two conditions holds:
 
-1. **Deterministic and meaning-preserving** — a closed, enumerated substitution that cannot change
-   technical meaning. `don't` → `do not`. `utilise` → `use` where the pack marks it safe.
-2. **Semantically gated** — a model-proposed rewrite that passed an _independent_
-   `rewrite-equivalence` evaluation and left every protected literal in the span byte-identical.
-   Disabled by default (`autofix.allowSemanticFixes: false`), because enabling it means trusting a
-   model verdict to authorise a source edit.
+1. **Deterministic and meaning-preserving**: a closed, enumerated substitution that cannot change
+   technical meaning.
+   - Example: `don't` → `do not`.
+   - Example: `utilise` → `use`, where the pack marks it safe.
+2. **Semantically gated**: a model-proposed rewrite that an independent check has approved.
+   - The check is a separate `rewrite-equivalence` evaluation, and it must find every protected
+     literal in the span unchanged.
+   - This path is disabled by default (`autofix.allowSemanticFixes: false`). Enabling it means
+     trusting a model verdict to authorise a source edit.
 
-The evaluator's own `meaningPreserved` flag is **not** sufficient for case 2: it comes from the same
-call that proposed the change. A separate request is made, and the gate fails closed — a transport
-failure, invalid output, or an `uncertain` verdict all mean "no fix".
+The evaluator's own `meaningPreserved` flag is **not** enough for case 2, because that flag comes
+from the same call that proposed the change. A separate request checks the rewrite instead. The gate
+fails closed: a transport failure, an invalid output, or an `uncertain` verdict all mean "no fix".
 
 ### Never autofixed
 
 Regardless of rule or configuration:
 
-- anything inside a `danger`, `warning`, `caution` or `note` admonition;
-- anything that changes a digit — quantities, tolerances, ranges, versions, part numbers;
-- anything that changes a negation, including collapsing a double negation;
-- anything that changes a modal verb (`must`, `shall`, `should`, `can`, `may`, `might`, `will`,
-  `would`, `need`, `ought`);
-- anything that changes an ordering word (`before`, `after`, `first`, `then`, `next`, `finally`,
-  `while`, `until`, `during`, `when`, `once`);
-- anything overlapping a protected region — code, commands, identifiers, paths, URLs, placeholders,
-  quoted literals;
-- anything a rule did not declare `fixable`.
+- Anything inside a `danger`, `warning`, `caution` or `note` admonition.
+- Anything that changes a digit.
+  - a quantity, a tolerance, a range
+  - a version, a part number
+- Anything that changes a negation, including collapsing a double negation.
+- Anything that changes a modal verb.
+  - `must`, `shall`, `should`, `can`
+  - `may`, `might`, `will`, `would`
+  - `need`, `ought`
+- Anything that changes an ordering word.
+  - `before`, `after`, `first`, `then`
+  - `next`, `finally`, `while`, `until`
+  - `during`, `when`, `once`
+- Anything overlapping a protected region.
+  - Code, commands, identifiers, paths
+  - URLs, placeholders, quoted literals
+- Anything a rule did not declare `fixable`.
 
 `autofix.allowInAdmonitions` is typed `z.literal(false)`. Setting it to `true` is a schema error, so
 the refusal is explicit and testable rather than implicit.
 
 ### Normalisation before comparison
 
-The negation and ordering checks compare _relations_, not spellings. Negative contractions
-(`don't` → `do not`, `won't` → `will not`, `cannot` → `can not`) and register variants of ordering
-words (`whilst` → `while`, `prior to` → `before`, `subsequent to` → `after`, `amongst` → `among`) are
-normalised on both sides first.
+The negation and ordering checks compare _relations_, not spellings. Negative contractions are
+normalised on both sides first: `don't` → `do not`, `won't` → `will not`, and `cannot` → `can not`.
+So are register variants of ordering words: `whilst` → `while`, `prior to` → `before`,
+`subsequent to` → `after`, and `amongst` → `among`.
 
-Without this, expanding `don't` to `do not` would be refused as "changes negation" and
-`prior to` → `before` as "changes an ordering word" — both correct substitutions that the pack marks
-safe. This was a real defect caught by the fix-gate tests.
+Without this normalisation, expanding `don't` to `do not` would be refused as "changes negation".
+Turning `prior to` into `before` would be refused as "changes an ordering word". Both are correct
+substitutions that the pack marks safe, and this was a real defect caught by the fix-gate tests.
 
 ### Overlapping fixes
 
@@ -128,14 +139,15 @@ overlap cause **both** to be refused, each diagnostic gaining
 `overlapping-fixes-refused` run notice.
 
 Both are dropped rather than one being preferred by precedence. Two rules disagreeing about the same
-characters is precisely the situation where an automated edit is least trustworthy, so the tool
-declines and says so. An identical replacement of an identical range from two rules is a duplicate,
-not a conflict, and one survives.
+characters is precisely the situation where an automated edit is least trustworthy. The tool
+declines, and it says so. An identical replacement of an identical range from two rules is a
+duplicate, not a conflict, and one survives.
 
 Resolution is deterministic: the same input always produces the same outcome.
 
 ### Suggestions versus fixes
 
-A diagnostic may carry `suggestions` even when no fix is offered — `number-unit-format` suggests
-`25 Nm` for `25Nm` but never applies it, because the autofix policy forbids automated edits to
-quantities. textlint surfaces suggestions to an editor; `textlint --fix` applies only gated fixes.
+A diagnostic may carry `suggestions` even when no fix is offered. For example, `number-unit-format`
+suggests `25 Nm` for `25Nm`, but it never applies that suggestion. The autofix policy forbids
+automated edits to quantities. textlint surfaces suggestions to an editor. `textlint --fix` applies
+only gated fixes.

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -17,14 +17,23 @@ fixtures/
 
 ## Licence rules
 
-Only sources whose licence permits redistribution **and is not share-alike or copyleft** are included:
-public domain (US federal government works, SQLite), MIT, BSD, Apache-2.0, the curl and PostgreSQL
-licences, and CC-BY-4.0. Share-alike and copyleft licences are excluded on purpose — they would
-propagate their obligations onto the rewritten counterparts, which are adaptations.
+Only sources whose licence permits redistribution are included. A share-alike or copyleft licence
+excludes a source. It would propagate its obligations onto the rewritten counterpart, which is an
+adaptation.
 
-`derivativeLicence` records the licence of the counterpart: `MIT (this repository)` for permissive and
-public-domain sources, and `CC-BY-4.0` for CC-BY sources, where attribution propagates. The validator
-enforces this, and rejects any share-alike or copyleft licence outright.
+Accepted licences:
+
+- public domain (US federal government works, SQLite)
+- `MIT`
+- `BSD`
+- `Apache-2.0`
+- the curl licence
+- the PostgreSQL licence
+- `CC-BY-4.0`
+
+`derivativeLicence` records the licence of the counterpart. Permissive and public-domain sources get
+`MIT (this repository)`. `CC-BY` sources get `CC-BY-4.0`, where attribution propagates. The validator
+enforces this and rejects any share-alike or copyleft licence outright.
 
 Composition:
 
@@ -32,13 +41,13 @@ Composition:
 | ---------------------------------- | -------- |
 | Public Domain (SQLite)             | 4        |
 | Public Domain (US Government work) | 2        |
-| Apache-2.0                         | 4        |
-| Apache-2.0 WITH LLVM-exception     | 2        |
-| CC-BY-4.0                          | 2        |
+| `Apache-2.0`                       | 4        |
+| `Apache-2.0 WITH LLVM-exception`   | 2        |
+| `CC-BY-4.0`                        | 2        |
 | PostgreSQL Licence                 | 1        |
-| BSD-3-Clause                       | 1        |
+| `BSD-3-Clause`                     | 1        |
 | curl licence                       | 1        |
-| MIT                                | 1        |
+| `MIT`                              | 1        |
 
 ## Provenance is auditable, not asserted
 
@@ -53,16 +62,16 @@ vp run fixtures:validate   # build, then verify everything below
 
 `validateFixtureCorpus()` checks:
 
-- the manifest and lock satisfy their schemas;
-- each `originalSha256` matches the committed file;
+- the manifest and lock satisfy their schemas.
+- each `originalSha256` matches the committed file.
 - each `provenanceKey` resolves to a lock record with a 2xx status and non-zero bytes, whose URL
-  corresponds to the fixture's `sourceUrl`;
-- no share-alike or copyleft licence, and a licence quote of at least 10 characters with a URL;
-- CC-BY sources propagate attribution into `derivativeLicence`;
-- category minimums (≥ 2 per category across 9 categories) and corpus size (≥ 15);
-- `heldout` is at least 25% of the corpus, and the splits are disjoint by content hash;
-- no unlisted files in `fixtures/original/`;
-- **protected literals are byte-identical** between an original and its counterpart;
+  corresponds to the fixture's `sourceUrl`.
+- no share-alike or copyleft licence, and a licence quote of at least 10 characters with a URL.
+- `CC-BY` sources propagate attribution into `derivativeLicence`.
+- category minimums (≥ 2 per category across 9 categories) and corpus size (≥ 15).
+- `heldout` is at least 25% of the corpus, and the splits are disjoint by content hash.
+- no unlisted files in `fixtures/original/`.
+- **protected literals are byte-identical** between an original and its counterpart.
 - annotations parse, agree with the manifest split, quote text that actually exists, and use real
   character offsets.
 
@@ -70,23 +79,30 @@ vp run fixtures:validate   # build, then verify everything below
 
 Each category has at least two fixtures:
 
-`installation`, `maintenance`, `troubleshooting`, `safety-warning`, `descriptive`,
-`api-configuration`, `cli-reference`, `structured-content` (tables + lists + code blocks),
-`hard-negative`.
+- `installation`
+- `maintenance`
+- `troubleshooting`
+- `safety-warning`
+- `descriptive`
+- `api-configuration`
+- `cli-reference`
+- `structured-content` (tables + lists + code blocks)
+- `hard-negative`
 
-`hard-negative` fixtures were selected because a naive linter flags them _wrongly_: long sentences
-that are really lists of identifiers, correct passive constructions, dense abbreviation use, SQL
-keywords that look like unintroduced abbreviations. They exist to keep false positives visible, and
-their annotations mostly record `disputed` findings rather than rewrites.
+`hard-negative` fixtures were selected because a naive linter flags them _wrongly_. Examples include
+long sentences that are really lists of identifiers, correct passive constructions, and dense
+abbreviation use. They also include SQL keywords that look like unintroduced abbreviations. These
+fixtures exist to keep false positives visible, and their annotations mostly record `disputed`
+findings rather than rewrites.
 
 ## Splits
 
 `dev` (12 fixtures) is for tuning rules, prompts and thresholds. `heldout` (6) is for reporting
 evaluator quality and must not be tuned against.
 
-The separation is enforced three ways: the validator asserts the splits are disjoint by content hash
-and that `heldout` is ≥ 25% of the corpus; `vp run eval:semantic` defaults to `heldout` and requires
-`--split all` to mix; and a test asserts no `heldout` content hash appears in `dev`.
+The separation is enforced three ways. The validator asserts the splits are disjoint by content
+hash, and that `heldout` is ≥ 25% of the corpus. `vp run eval:semantic` defaults to `heldout`, and
+requires `--split all` to mix. A test also asserts no `heldout` content hash appears in `dev`.
 
 ## Rewriting rules
 
@@ -95,19 +111,24 @@ This is not a style rewrite.
 
 Byte-identical in both versions:
 
-- fenced and inline code, shell commands, literal output;
-- identifiers, API and field names, constants, flags, environment variables;
-- URLs, email addresses, file paths;
-- product, component and part names; version strings;
-- every number, quantity, tolerance, range and unit;
-- placeholders; table structure and cell literals;
+- fenced and inline code, shell commands, literal output.
+- identifiers, API names, and field names.
+- constants, flags, and environment variables.
+- email addresses, file paths, and URLs.
+- product, component and part names.
+- version strings.
+- every number, quantity, tolerance, range and unit.
+- placeholders.
+- table structure and cell literals.
 - the required order of procedural steps.
 
 Preserved in meaning:
 
-- negation; preconditions and conditions; actor responsibility;
+- negation.
+- preconditions and conditions.
+- actor responsibility.
 - modal force — `must` / `shall` / `should` / `can` / `may` / `do not` are never softened or
-  strengthened;
+  strengthened.
 - the distinction between instruction, description, note, caution and warning. A `WARNING` is never
   downgraded to a note, and no hazard statement is removed.
 
@@ -140,129 +161,133 @@ touched.
 ```
 
 `disputed` is a first-class outcome: it records that the linter was **wrong** and the prose was left
-alone. A reviewer is not obliged to satisfy a heuristic, and the tests are built so that refusing does
-not fail the build — a fixture with no accepted change must simply be a `hard-negative` or carry a
-`notes` explanation, and must record something as `disputed` or `deferred`.
+alone. A reviewer is not obliged to satisfy a heuristic. The tests are built so that refusing does
+not fail the build. A fixture with no accepted change must simply be a `hard-negative`, or carry a
+`notes` explanation. It must also record something as `disputed` or `deferred`.
 
 ## How the adjudication was run
 
 The corpus holds two populations of record, produced by different runs over different partitions.
 Conflating them is easy and the distinction matters, so state it first:
 
-| Records                  | Count | Produced by                | Partition              | Provenance in the data   |
-| ------------------------ | ----: | -------------------------- | ---------------------- | ------------------------ |
-| `candidateAdjudications` |   105 | `reviewer-a`…`reviewer-d`  | 5 / 4 / 4 / 4 fixtures | `reviewerKind`, required |
-| `changes`                |    70 | `rewriter-a`, `rewriter-b` | 9 fixtures each        | `reviewerKind`, required |
+| Records                  | Count | Produced by                       | Partition              | Provenance in the data   |
+| ------------------------ | ----: | --------------------------------- | ---------------------- | ------------------------ |
+| `candidateAdjudications` |   105 | `reviewer-a` through `reviewer-d` | 5 / 4 / 4 / 4 fixtures | `reviewerKind`, required |
+| `changes`                |    70 | `rewriter-a`, `rewriter-b`        | 9 fixtures each        | `reviewerKind`, required |
 
-**`candidateAdjudications` — four independent agent reviewers**, one per `fixtures/verdicts/` file,
-each judging a passage against the rule intent in `provisional-rules.md` and nothing else. No human
-produced any of these 105 records. Every one carries `reviewerKind`, so that is answerable from the
-data rather than from this paragraph; the field is required and undefaulted precisely so a record can
-never omit it, and duplicate keys are refused so that the answer a reader gets from the bytes is the
-answer every consumer gets from the parse. `reviewer` (`reviewer-a`…`reviewer-d`) is a label for which run produced a verdict,
-never a person.
+**`candidateAdjudications` comes from four independent agent reviewers**, one per
+`fixtures/verdicts/` file. Each reviewer judges a passage against the rule intent in
+`provisional-rules.md`, and nothing else. No human produced any of these 105 records. Every record
+carries `reviewerKind`. That makes the question answerable from the data itself, not from this
+paragraph. The field is required and undefaulted, so a record can never omit it. Duplicate keys are
+refused too. The answer a reader gets from the bytes is the answer every consumer gets from the
+parse. `reviewer` (one of `reviewer-a` through `reviewer-d`) is a label for which run produced a
+verdict, never a person.
 
 **`changes` — the 70 rewrite records** behind the 32 accepted / 36 disputed / 2 deferred figures in
 `implementation-report.md`. These carry the same required `reviewer` and `reviewerKind` as the
-adjudications. They did not at first, and the gap was not cosmetic: while the only trace of who
-wrote a rewrite was the annotation's `reviewers` array, that array was an assertion no record
-pointed into, so a name could be added to it or removed from it without contradicting anything in
-the file. It is now derived — exactly the set of names the two record populations carry — and
+adjudications. They did not at first, and the gap was not cosmetic. The only trace of who wrote a
+rewrite used to be the annotation's `reviewers` array. That array was an assertion no record pointed
+into. So a name could be added to it, or removed from it, without contradicting anything else in the
+file. It is now derived — exactly the set of names the two record populations carry.
 `merge-candidate-verdicts.mjs` refuses a file where it is anything else.
 
 Be precise about what that buys, because it is less than it sounds. The adjudications are pinned to
-something outside their own file: each one binds to a live candidate passage, so it cannot be
-invented. The rewrite records are not. Editing every `changes[].reviewer` in an annotation _and_ its
-`reviewers` array together is self-consistent, and so is adding a rewrite that never happened or
-deleting four that did — measured, all three pass the merge tool untouched.
+something outside their own file. Each one binds to a live candidate passage, so it cannot be
+invented. The rewrite records are not. Editing every `changes[].reviewer` in an annotation, together
+with its `reviewers` array, is self-consistent. So is adding a rewrite that never happened. So is
+deleting four rewrites that did happen. Measured, all three pass the merge tool untouched.
 
-What refuses them is `scripts/ci/check-annotation-provenance.sh`, and it took three attempts to get
-there, each defeated by the same mistake: a check that constrains an aggregate is defeated by
-whatever rearrangement preserves that aggregate. The totals (105 adjudications, 70 rewrites, the
-per-run split, every record saying `agent`) are preserved by moving credit between two fixtures in
-opposite directions. The per-fixture reviewer sets that closed _that_ hole are themselves preserved
-by shuffling record counts between fixtures crediting the same run — measured, splicing a real
-`disputed` record out of `curl-url-option-reference` and dropping in a second copy of that file's own
-`accepted` record passed every gate in the project and moved the split reported above from 32 / 36 to
-33 / 35.
+What refuses them is `scripts/ci/check-annotation-provenance.sh`. It took three attempts to get
+there, each defeated by the same mistake. A check that constrains an aggregate is defeated by
+whatever rearrangement preserves that aggregate. The totals are preserved by moving credit between
+two fixtures in opposite directions. Those totals are: 105 adjudications, 70 rewrites, the per-run
+split, and every record saying `agent`. The per-fixture reviewer sets closed _that_ hole. But those
+sets are preserved too, by shuffling record counts between fixtures that credit the same run. This
+was measured directly. Splicing a real `disputed` record out of `curl-url-option-reference` passed
+every gate in the project. So did dropping in a second copy of that file's own `accepted` record.
+That swap also moved the split reported above from 32 / 36 to 33 / 35.
 
-So the script also declares a digest of each fixture's annotation: object keys sorted, so
-reformatting is not a change, array order preserved, so reordering is. That pins content rather than
-counts, which is the only thing left when a record binds to nothing outside its own file.
+So the script also declares a digest of each fixture's annotation. Object keys are sorted, so
+reformatting is not a change. Array order is preserved, so reordering is a change. That pins content
+rather than counts. Content is the only thing left to pin when a record binds to nothing outside its
+own file.
 
-The digest covers the whole annotation rather than only its `changes`, and the reason is worth
-recording because the narrower version looked obviously sufficient. An adjudication binds to a live
-candidate passage, so it seemed anchored — but the binding constrains _where a record sits_, not
-_what it says_. `verdict`, `reason` and `reviewerConfidence` are copied from the reviewer row and
-checked against nothing, and the only things constraining them were two aggregates in
-`corpus.test.ts` — since replaced by a record-by-record comparison against `fixtures/verdicts/`.
-Measured: demoting the corpus's two confirmed `passive-voice-candidate` defects
-while promoting two other passages of the same rule preserved both aggregates, passed every gate,
-and quietly changed which passages the semantic evaluators are scored against.
+The digest covers the whole annotation rather than only its `changes`. The reason is worth
+recording, because the narrower version seemed like enough. An adjudication binds to a live candidate
+passage, so it seemed anchored. But the binding constrains _where a record sits_, not _what it says_.
+`verdict`, `reason`, and `reviewerConfidence` are copied from the reviewer row and checked against
+nothing. The only things constraining them were two aggregates in `corpus.test.ts`, since replaced by
+a record-by-record comparison against `fixtures/verdicts/`. Measured: demoting the corpus's two
+confirmed `passive-voice-candidate` defects preserved both aggregates. So did promoting two other
+passages of the same rule instead. It passed every gate. It also quietly changed which passages the
+semantic evaluators are scored against.
 
 Two smaller things follow from hashing parsed values rather than bytes. Duplicate JSON keys make the
-file on disk and the value every check sees disagree — `JSON.parse` keeps the last and says nothing —
-so every JSON file under `fixtures/` is read through `scripts/lib/parse-json-strict.mjs`, which
-refuses them. That scan covers the whole tree rather than the annotations alone, and the reason is
-worth recording: a revision that guarded only the annotations argued the rest was defence in depth,
-and a review disproved it by moving the identical forgery one directory over. `fixtures/verdicts/` is
-what the adjudications are _derived from_, so a duplicated `reviewer` pair there flows the last value
-into every record while the committed annotation and its digest stay byte-identical — the file reads
-as human-audited and `agent=175` still matches. The same trick on `manifest.json` makes the manifest
-document a share-alike licence while the validator reads the permissive duplicate, walking through
-the gate that exists to refuse copyleft.
+file on disk and the value every check sees disagree. `JSON.parse` keeps the last key and says
+nothing about the conflict. So every JSON file under `fixtures/` is read through
+`scripts/lib/parse-json-strict.mjs`, which refuses them. That scan covers the whole tree, not just
+the annotations. The reason is worth recording. An earlier revision guarded only the annotations,
+arguing the rest was defence in depth. A review disproved that: it moved the identical forgery one
+directory over. `fixtures/verdicts/` is what the adjudications are _derived from_. So a duplicated
+`reviewer` pair there flows the last value into every record. The committed annotation and its digest
+stay byte-identical while that happens. The file still reads as human-audited, and `agent=175` still
+matches. The same trick works on `manifest.json`. It makes the manifest document a share-alike
+licence, while the validator reads the permissive duplicate. That walks straight through the gate
+that exists to refuse copyleft.
 
-Bytes are not hashed directly, which would also catch that, because the repository sets no
-`.gitattributes` and a CRLF checkout would then fail for everyone on Windows.
+Bytes are not hashed directly, even though that would also catch the problem. The repository sets no
+`.gitattributes`, so a CRLF checkout would then fail for everyone on Windows.
 
-All of these numbers and digests are expected to change when the corpus does; the point is that
-changing them is an edit somebody makes on purpose, in the same commit as the edit that caused it.
-The gate itself is covered by `test/e2e/check-annotation-provenance.test.ts`, which exists because
-a review deleted each of its checks in turn and the project stayed green every time.
+All of these numbers and digests are expected to change when the corpus does. The point is that
+changing them is a deliberate edit. It happens in the same commit as the edit that caused it. The
+gate itself is covered by `test/e2e/check-annotation-provenance.test.ts`. That test exists because a
+review once deleted each of its checks in turn. Even then, the project stayed green every time.
 
 One more limit, since the field name invites the wrong reading. `reviewer` names the run that
-produced an annotation's rewrites, not the author of the text as it stands: 11 of the 70 records
-have had their content edited since, by later reconciliation commits that recorded nothing about
-themselves.
+produced an annotation's rewrites. It does not name the author of the text as it stands today. 11 of
+the 70 records have had their content edited since. Later reconciliation commits made those edits,
+and those commits recorded nothing about themselves.
 
 What the adjudication method establishes, and what it does not:
 
-- **Each passage was judged exactly once.** The four reviewers' fixture sets are pairwise disjoint —
-  measured: zero fixtures shared between any pair — and `merge-candidate-verdicts.mjs` rejects a
+- **Each passage was judged exactly once**. The four reviewers' fixture sets are pairwise disjoint.
+  Measured, zero fixtures were shared between any pair. `merge-candidate-verdicts.mjs` also rejects a
   second verdict on the same `(ruleId, span)` as a duplicate. So there is no cross-check to appeal
-  to: no passage was independently confirmed, and `goldLabelFor`'s disagreement path
+  to. No passage was independently confirmed, and `goldLabelFor`'s disagreement path
   (`labels.size !== 1 → unlabelled`) never fires on this corpus. Agreement between reviewers is not
-  weak evidence here; it is absent, because no two reviewers looked at the same thing.
-- **The binding is enforced even though the judgement is not corroborated.** The merge tool binds
-  each verdict to a `(ruleId, span, quote)` triple, and a verdict that does not bind to a live
-  passage fails the build.
-- **The labels are model-authored ground truth for a model-based evaluator.** The semantic evaluators
-  are scored against these records, so a favourable score is partly a measure of agreement between
-  two applications of similar judgement, not an external check.
-- **The reference documents were not written as controlled language.** A "false positive" here means
-  a finding a reviewer judged wrong against the rule's stated intent — not a finding that contradicts
-  any standard. The corpus can therefore say a good deal about precision and very little about recall.
+  weak evidence here. It is absent, because no two reviewers looked at the same thing.
+- **The binding is enforced even though the judgement is not corroborated**. The merge tool binds
+  each verdict to a `(ruleId, span, quote)` triple. A verdict that does not bind to a live passage
+  fails the build.
+- **The labels are model-authored ground truth for a model-based evaluator**. The semantic evaluators
+  are scored against these records. A favourable score is therefore partly a measure of agreement
+  between two similar applications of judgement. It is not an external check.
+- **The reference documents were not written as controlled language**. A "false positive" here means
+  a finding a reviewer judged wrong against the rule's stated intent. It does not mean a finding that
+  contradicts any external standard. The corpus can therefore say a good deal about precision and
+  very little about recall.
 
 Treat the resulting figures as the project's own measurement of its own heuristics. They are reported
-because a rule set with no measurement at all is worse, not because they are independent evidence.
+because a rule set with no measurement at all is worse. They are not reported because they are
+independent evidence.
 
 ## What the records are bound to, and what would break the binding
 
 `originalSpans`, and the `candidateAdjudications` merged in from `fixtures/verdicts/` (see
 [`provisional-rules.md`](./provisional-rules.md#measured-precision-of-the-candidate-heuristics)),
-both bind a verdict to a specific `(ruleId, span, quote)`, on the assumption that spans are derived
-the way they are today, by the regex-based scanner.
-[Issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25) proposes deriving spans
-from a real parser instead; if that change moves a span, the verdict recorded against the old span
-no longer describes the new one and needs fresh review.
-`scripts/ci/check-candidate-ground-truth.sh` already enforces this for candidate verdicts; a parser
+both bind a verdict to a specific `(ruleId, span, quote)`. That binding assumes spans are derived the
+way they are today, by the regex-based scanner. [Issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25)
+proposes deriving spans from a real parser instead. If that change moves a span, the verdict recorded
+against the old span no longer describes the new one. It then needs fresh review.
+`scripts/ci/check-candidate-ground-truth.sh` already enforces this for candidate verdicts. A parser
 adoption would need the same discipline applied to `originalSpans`.
 
-That check runs `scripts/merge-candidate-verdicts.mjs --check`, which does two things: it refuses a
-verdict that binds to no live passage, and it compares every record the verdicts produce against
+That check runs `scripts/merge-candidate-verdicts.mjs --check`, which does two things. It refuses a
+verdict that binds to no live passage. It also compares every record the verdicts produce against
 what is committed in `fixtures/annotations/`. The second half is what makes the annotation files
-themselves checked rather than merely generated — an adjudication edited by hand there, or left
-behind after its candidate moved, fails the build instead of sitting in the corpus unnoticed. To
+themselves checked, rather than merely generated. An adjudication edited by hand there fails the
+build. So does one left behind after its candidate moved. Neither sits in the corpus unnoticed. To
 regenerate rather than check, run the same script without `--check` and review the diff.
 
 ## Corpus tests
@@ -285,12 +310,14 @@ regenerate rather than check, run the same script without `--check` and review t
 
 ## Adding a fixture
 
-1. Add the source to `scripts/fetch-sources.mjs` and run `vp run fixtures:fetch`. Never hand-write a
-   provenance record.
-2. Verify the licence by fetching the licence page or the repository `LICENSE` file, and quote it
-   verbatim in the manifest and in `LICENSES.md`.
-3. Cut a verbatim excerpt of 300–2400 characters into `fixtures/original/<id>.md` with the header
+Never hand-write a provenance record: `scripts/fetch-sources.mjs` writes it for you.
+
+1. Add the source to `scripts/fetch-sources.mjs`.
+2. Run `vp run fixtures:fetch` to download it.
+3. Verify the licence using the licence page or the repository `LICENSE` file.
+4. Quote the licence verbatim in the manifest and in `LICENSES.md`.
+5. Cut a verbatim excerpt of `300–2400` characters into `fixtures/original/<id>.md`, using the header
    comment the other fixtures use.
-4. Add the manifest entry, including the SHA-256 of the file as committed.
-5. Write the counterpart and the annotation.
-6. `vp run fixtures:validate && vp test test/fixtures`.
+6. Add the manifest entry, including the file's committed `SHA-256`.
+7. Write the counterpart and the annotation.
+8. Run `vp run fixtures:validate && vp test test/fixtures`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -24,6 +24,8 @@ Observed by `git log`, `git status`, and a full file listing at `HEAD` (`1379788
 
 `https://asd-ste100.org/` states verbatim:
 
+<!-- ste-ai-ignore-next-line punctuation-constraints -- verbatim quotation, not our prose -->
+
 > Simplified Technical English, ASD-STE100, is a Copyright and a Trademark of ASD, Brussels,
 > Belgium. All rights reserved. European Union Trade Mark No. 017966390.
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -6,19 +6,19 @@ Status: executing. This document is an implementation aid, not the deliverable.
 
 Observed by `git log`, `git status`, and a full file listing at `HEAD` (`1379788 Initial commit`):
 
-| Question                                           | Finding                                                                                                  | Evidence                                          |
-| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| Existing code?                                     | No. Repo contains `README.md` (17 bytes), `LICENSE`, `.gitignore` only.                                  | `find . -type f` → 3 files                        |
-| Language / package manager                         | None established. `.gitignore` is the standard Node/npm template (mentions npm, yarn, pnpm, bun caches). | `.gitignore` contents                             |
-| TypeScript config                                  | Absent.                                                                                                  | no `tsconfig*.json`                               |
-| Test framework                                     | Absent.                                                                                                  | no test config                                    |
-| Lint/format conventions                            | Absent.                                                                                                  | no eslint/prettier config                         |
-| CI                                                 | Absent.                                                                                                  | no `.github/`                                     |
-| Architectural rules (CLAUDE.md / AGENTS.md / ADRs) | Absent.                                                                                                  | no such files                                     |
-| Authorised ASD-STE100 source or dictionary         | **Absent.**                                                                                              | see below                                         |
-| llama.cpp client / model client                    | Absent.                                                                                                  | no source files                                   |
-| Repo licence                                       | MIT, © 2026 Jamie Nelson                                                                                 | `LICENSE`                                         |
-| Toolchain available                                | Node v22.22.2, npm 10.9.7, pnpm, yarn, bun; npm registry reachable                                       | `node --version`, `curl registry.npmjs.org` → 200 |
+| Question                                   | Finding                                                                                                             | Evidence                                          |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Existing code?                             | No. Repo contains `README.md` (17 bytes), `LICENSE`, `.gitignore` only.                                             | `find . -type f` → 3 files                        |
+| Language and package manager               | None established. `.gitignore` is the standard Node.js and npm template (mentions npm, yarn, pnpm, and bun caches). | `.gitignore` contents                             |
+| TypeScript config                          | Absent.                                                                                                             | no `tsconfig*.json`                               |
+| Test framework                             | Absent.                                                                                                             | no test config                                    |
+| Lint and format conventions                | Absent.                                                                                                             | no ESLint or Prettier config                      |
+| Continuous integration (CI)                | Absent.                                                                                                             | no `.github/`                                     |
+| Architectural rules                        | Absent. No CLAUDE.md, AGENTS.md, or architecture decision records (ADRs) exist.                                     | no such files                                     |
+| Authorised ASD-STE100 source or dictionary | **Absent.**                                                                                                         | see below                                         |
+| llama.cpp client or model client           | Absent.                                                                                                             | no source files                                   |
+| Repo licence                               | MIT, © 2026 Jamie Nelson                                                                                            | `LICENSE`                                         |
+| Toolchain available                        | Node.js and npm are present, alongside pnpm, yarn, and bun. The npm registry is reachable.                          | `node --version`, `curl registry.npmjs.org` → 200 |
 
 ### Source-authority determination
 
@@ -27,31 +27,31 @@ Observed by `git log`, `git status`, and a full file listing at `HEAD` (`1379788
 > Simplified Technical English, ASD-STE100, is a Copyright and a Trademark of ASD, Brussels,
 > Belgium. All rights reserved. European Union Trade Mark No. 017966390.
 
-Retrieved 2026-07-26. No open licence, redistribution grant, or machine-readable rule pack is
-offered. Therefore:
+Retrieved 26 July 2026. The site offers no open licence, redistribution grant, or
+machine-readable rule pack. Therefore:
 
-- **No normative ASD-STE100 material is available to this repository.**
+- **No normative ASD-STE100 material is available to this repository**.
 - Writing Rules and the Dictionary are **not** reconstructed from memory or secondary summaries.
 - Every shipped rule is classified `provisional` and carries that status in its metadata,
   in diagnostics, and in the docs.
-- A **rule-pack import boundary** (`src/core/rule-pack/`) is the single supported route by
-  which an authorised, licensed pack can later supply normative rule data and a controlled
-  dictionary. Nothing else in the codebase hard-codes vocabulary.
+- A **rule-pack import boundary** (`src/core/rule-pack/`) is the single supported route for new
+  rule data. Through it, an authorised, licensed pack can later supply normative rules and a
+  controlled dictionary. Nothing else in the codebase hard-codes vocabulary.
 
 Consequence for claims: the project must never assert ASD-STE100 conformance or certification.
 See `docs/DISCLAIMER.md`.
 
 ## Chosen conventions (decisions)
 
-| Decision          | Choice                                                            | Rationale                                                                                                                                                                                                                   |
-| ----------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Language          | TypeScript, `strict` + `noUncheckedIndexedAccess`, ESM, NodeNext  | Spec default; nothing in repo says otherwise                                                                                                                                                                                |
-| Package manager   | npm (lockfile committed)                                          | `.gitignore` is npm-flavoured; npm is present                                                                                                                                                                               |
-| Layout            | **Single package**, enforced internal module boundaries           | Repo has no monorepo justification. Boundary direction is enforced by an automated test (`test/architecture/module-boundaries.test.ts`) rather than by package.json topology — this is verifiable, not merely conventional. |
-| Test runner       | Vitest 4                                                          | native ESM + TS, fast, snapshot support                                                                                                                                                                                     |
-| Rule validation   | `textlint-tester` for the textlint adapter; Vitest for core       | textlint's own harness is the contract test for adapter behaviour                                                                                                                                                           |
-| Schema validation | Zod 4                                                             | model-response and rule-pack validation with typed output                                                                                                                                                                   |
-| Segmentation      | `sentence-splitter` (textlint org) + own protected-region masking | reuse ecosystem tooling; masking keeps offsets exact                                                                                                                                                                        |
+| Decision          | Choice                                                                                | Rationale                                                                                                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Language          | TypeScript, `strict` + `noUncheckedIndexedAccess`, ECMAScript modules (ESM), NodeNext | This is the specification's default. Nothing in the repository says otherwise.                                                                                                                              |
+| Package manager   | npm (lockfile committed)                                                              | npm is present. `.gitignore` is npm-flavoured.                                                                                                                                                              |
+| Layout            | **Single package**, enforced internal module boundaries                               | Repo has no monorepo justification. An automated test (`test/architecture/module-boundaries.test.ts`) enforces boundary direction, not package.json topology — this is verifiable, not merely conventional. |
+| Test runner       | Vitest 4                                                                              | native ESM and TypeScript support, with fast snapshots                                                                                                                                                      |
+| Rule validation   | `textlint-tester` for the textlint adapter. Vitest for core.                          | textlint's own harness is the contract test for adapter behaviour                                                                                                                                           |
+| Schema validation | Zod 4                                                                                 | model-response and rule-pack validation with typed output                                                                                                                                                   |
+| Segmentation      | `sentence-splitter` (textlint org) + own protected-region masking                     | Reuse ecosystem tooling. Masking keeps offsets exact.                                                                                                                                                       |
 
 ### Module boundary rules (enforced by test)
 
@@ -70,28 +70,27 @@ not import `deterministic/rules/*` internals and that `model-client` never impor
 
 ## Work breakdown
 
-1. Scaffolding: package.json, tsconfig, vitest, eslint, prettier, CI. ✔
-2. `core`: domain types, source document + offset map, protected-region extractor, segmenter,
-   diagnostics, fix planner, rule registry. ✔
-3. `rule-pack`: Zod schema, loader, provisional non-proprietary pack. ✔
-4. `deterministic`: 14 rules, each with id, status, config schema, exact ranges, tests. ✔
-5. `textlint`: adapter (node ↔ core), preset, per-rule modules. ✔
-6. `model-client`: llama.cpp-compatible transport, content-hash cache, timeout/cancel, retry
-   policy for transport-only failures. ✔
-7. `semantic`: broker (concurrency, ordering, batching, tracing), 8 evaluators, versioned
-   prompt assets, response schema. ✔
-8. Fixtures: fetch script with provenance capture, 18 originals, manifest. ✔
-9. Adjudication: compliant counterparts + annotation records + corpus-integrity tests. ✔
-10. Tests: unit, offsets, protected regions, contract, malformed response, timeout,
-    cancellation, cache, fake-server integration, fixture expectations, e2e textlint. ✔
-11. Eval tooling: confusion matrix, precision/recall/F1, uncertain rate, latency percentiles;
-    train/dev/heldout split enforcement. ✔
-12. Docs: architecture, rule authoring, semantic evaluators, rule-pack import, llama.cpp setup,
-    diagnostic + autofix policy, disclaimer, implementation report. ✔
-13. Fresh-context verifier subagent, then defect correction and gate re-run. ✔
+Each phase below is complete (✔). The scope column lists that phase's delivered components.
+
+| Phase           | Scope                                                                                                                                                                                | Status |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| Scaffolding     | `package.json`<br>TypeScript config<br>Vitest config<br>ESLint and Prettier config<br>CI                                                                                             | ✔      |
+| `core`          | Domain types<br>Source document and offset map<br>Protected-region extractor<br>Segmenter<br>Diagnostics<br>Fix planner<br>Rule registry                                             | ✔      |
+| `rule-pack`     | Zod schema<br>Loader<br>Provisional non-proprietary pack                                                                                                                             | ✔      |
+| `deterministic` | 14 rules<br>Each rule carries an id and a status<br>Each rule carries a config schema, exact ranges, and tests                                                                       | ✔      |
+| `textlint`      | Adapter (node and core)<br>Preset<br>Per-rule modules                                                                                                                                | ✔      |
+| `model-client`  | llama.cpp-compatible transport<br>Content-hash cache<br>Timeout and cancellation<br>Retry policy for transport-only failures                                                         | ✔      |
+| `semantic`      | Broker: concurrency, ordering, batching, and tracing<br>8 evaluators<br>Versioned prompt assets<br>Response schema                                                                   | ✔      |
+| Fixtures        | Fetch script with provenance capture<br>18 originals<br>Manifest                                                                                                                     | ✔      |
+| Adjudication    | Compliant counterparts<br>Annotation records<br>Corpus-integrity tests                                                                                                               | ✔      |
+| Tests           | Unit<br>Offsets<br>Protected regions<br>Contract<br>Malformed response<br>Timeout<br>Cancellation<br>Cache<br>Fake-server integration<br>Fixture expectations<br>End-to-end textlint | ✔      |
+| Eval tooling    | Confusion matrix<br>Precision<br>Recall<br>F1<br>Uncertain rate<br>Latency percentiles<br>Train, dev, and heldout split enforcement                                                  | ✔      |
+| Docs            | Architecture<br>Rule authoring<br>Semantic evaluators<br>Rule-pack import<br>llama.cpp setup<br>Diagnostic and autofix policy<br>Disclaimer<br>Implementation report                 | ✔      |
+| Verification    | Fresh-context verifier subagent<br>Defect correction<br>Gate re-run                                                                                                                  | ✔      |
 
 ## Non-goals
 
 - No ASD-STE100 dictionary reconstruction.
 - No conformance claim.
-- No autofix for safety-sensitive, negated, ordered, quantitative, or identifier content.
+- No autofix applies to safety-sensitive or negated content. None applies to ordered,
+  quantitative, or identifier content either.

--- a/docs/llama-cpp-setup.md
+++ b/docs/llama-cpp-setup.md
@@ -1,7 +1,7 @@
 # Running a local llama.cpp server
 
 The semantic subsystem is optional. Everything below is only needed if you want semantic
-adjudication; the deterministic rules never contact a service.
+adjudication. The deterministic rules never contact a service.
 
 ## What the client expects
 
@@ -11,13 +11,20 @@ A single HTTP route:
 POST <endpoint>/v1/chat/completions
 ```
 
-with an OpenAI-shaped body (`model`, `messages`, `temperature`, `max_tokens`, `stream: false`, and
-`response_format: { type: "json_schema", json_schema: { … } }`), returning
-`choices[0].message.content` as a string.
+The request body is OpenAI-shaped. It carries these fields:
+
+- `model`
+- `messages`
+- `temperature`
+- `max_tokens`
+- `stream: false`
+- `response_format: { type: "json_schema", json_schema: { … } }`
+
+The response returns `choices[0].message.content` as a string.
 
 `llama-server` from llama.cpp provides this. So does any OpenAI-compatible server, which is why the
 endpoint is configuration rather than a hard-coded assumption. The client is
-`src/model-client/llama-client.ts`; it is injectable, so tests never need a real server.
+`src/model-client/llama-client.ts`. It is injectable, so tests never need a real server.
 
 ## Build and run
 
@@ -55,16 +62,17 @@ curl -s http://127.0.0.1:8080/v1/chat/completions \
 The evaluators are narrow classification tasks that must emit one small JSON object. That is a modest
 requirement, and a small instruction-tuned model is usually adequate. What matters:
 
-- **it must follow a JSON schema.** llama.cpp converts `response_format: json_schema` into a GBNF
-  grammar, which makes malformed JSON nearly impossible. Every response is still validated —
-  grammar-constrained decoding is a convenience, not a trust boundary.
-- **`--ctx-size` must fit the prompt.** The largest prompt is `rewrite-equivalence`, which carries
-  the original text, the rewrite, and the protected-literal list. 4096 tokens is comfortable for
+- **it must follow a JSON schema.** llama.cpp converts `response_format: json_schema` into a
+  grammar. The grammar uses Backus-Naur Form (GBNF), llama.cpp's own grammar syntax. This
+  constraint makes malformed JSON nearly impossible. Every response is still validated — grammar-constrained
+  decoding is a convenience, not a trust boundary.
+- **`--ctx-size` must fit the prompt.** The largest prompt is `rewrite-equivalence`. It carries the
+  original text, the rewrite, and the protected-literal list. 4096 tokens is comfortable for
   sentence-level passages.
-- **temperature 0.** The broker sends `temperature: 0` and caches on a content hash, so repeated runs
-  over unchanged text are reproducible. A non-zero temperature defeats both.
-- **`--parallel` should be at least `semantic.maxConcurrency`**, otherwise requests queue and the
-  latency percentiles in the evaluation report measure your queue rather than the model.
+- **temperature 0.** The broker sends `temperature: 0`. It also caches results by content hash, so
+  repeated runs over unchanged text produce the same result. A non-zero temperature defeats both.
+- **`--parallel` should be at least `semantic.maxConcurrency`.** Otherwise, requests queue. The
+  latency percentiles in the evaluation report then measure your queue, not the model.
 
 ## Point the linter at it
 
@@ -89,8 +97,16 @@ Then:
 npx ste-ai lint docs/install.md --semantic --trace
 ```
 
-`--trace` writes one JSON line per request to stderr with the prompt version, model id, content hash,
-attempt count, cache-hit flag and latency. That is the audit trail for a semantic finding.
+`--trace` writes one JSON line per request to stderr. Each line includes:
+
+- the prompt version
+- the model id
+- a content hash
+- the try count
+- a cache-hit flag
+- the latency
+
+These fields form the audit trail for a semantic finding.
 
 ## Measuring it
 
@@ -106,9 +122,15 @@ vp run eval:semantic -- --split dev --endpoint http://127.0.0.1:8080 --model my-
 vp run eval:semantic -- --split heldout --out eval-heldout.json
 ```
 
-Output includes TP / FP / TN / FN, precision, recall, F1, uncertain rate, failure rate and p50/p90/p99
-latency, per evaluator and overall. Ground truth comes from the fixture adjudication records, and
-unadjudicated candidates are excluded and counted separately rather than guessed at. See
+The report lists these metrics, per evaluator and overall:
+
+- true positives (TP), false positives (FP), true negatives (TN), and false negatives (FN)
+- precision, recall, and F1
+- uncertain rate and failure rate
+- p50, p90, and p99 latency
+
+Ground truth comes from the fixture adjudication records. Unadjudicated candidates are excluded and
+counted separately, rather than guessed at. See
 [`semantic-evaluators.md`](./semantic-evaluators.md#measurement).
 
 **Split discipline:** `dev` is for tuning, `heldout` is for reporting. `--split heldout` is the
@@ -118,23 +140,30 @@ default and mixing requires `--split all` explicitly.
 
 Nothing breaks and nothing is silently passed. Per `diagnostics.onSemanticServiceFailure`:
 
-- `notice` (default) — a run notice at `warning` level, plus `review-required` for each undecided
-  passage;
-- `error` — the same notice at `error` level, so the run fails; the CLI exits 3;
-- `silent` — no diagnostics, notice still recorded for a programmatic caller to inspect.
+- `notice` (default) — a run notice at `warning` level, plus `review-required` for each undecided passage.
+- `error` — the same notice at `error` level. The run fails, and the CLI exits with code 3.
+- `silent` — no diagnostics. The notice is still recorded, for a programmatic caller to inspect.
 
-Deterministic diagnostics are unaffected — there is a test asserting that an outage leaves the
+Deterministic diagnostics are unaffected. A test checks this directly: an outage leaves the
 deterministic finding set byte-identical to an offline run.
 
 ## Security notes
 
-- Bind to `127.0.0.1`. The client sends document text to the endpoint; do not expose it.
-- Protected content is masked out of the passages sent to evaluators, so code, credentials in
-  configuration fragments, URLs, paths and identifiers are not transmitted. Where an evaluator needs to
-  know that a protected token is present — the candidate-antecedent list, for instance — it receives a
-  placeholder naming the kind (`«file-path»`) rather than the literal. `test/integration/redaction.test.ts`
-  captures the actual HTTP request bodies and asserts that a set of planted secrets, tokens, paths and
-  hostnames appears in none of them. Still verify it for your own corpus with `--trace` before pointing
-  the linter at anything sensitive.
+- Bind to `127.0.0.1`. The client sends document text to the endpoint. Do not expose it.
+- Protected content is masked out of the passages sent to evaluators. None of the following reach
+  the request.
+  - Code
+  - Credentials in configuration fragments
+  - URLs
+  - Paths
+  - Identifiers
+
+  Some evaluators still need to know that a protected token is present — the candidate-antecedent
+  list, for instance. In that case, the evaluator gets a placeholder naming the kind (`«file-path»`)
+  instead of the literal value. `test/integration/redaction.test.ts` captures the actual HTTP
+  request bodies. It asserts that a set of planted secrets, tokens, paths, and hostnames never
+  appears in them. Still verify this for your own corpus with `--trace`, before pointing the linter
+  at anything sensitive.
+
 - `semantic.apiKey` is sent as a bearer token if set. Supply it via the environment, not the
   committed config file.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,31 +1,40 @@
 # Publishing to npm
 
-Publishing uses two workflows. A push to `main` runs `.github/workflows/release-tag.yml`, where
-semantic-release evaluates the Conventional Commit history, updates `package.json` and
-`package-lock.json`, commits those versions, and creates the next `v`-prefixed tag on that release
-commit. That tag starts `.github/workflows/publish.yml`, which verifies that the checked-out package
-version matches the tag, creates a GitHub release with generated notes, builds the package with Vite+
-Pack, and publishes the contents selected by `package.json`. The npm publish uses trusted publishing
-(OIDC), so it does not need a long-lived `NPM_TOKEN` secret.
+Publishing uses two workflows. A push to `main` runs `.github/workflows/release-tag.yml`. This
+workflow runs semantic-release over the Conventional Commit history. The workflow updates
+`package.json` and `package-lock.json`, then commits those version changes. The workflow then
+creates the next `v`-prefixed tag on that release commit.
+
+That tag starts `.github/workflows/publish.yml`. This second workflow verifies that the checked-out
+package version matches the tag. The workflow creates a GitHub release with generated notes and
+builds the package with Vite+ Pack. The workflow then publishes the contents selected by
+`package.json`.
+
+The npm publish uses trusted publishing (OIDC). Trusted publishing does not need a long-lived
+`NPM_TOKEN` secret.
 
 ## One-time npm setup
 
-The package does not exist on npm yet. A maintainer must bootstrap it once before npm can attach a
-trusted publisher:
+The package does not exist on npm yet. A maintainer must bootstrap the package once before npm can
+attach a trusted publisher:
 
 1. Sign in to npm with an account that owns the package name and has two-factor authentication
    enabled.
-2. From a clean checkout of the commit to release, run `vp install --frozen-lockfile`, `vp check`,
-   `vp test`, and `vp pack`.
-3. Confirm the tarball with `npm pack --dry-run`, then run `npm publish --access public`. This is the
-   only publish that needs interactive npm authentication. Provenance starts with the subsequent
-   CI publishes because the local bootstrap does not have GitHub's OIDC identity.
-4. On npmjs.com, open **Packages → textlint-rule-preset-ste-ai → Settings → Trusted Publisher** and
+2. Start from a clean checkout of the commit to release.
+3. Run `vp install --frozen-lockfile`, then `vp check`, then `vp test`, then `vp pack`.
+4. Confirm the tarball with `npm pack --dry-run`.
+5. Run `npm publish --access public`.
+6. This manual step is the only publish that requires you to log in to npm interactively.
+7. The local bootstrap does not have GitHub's OIDC identity.
+8. Provenance therefore starts with the subsequent Continuous Integration (CI) publishes.
+9. On npmjs.com, open **Packages → textlint-rule-preset-ste-ai → Settings → Trusted Publisher** and
    select **GitHub Actions**.
-5. Enter organization or user `Jamie-BitFlight`, repository `textlint-rule-preset-ste-ai`, workflow
-   filename `publish.yml`, and environment `npm`. Allow the **npm publish** action.
-6. After verifying trusted publishing, set publishing access to **Require two-factor authentication
-   and disallow tokens**. The workflow uses short-lived OIDC credentials and does not need a token.
+10. Enter organization or user `Jamie-BitFlight`, repository `textlint-rule-preset-ste-ai`, workflow
+    filename `publish.yml`, and environment `npm`.
+11. Allow the **npm publish** action.
+12. After verifying trusted publishing, set publishing access to **Require two-factor authentication
+    and disallow tokens**.
+13. The workflow uses short-lived OIDC credentials and does not need a token.
 
 ## One-time GitHub setup
 
@@ -33,30 +42,37 @@ Create a GitHub environment named `npm` under **Settings → Environments**. Add
 other deployment protection rules if releases should require explicit approval. Do not add an npm
 token secret.
 
-Create a GitHub App that can write repository contents, install it on this repository, and allow the
-App to bypass the `main` branch rule for semantic-release's version commit. Configure these Actions
-values:
+Create a GitHub App that can write repository contents. Install the App on this repository. Allow
+the App to bypass the `main` branch rule for semantic-release's version commit. Configure these
+Actions values:
 
 - Repository variable `RELEASE_APP_ID`: the App ID.
 - Repository secret `RELEASE_APP_PRIVATE_KEY`: a private key generated for the App.
 
 The App token is necessary because GitHub suppresses new workflow runs for tags created with a
-workflow's built-in `GITHUB_TOKEN`. The App-created semantic-release tag is allowed to trigger the
-separate publish workflow. The tag workflow ignores semantic-release's own `chore(release)` commit,
-which prevents the version commit from starting another release calculation without suppressing the
-tag-triggered publish workflow.
+workflow's built-in `GITHUB_TOKEN`. The App-created semantic-release tag can trigger the separate
+publish workflow. The tag workflow ignores semantic-release's own `chore(release)` commit. This
+exclusion stops the version commit from starting another release calculation. The tag-triggered
+publish workflow still runs. That workflow triggers off the tag, not off the commit.
 
 ## Publishing a version
 
-1. Merge Conventional Commits to `main`: `fix:` creates a patch, `feat:` creates a minor, and a
-   breaking change creates a major release. Commits without a release-bearing type do not create a
-   tag.
-2. Confirm **Create semantic release tag** created a `chore(release)` commit with updated package and
-   lockfile versions, then tagged that exact commit.
-3. The tag automatically starts **Publish package**, which confirms `package.json` already matches
-   the tag, runs the checks and tests, creates the GitHub release notes, and publishes to npm.
-4. Approve the `npm` environment deployment if GitHub requests it.
-5. Confirm the workflow completed and verify the version and provenance badge on npmjs.com.
+1. Merge Conventional Commits to `main`.
+2. A `fix:` commit creates a patch release.
+3. A `feat:` commit creates a minor release.
+4. A breaking change creates a major release.
+5. Commits without a release-bearing type do not create a tag.
+6. Confirm **Create semantic release tag** created a `chore(release)` commit with the updated
+   versions.
+7. Confirm **Create semantic release tag** tagged that exact commit.
+8. The tag automatically starts **Publish package**.
+9. **Publish package** confirms that `package.json` already matches the tag.
+10. **Publish package** runs the checks and tests.
+11. **Publish package** creates the GitHub release notes.
+12. **Publish package** publishes the package to npm.
+13. Approve the `npm` environment deployment if GitHub requests approval.
+14. Confirm the workflow completed.
+15. Verify the version and provenance badge on npmjs.com.
 
-npm rejects publishing a version that already exists. If a workflow must be retried after npm
-accepted the package, publish a new version rather than rerunning the same release.
+npm rejects publishing a version that already exists. If npm already accepted the package, retry
+with a new version. Do not rerun the same release.

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -1,17 +1,16 @@
 # Importing an authorised rule pack
 
-This is the **only** supported route by which normative controlled-language data enters the package.
-No rule hard-codes vocabulary: every word list, term mapping and numeric limit is read from the
-active pack, so supplying licensed data changes behaviour without changing a line of rule code.
+This page describes the only supported route by which normative controlled-language data enters the package.
+No rule hard-codes vocabulary. The active pack supplies every word list, term mapping, and numeric limit.
+Supplying licensed data therefore changes behaviour without changing a line of rule code.
 
 ## Before you start
 
-Supplying a pack is a licensing decision. This project makes no determination about what you are
-permitted to include, and adds no conformance wording of its own. See
-[`DISCLAIMER.md`](./DISCLAIMER.md).
+Supplying a pack is a licensing decision. This project makes no determination about what you may
+include. It adds no conformance wording of its own. See [`DISCLAIMER.md`](./DISCLAIMER.md).
 
-Do not commit a proprietary pack to a public repository. Keep it outside the tree and point at it,
-or hold it in a private artefact store.
+Do not commit a proprietary pack to a public repository. Keep it outside the tree. Point the
+configuration at it. Alternatively, store it in a private artefact repository.
 
 ## The schema
 
@@ -135,22 +134,29 @@ programmatic API.
 | `packPermitsConformanceClaim()`  | `false`                                   | `true` if `conformanceClaim !== 'none'` |
 | Vocabulary, limits, contractions | small authored set                        | yours                                   |
 
-Rule _code_ does not change. Rules whose trigger cannot be expressed in the pack schema stay
-provisional regardless of what the pack declares — a pack cannot promote a heuristic by asserting
-authority over it.
+Rule _code_ does not change. Some rules have triggers the pack schema cannot express. Those rules
+stay provisional, regardless of what the pack declares. A pack cannot promote a heuristic by
+asserting authority over it.
 
 ## What the pack cannot do
 
-- It cannot add a new rule. A new rule needs code; see [`rule-authoring.md`](./rule-authoring.md).
-- It cannot grant a fix that the autofix gate refuses. `safeSubstitution: true` is necessary but not
-  sufficient: `checkFixSafety()` and `gateFix()` still run, and still refuse anything that changes a
-  digit, a negation, a modal, an ordering word, or that sits in an admonition.
+- It cannot add a new rule. A new rule needs code. See [`rule-authoring.md`](./rule-authoring.md).
+- It cannot grant a fix that the autofix gate refuses. `safeSubstitution: true` is necessary, but it
+  is not enough. `checkFixSafety()` and `gateFix()` still run. They still refuse a fix that changes
+  any of the following.
+  - a digit.
+  - a negation.
+  - a modal.
+  - an ordering word.
+
+  They also refuse a fix that sits in an admonition.
+
 - It cannot make the linter print conformance wording. Nothing in the codebase emits a conformance
-  claim; `conformanceClaim` only records what the supplier asserts, for the audit trail.
+  claim. `conformanceClaim` only records what the supplier asserts, for the audit trail.
 
 ## Extending the schema
 
-If your pack carries data the schema cannot express — a part-of-speech table, per-rule exception
-lists, a sense inventory — extend `src/rule-pack/schema.ts` and the consuming rule together, and add
-a test that the new field actually changes behaviour. Do not smuggle data through
-`rules[].options`: that path is unvalidated beyond the rule's own options schema.
+Your pack might carry data the schema cannot express: a part-of-speech table, per-rule exception
+lists, or a sense inventory. In that case, extend `src/rule-pack/schema.ts` and the consuming rule
+together. Add a test that confirms the new field actually changes behaviour. Do not smuggle data
+through `rules[].options`: that path is unvalidated beyond the rule's own options schema.

--- a/docs/semantic-evaluators.md
+++ b/docs/semantic-evaluators.md
@@ -2,34 +2,34 @@
 
 ## Why narrow tasks
 
-There is no "check this text against the whole scheme" request in this package, and adding one would
-be a mistake. A broad request cannot be measured (what is the ground truth for "is this compliant?"),
-cannot be calibrated (one confidence number for a dozen different judgements), and cannot be traced
-back to a rule.
+This package has no "check this text against the whole scheme" request, and adding one would be a
+mistake. A broad request cannot be measured, because there is no ground truth for whether text is
+compliant. It cannot be calibrated, because one confidence number cannot stand in for a dozen
+different judgements. And it cannot be traced back to a single rule.
 
 Instead there are eight bounded classification tasks. Each has:
 
-- one question with a `compliant` / `violation` / `uncertain` answer;
-- its own versioned prompt asset in `prompts/<version>/<id>.md`;
-- a declared payload — **only** the keys it lists are transmitted, so a rule cannot widen the context
-  a model sees by stuffing extra fields into a candidate;
-- a required evidence span, so a verdict can be anchored back to source.
+- One question with a `compliant`, `violation`, or `uncertain` answer.
+- Its own versioned prompt asset in `prompts/<version>/<id>.md`.
+- A declared payload that lists **only** the keys that are transmitted. This means a rule cannot
+  widen the context a model sees by stuffing extra fields into a candidate.
+- A required evidence span, so a verdict can be anchored back to source.
 
 ## The eight
 
-| Evaluator                      | Question                                                          | Produced by                                          |
-| ------------------------------ | ----------------------------------------------------------------- | ---------------------------------------------------- |
-| `approved-word-sense`          | Is this word used in a sense the active pack permits?             | `unapproved-vocabulary` with `adjudicateSense: true` |
-| `permitted-part-of-speech`     | Is this word used in a permitted part of speech?                  | pack-driven                                          |
-| `one-instruction-per-sentence` | Does this sentence tell the reader to do more than one thing?     | `one-instruction-per-sentence` (comma-joined shape)  |
-| `passive-voice-adjudication`   | Is this a true passive verb, or an adjectival state?              | `passive-voice-candidate`                            |
-| `pronoun-antecedent-ambiguity` | Does this pronoun have more than one plausible antecedent?        | `ambiguous-pronoun-candidate`                        |
-| `noun-cluster-comprehension`   | Is this noun run hard to read, or one established name?           | `noun-cluster-candidate`                             |
-| `technical-term-legitimacy`    | Is this unlisted word domain terminology or avoidable vocabulary? | pack-driven                                          |
-| `rewrite-equivalence`          | Does a proposed rewrite preserve technical meaning?               | the autofix gate and the fixture tooling             |
+| Evaluator                      | Question                                                                         | Produced by                                          |
+| ------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `approved-word-sense`          | Is this word used in a sense the active pack permits?                            | `unapproved-vocabulary` with `adjudicateSense: true` |
+| `permitted-part-of-speech`     | Is this word used in a permitted part of speech?                                 | pack-driven                                          |
+| `one-instruction-per-sentence` | Does this sentence tell the reader to do more than one thing?                    | `one-instruction-per-sentence` (comma-joined shape)  |
+| `passive-voice-adjudication`   | Is this a true passive verb, or an adjectival state?                             | `passive-voice-candidate`                            |
+| `pronoun-antecedent-ambiguity` | Does this pronoun have more than one plausible antecedent?                       | `ambiguous-pronoun-candidate`                        |
+| `noun-cluster-comprehension`   | Is this noun run hard to read, or one established name?                          | `noun-cluster-candidate`                             |
+| `technical-term-legitimacy`    | Is this unlisted word part of domain terminology, or is it avoidable vocabulary? | pack-driven                                          |
+| `rewrite-equivalence`          | Does a proposed rewrite preserve technical meaning?                              | the autofix gate and the fixture tooling             |
 
-Permitted senses and parts of speech are supplied **at request time** from the active rule pack, and
-the prompt instructs the model to judge against that list and not against any dictionary it may have
+Permitted senses and parts of speech are supplied **at request time**, from the active rule pack.
+The prompt instructs the model to judge against that list, not against any dictionary it may have
 memorised. This is what keeps a licensed dictionary inside the import boundary instead of relying on
 model recall.
 
@@ -37,21 +37,24 @@ model recall.
 
 Every prompt asset is checked by `test/unit/prompts.test.ts` to:
 
-- state one bounded classification task;
-- permit `uncertain`;
-- require an evidence span (`evidenceStart` / `evidenceEnd`);
-- forbid changing literals, negation, ordering, quantities, identifiers and modal force;
-- forbid rewriting the document;
-- require JSON only, with no prose and no code fence;
-- **not** ask the model to reveal its reasoning — a concise decision plus evidence, never a
-  chain of thought;
-- carry compliant, violating **and hard-negative** examples.
+- State one bounded classification task.
+- Permit `uncertain`.
+- Require an evidence span, given as `evidenceStart` and `evidenceEnd`.
+- Forbid changing literals, negation, ordering and quantities, as well as identifiers and modal
+  force.
+- Forbid rewriting the document.
+- Require JSON only, with no prose and no code fence.
+- **Not** ask the model to reveal its reasoning — a concise decision plus evidence, never a chain
+  of thought.
+- Carry compliant, violating **and hard-negative** examples.
 
-Hard negatives are the part that matters. Every prompt includes cases that look like violations and
-are not: `Do not remove the cover and do not touch the busbar` is two prohibitions rather than two
-instructions; `Transport Layer Security certificate chain` is a standard name rather than a noun
-pile; `The connector is keyed so that it cannot be fitted the wrong way` is an adjectival property
-rather than a passive verb.
+Hard negatives are the part that matters. Every prompt includes cases that look like violations,
+but are not:
+
+- `Do not remove the cover and do not touch the busbar` is two prohibitions, not two instructions.
+- `Transport Layer Security certificate chain` is a standard name, not a noun pile.
+- `The connector is keyed so that it cannot be fitted the wrong way` is an adjectival property, not
+  a passive verb.
 
 ## File format
 
@@ -69,12 +72,12 @@ variables: ruleId, passage, invariants, construction, …
 
 Rendering throws when a placeholder has no value **and** when a value has no placeholder. Both are
 prompt-construction bugs that would otherwise reach a model silently. A golden test pins the exact
-rendered user message for one evaluator, so a prompt edit that changes request content is visible in
-review.
+rendered user message for one evaluator. This makes a prompt edit that changes request content
+visible in review.
 
-Prompts are versioned by directory. `semantic.promptVersion` selects the version, and the version is
-recorded in every trace and in the content hash — so changing a prompt invalidates the cache rather
-than serving a stale verdict.
+Prompts are versioned by directory. `semantic.promptVersion` selects the version. The version is
+recorded in every trace and in the content hash. Changing a prompt therefore invalidates the cache
+instead of serving a stale verdict.
 
 ## Response contract
 
@@ -95,41 +98,41 @@ than serving a stale verdict.
 
 | Rejection                                                                      | Kind                     |
 | ------------------------------------------------------------------------------ | ------------------------ |
-| no JSON object, truncated JSON, extra key, missing key, wrong type             | `invalid-response`       |
+| no JSON object<br>truncated JSON<br>extra key<br>missing key<br>wrong type     | `invalid-response`       |
 | confidence outside `[0,1]`, non-integer or negative offsets, empty explanation | `invalid-response`       |
 | `ruleId` not the requested rule, more than three replacements                  | `invalid-response`       |
 | `evidenceEnd < evidenceStart`, or beyond the passage length                    | `out-of-range`           |
 | `compliant` **and** replacements suggested                                     | `contradictory-response` |
 | `compliant` **and** `meaningPreserved: false`                                  | `contradictory-response` |
 | replacement suggested **while** `meaningPreserved: false`                      | `contradictory-response` |
-| `uncertain` **at** confidence > 0.9                                            | `contradictory-response` |
+| `uncertain` **at** confidence above `0.9`                                      | `contradictory-response` |
 
-JSON is extracted from a fenced block or from surrounding prose before validation — small local models
-routinely wrap their answer — but the schema still does all the deciding.
+JSON is extracted from a fenced block, or from surrounding prose, before validation. Small local
+models often wrap their answer this way. But the schema still does all the deciding.
 
 ## Confidence is not probability
 
 `confidence` is preserved verbatim as `modelReportedConfidence`. It is the number the model emitted:
 not calibrated, not a probability, not comparable across models. Decision thresholds are separate,
-operator-owned configuration (`defaultConfidenceThreshold`, `confidenceThresholds[evaluatorId]`), and
-both numbers are carried on the diagnostic so a reader can see why a verdict was kept or suppressed.
+operator-owned configuration: `defaultConfidenceThreshold` and `confidenceThresholds[evaluatorId]`.
+Both numbers are carried on the diagnostic, so a reader can see why a verdict was kept or suppressed.
 
 ## Broker guarantees
 
-| Guarantee              | How                                                                                                  |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| bounded concurrency    | worker pool sized to `min(maxConcurrency, queue length)`                                             |
-| deterministic ordering | candidates sorted by id for work; outcomes returned in the caller's order                            |
-| safe batching          | identical content hashes share one request; nothing else is merged                                   |
-| content-hash caching   | hash covers evaluator, prompt version, model, temperature, rendered messages                         |
-| timeouts               | `AbortSignal.timeout` combined with the caller's signal via `AbortSignal.any`                        |
-| cancellation           | reported as `cancelled`, distinct from `timeout`, and never retried                                  |
-| retry policy           | transport faults only: network, timeout, 408, 429, 5xx. Never 4xx, never invalid output              |
-| bounded repair         | at most `maxRepairAttempts` (≤ 1); the repair message restates the contract and adds no task content |
-| redaction              | passages are built from masked text; only declared payload keys are sent                             |
-| tracing                | prompt version, model id, content hash, attempts, cache hit, duration, repaired flag                 |
-| dependency injection   | `transport`, `cache`, `promptProvider`, `now`, `trace` are all injectable                            |
-| graceful uncertainty   | `uncertain` becomes `review-required`, never a violation                                             |
+| Guarantee              | How                                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| bounded concurrency    | worker pool sized to `min(maxConcurrency, queue length)`                                                                              |
+| deterministic ordering | candidates sorted by id for work, and outcomes returned in the caller's order                                                         |
+| safe batching          | identical content hashes share one request, and nothing else is merged                                                                |
+| content-hash caching   | hash covers evaluator<br>prompt version<br>model<br>temperature<br>rendered messages                                                  |
+| timeouts               | `AbortSignal.timeout` combined with the caller's signal via `AbortSignal.any`                                                         |
+| cancellation           | reported as `cancelled`, distinct from `timeout`, and never retried                                                                   |
+| retry policy           | transport faults only: network, timeout, or 408/429/5xx. Never 4xx, never invalid output                                              |
+| bounded repair         | `maxRepairAttempts` caps the repair loop at no more than one round. The repair message restates the contract and adds no task content |
+| redaction              | passages are built from masked text. Only declared payload keys are sent                                                              |
+| tracing                | prompt version<br>model id<br>content hash<br>attempts<br>cache hit<br>duration<br>repaired flag                                      |
+| dependency injection   | `transport`, `cache`, `promptProvider`, `now` and `trace` are all injectable                                                          |
+| graceful uncertainty   | `uncertain` becomes `review-required`, never a violation                                                                              |
 
 ## Measurement
 
@@ -137,32 +140,38 @@ both numbers are carried on the diagnostic so a reader can see why a verdict was
 vp run eval:semantic -- --split heldout --endpoint http://127.0.0.1:8080 --model my-model
 ```
 
-Reported per evaluator and overall: true positives, false positives, true negatives, false negatives,
-precision, recall, F1, uncertain rate, failure rate, and p50/p90/p99 latency (cache hits excluded from
-latency).
+Reported per evaluator and overall:
+
+- True positives, false positives, true negatives, and false negatives.
+- Precision, recall, and F1.
+- Uncertain rate and failure rate.
+- Latency at p50, p90, and p99, excluding cache hits.
 
 **Ground truth** comes from the fixture adjudication records, not from the linter's own output:
 
-- a candidate whose span is covered by an **accepted** change for the same rule is a gold violation —
-  a reviewer decided the passage really was defective;
-- a candidate covered by a **disputed** change is a gold non-violation — a reviewer decided the
-  deterministic pass was wrong;
-- anything else is **unlabelled**, excluded from the confusion matrix, and reported separately.
+- A candidate whose span is covered by an **accepted** change for the same rule is a gold
+  violation. A reviewer decided the passage really was defective.
+- A candidate covered by a **disputed** change is a gold non-violation. A reviewer decided the
+  deterministic pass was wrong.
+- Anything else is **unlabelled**, excluded from the confusion matrix, and reported separately.
 
-Excluding unlabelled candidates matters: counting them would invent ground truth for passages nobody
-adjudicated, and would make precision look better or worse depending on which way the model guessed.
+Excluding unlabelled candidates matters. Counting them would invent ground truth for passages
+nobody adjudicated. It would also make precision look better or worse, depending on which way the
+model guessed.
 
 **Split discipline.** `dev` fixtures are for tuning prompts and thresholds. `heldout` fixtures are for
-reporting and must not be tuned against. The manifest records the split per fixture, the validator
-asserts the splits are disjoint by content hash and that `heldout` is at least 25% of the corpus, and
-the evaluation script defaults to `heldout` and requires `--split all` to mix.
+reporting and must not be tuned against. The manifest records the split per fixture. The validator
+asserts that the splits are disjoint by content hash, and that `heldout` is at least 25% of the
+corpus. The evaluation script defaults to `heldout` and requires `--split all` to mix.
 
 ## Adding an evaluator
 
 1. Add the id to `SemanticEvaluatorId` in `src/core/types.ts`.
 2. Add an `EvaluatorDefinition` to `src/semantic/evaluators.ts` declaring `payloadKeys` and
-   `requiredKeys`. Keep the payload minimal — this is the redaction mechanism.
-3. Write `prompts/v1/<id>.md`. `test/unit/prompts.test.ts` will hold you to the contract above,
-   including hard-negative examples.
-4. Emit candidates for it from a rule, with `invariants` naming what must not change.
-5. Add fixture annotations that label the new candidates, or the evaluator will be unmeasurable.
+   `requiredKeys`.
+3. Keep the payload minimal — this is the redaction mechanism.
+4. Write `prompts/v1/<id>.md`.
+5. `test/unit/prompts.test.ts` will hold you to the contract above, including hard-negative
+   examples.
+6. Emit candidates for it from a rule, with `invariants` naming what must not change.
+7. Add fixture annotations that label the new candidates, or the evaluator will be unmeasurable.

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -1,13 +1,13 @@
 # Inline suppression
 
 Every rule this package ships is `provisional`. A provisional rule will sometimes be wrong about a
-particular sentence, and before inline suppression existed the only remedy was to disable the rule
-for the whole run — losing every other finding it would have made. An inline directive narrows that
-to one line or one region, and says in the source why.
+particular sentence. Before inline suppression existed, the only remedy was to disable the rule for
+the whole run. That approach lost every other finding the rule would have made. An inline directive
+narrows the fix to one line or one region. It also records why, right in the source.
 
 A suppression is an **authored claim**: someone looked at this finding and decided it does not
-apply here. It is treated as a claim throughout — recorded, attributed to a reason, and reported —
-not as a way of deleting the finding.
+apply here. The tool treats it as a claim throughout. It is recorded, tied to a reason, and
+reported. A suppression is not a way to delete the finding.
 
 ## Syntax
 
@@ -20,13 +20,13 @@ Three directive forms, written as HTML comments:
 ```
 
 - The keyword is the first token inside the comment, and keywords are case-sensitive.
-- Rule ids are separated by commas and/or whitespace and appear before the separator, which is a
-  double hyphen with a space on each side. An empty list means every rule.
+- Rule ids are separated by commas, by whitespace, or by both. They appear before the separator,
+  which is a double hyphen with a space on each side. An empty list means every rule.
 - The reason is everything after the first such separator, trimmed.
 - `ste-ai-ignore-end` takes no rule ids and no reason.
-- The same HTML-comment form is used in `markdown` and in `text` documents. In markdown a comment
-  is already a protected region and produces no prose; in `text` it is ordinary prose, so the
-  scanner reads the source directly rather than relying on protected regions.
+- The same HTML-comment form works in `markdown` documents and in `text` documents. In markdown a
+  comment is already a protected region, so it produces no prose. In `text` a comment is ordinary
+  prose. There the scanner reads the source directly, instead of relying on protected regions.
 
 ### A reason is required
 
@@ -34,8 +34,8 @@ A directive with no reason, or with an empty reason, is **not applied**. It is i
 it named is still reported, and `suppression-reason-missing` is emitted.
 
 This is the one piece of syntax with no convenience form. A suppression without a reason is
-indistinguishable from a mistake six months later, and a linter that lets a reader see the silence
-but not the argument for it has replaced one unverified claim with another.
+indistinguishable from a mistake six months later. A linter can let a reader see the silence but
+not the argument for it. Such a linter has only replaced one unverified claim with another.
 
 ## What a directive claims
 
@@ -43,23 +43,33 @@ but not the argument for it has replaced one unverified claim with another.
 | ------------------------- | ------------------------------------------------------------------------------------ |
 | `ste-ai-ignore-next-line` | the next block of prose                                                              |
 | `ste-ai-ignore-start`     | from the end of the `ignore-start` comment to the start of the matching `ignore-end` |
-| `ste-ai-ignore-end`       | nothing; it closes the open `ignore-start`                                           |
+| `ste-ai-ignore-end`       | nothing — it closes the open `ignore-start`                                          |
 
 **A block, not a line.** `ste-ai-ignore-next-line` claims the first block whose end lies after the
-directive, with the span clamped to begin at the directive's own end. A block is a paragraph, a
-heading, a list item, a table cell, a block quote or a caption — the same unit every rule works in.
+directive. The span is clamped to begin at the directive's own end. A block is the same unit every
+rule in this package works in. It is one of:
+
+- a paragraph
+- a heading
+- a list item
+- a table cell
+- a block quote
+- a caption
 
 The keyword keeps the name every other linter uses, because that is the name a reader reaches for.
 What it claims is a block, and the distinction matters in three places:
 
-- **A soft-wrapped paragraph is one block**, so the claim does not move when the prose is rewrapped.
-  See [Reformatting the prose](#reformatting-the-prose).
-- **A directive written directly above its paragraph, with no blank line, is absorbed into that
-  paragraph's block** — the block therefore starts before the directive. The clamp is what keeps
-  such a directive claiming the rest of its own paragraph rather than the prose above it.
-- **Blank lines and blockquote markers need no special handling.** A directive separated from its
-  paragraph by a blank line produces no block of its own in markdown, and a directive inside a
-  blockquote is not prose either, so stacking works in both without a rule for either:
+- **A soft-wrapped paragraph is one block**. See [Reformatting the prose](#reformatting-the-prose).
+- **A directive right above its paragraph, with no blank line, joins that paragraph's block**.
+- **Blank lines and blockquote markers need no special handling**.
+
+The claim does not move when a soft-wrapped paragraph is rewrapped, because it stays one block. A
+directive that joins its paragraph's block this way makes the block start before the directive. The
+clamp is what keeps that directive claiming the rest of its own paragraph, not the prose above it.
+
+A directive set off from its paragraph by a blank line produces no block of its own in markdown. A
+directive inside a blockquote is not prose either. Stacking therefore works in both cases, with no
+separate rule for either one. The example below shows two directives stacked above one paragraph.
 
 ```markdown
 <!-- ste-ai-ignore-next-line unapproved-vocabulary -- "terminate" is the vendor's API verb -->
@@ -70,19 +80,23 @@ Terminate the session before you remove the module.
 
 Both directives above claim the same paragraph, each for its own rule id and its own reason.
 
-Claiming a block is wider than claiming a line: a directive above a paragraph of five sentences
-covers all five for the rule ids it names. Name the rule ids to keep the claim narrow, and prefer a
-directive per paragraph over a range covering several.
+Claiming a block is wider than claiming a line. A directive above a paragraph of five sentences
+covers all five sentences, for the rule ids it names. Name the rule ids to keep the claim narrow.
+Prefer one directive per paragraph over a single range that covers several paragraphs.
 
-A finding is claimed when its **start offset** falls in `[span.start, span.end)` and the
-directive's rule-id list is empty or contains the finding's rule id. Where two directives both
-claim a finding, the first in source order wins.
+A finding is claimed when both of these hold:
 
-Anchoring on the start offset rather than on span overlap is what makes a multi-line finding
-behave predictably. A sentence-length diagnostic covers a sentence that may run over four lines;
-under an overlap rule, a `next-line` directive anywhere in those four lines would claim it, and a
-reader could not tell from the directive which finding it was aimed at. Under the start-offset
-rule a finding is claimed by the line it is _reported on_ — the line the CLI prints next to it.
+- its **start offset** falls in `[span.start, span.end)`
+- the directive's rule-id list is empty, or it contains the finding's rule id
+
+Where two directives both claim a finding, the first in source order wins.
+
+Anchoring on the start offset, rather than on span overlap, is what makes a multi-line finding
+behave predictably. A sentence-length diagnostic covers a sentence that may run over four lines.
+Under an overlap rule, a `next-line` directive anywhere in those four lines would claim it. A
+reader could not then tell, from the directive alone, which finding it was aimed at. Under the
+start-offset rule, a finding is claimed by the line it is _reported on_. That is the line the CLI
+prints next to it.
 
 `ste-ai-ignore-start` does not nest. A second `ignore-start` seen before an `ignore-end` closes the
 first at its own start position and emits `suppression-unclosed-range`. An `ignore-start` that is
@@ -90,14 +104,14 @@ never closed runs to the end of the document and emits the same notice.
 
 Any finding anchored inside a directive comment itself is suppressed unconditionally, with the
 reason `directive text is not prose`. Without this, a `format: 'text'` document — where comments
-are not masked out — would report findings on the directive line, which is not text anyone wrote
-for a reader.
+are not masked out — would report findings on the directive line. That line is not text anyone
+wrote for a reader.
 
 ### Reformatting the prose
 
 Rewrapping a paragraph does not change what a directive claims. This linter reads wording, not
-whitespace: a soft wrap is not a boundary any part of the analysis recognises, so the same prose
-wrapped and unwrapped is the same prose.
+whitespace. A soft wrap is not a boundary that any part of the analysis recognises. The same
+prose, wrapped or unwrapped, is treated as the same prose.
 
 Measured over the same three sentences written as one long line and as six soft-wrapped ones:
 
@@ -110,16 +124,18 @@ Measured over the same three sentences written as one long line and as six soft-
 | diagnostics        | —         | identical |
 | candidates         | —         | identical |
 
-Suppressions inherit that property from the block unit, and a test asserts it directly: the same
-paragraph, wrapped and unwrapped, withholds the same findings and emits no `suppression-unused`.
+Suppressions inherit that property from the block unit. A test asserts this directly: the same
+paragraph, wrapped or unwrapped, withholds the same findings. Neither version emits a
+`suppression-unused` notice.
 
-An earlier revision of this feature claimed a physical line, and a paragraph rewrapped so the
-offending word moved to a later line stopped being covered. That is fixed. It is recorded here
-because the failure was instructive: the line was the only unit in this package that whitespace
-could move, and it was borrowed from linters that read code, where a line is structural.
+An earlier revision of this feature claimed a physical line instead of a block. When a paragraph
+was rewrapped, the offending word could move to a later line. That line was no longer covered, so
+the suppression silently stopped working. That bug is fixed. It is recorded here because the
+failure was instructive. The line was the only unit in this package that whitespace could move. It
+had been borrowed from linters that read code, where a line is a structural unit.
 
-Line breaks that _are_ structural — a table row, a list item, a heading — are block boundaries and
-continue to be honoured as such.
+Some line breaks are structural — for example a table row, a list item, or a heading. This package
+continues to treat those as block boundaries.
 
 ## Configuration
 
@@ -134,60 +150,62 @@ continue to be honoured as such.
 }
 ```
 
-With `suppressions.enabled: false` no scan runs at all: no directive is applied, no suppression is
-recorded, and every finding is reported as though the directives were not in the file. This is the
-setting for an audit run that needs to see what the document contains rather than what its authors
-have ruled on.
+With `suppressions.enabled: false`, no scan runs at all. No directive is applied. No suppression is
+recorded. Every finding is reported as though there were no directives in the file. Use this
+setting for an audit run. It needs to see what the document contains, not what its authors have
+already ruled on.
 
 ## Admonitions
 
-A claim is **refused** when the block containing the anchor offset is a `danger`, `warning` or
-`caution` admonition and `allowInAdmonitions` is false, which is the default. The diagnostic is
-kept and `suppression-refused-in-admonition` is emitted at `warning`. `note` is not a safety
-register and never triggers the refusal.
+A claim is **refused** when two things are both true. The block containing the anchor offset is a
+`danger`, `warning`, or `caution` admonition. And `allowInAdmonitions` is false, which is the
+default. When a claim is refused, the diagnostic is kept, and `suppression-refused-in-admonition`
+is emitted at `warning`. `note` is not a safety register, so it never triggers the refusal.
 
 ### Why this differs from autofix
 
-`autofix.allowInAdmonitions` is typed `z.literal(false)` (`src/core/config.ts:50`) and can never be
-set to true. `suppressions.allowInAdmonitions` is an ordinary boolean, default false. The asymmetry
-is deliberate.
+`autofix.allowInAdmonitions` is typed `z.literal(false)` (`src/core/config.ts:62`). It can never
+be set to true. `suppressions.allowInAdmonitions` is an ordinary boolean, and its default is also
+false. The asymmetry between them is deliberate.
 
 Rewriting the source of a safety notice and withholding a report about one are different acts. The
-first changes what a reader in front of the equipment is told, and no model verdict or rule
-substitution in this package is trusted to do that. The second changes only what the linter says
-about wording that a person has already read and ruled on; it is an operator decision, and one an
-operator is entitled to take — but only explicitly, only with a reason in the source, and always
-with the withheld finding still recorded.
+first changes what a reader in front of the equipment is told. No model verdict, and no rule
+substitution in this package, is trusted to do that. The second act changes only what the linter
+says about wording a person has already read and ruled on. That is an operator decision, and an
+operator is entitled to make it. But the operator may only make it explicitly. A reason must be
+in the source. And the withheld finding must still be recorded.
 
 ## Suppressions are recorded, never discarded
 
 The load-bearing rule of this project is that silence must never mean compliant
-([`diagnostic-policy.md`](./diagnostic-policy.md#service-failure-is-never-compliance)). It applies
-to a suppressed finding exactly as it applies to a passage a model failed to adjudicate: the
-finding leaves the diagnostic list, and it does not leave the result.
+([`diagnostic-policy.md`](./diagnostic-policy.md#service-failure-is-never-compliance)). That rule
+applies to a suppressed finding exactly as it applies to a passage a model failed to adjudicate.
+The finding leaves the diagnostic list. It does not leave the result.
 
 Every withheld finding is visible on every surface that reports the run:
 
-| Surface          | Where                                                                                                                                          |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Programmatic API | `AnalysisResult.suppressions` — rule id, category, range, the message the finding would have carried, the reason, and the directive's own span |
-| CLI `--json`     | a `suppressions` array on each file's result object                                                                                            |
-| CLI human output | one `suppressed  {ruleId} at {line}:{column} — {reason}` line per record                                                                       |
-| Run notices      | `suppressions-applied` at `info`, once per run, with the count                                                                                 |
+| Surface          | Where                                                                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Programmatic API | `AnalysisResult.suppressions` — rule id<br>category<br>range<br>the message the finding would have carried<br>the reason<br>the directive's own span |
+| CLI `--json`     | a `suppressions` array on each file's result object                                                                                                  |
+| CLI human output | one `suppressed  {ruleId} at {line}:{column} — {reason}` line per record                                                                             |
+| Run notices      | `suppressions-applied` at `info`, once per run, with the count                                                                                       |
 
 Exit-code logic is unchanged by this feature. A suppressed diagnostic is simply not in the
-diagnostic list, so a suppression can turn exit `1` into exit `0`. That is what a suppression is
-for; the record of what was withheld is what makes it auditable rather than invisible.
+diagnostic list. That is enough for a suppression to turn exit `1` into exit `0`. That is what a
+suppression is for. The record of what was withheld is what makes it auditable, rather than
+invisible.
 
 ### A suppressed candidate is never sent to the model
 
-Candidates are filtered before adjudication, not after. A candidate whose start offset is claimed
-for its rule id is dropped from the run before anything else happens to it, and recorded as a
-suppression with category `review-required` and the candidate's own reason as its message.
+Candidates are filtered before adjudication, not after. Take a candidate whose start offset is
+claimed for its rule id. It is dropped from the run before anything else happens to it. It is then
+recorded as a suppression, with category `review-required` and the candidate's own reason as its
+message.
 
 Two consequences, both intended. An operator who has already ruled on a passage does not pay for a
-model to adjudicate it again. And the text of that passage never leaves the process — a suppression
-is therefore also the mechanism for keeping a specific passage away from a semantic service.
+model to adjudicate it again. And the text of that passage never leaves the process. A suppression
+is therefore also the mechanism for keeping one specific passage away from a semantic service.
 
 ## Notice codes
 
@@ -195,7 +213,7 @@ is therefore also the mechanism for keeping a specific passage away from a seman
 | ----------------------------------- | --------- | ------------------------ | ------------------------------------------------------------------------ |
 | `suppressions-applied`              | `info`    | `{ count }`              | emitted once when at least one finding was withheld                      |
 | `suppression-reason-missing`        | `warning` | `{ line }`               | directive ignored                                                        |
-| `suppression-unknown-rule`          | `warning` | `{ ruleId }`             | the named id is not a known rule; it never matches                       |
+| `suppression-unknown-rule`          | `warning` | `{ ruleId }`             | the named id is not a known rule — it never matches                      |
 | `suppression-unclosed-range`        | `warning` | `{ line }`               | `ignore-start` with no `ignore-end`                                      |
 | `suppression-end-without-start`     | `warning` | `{ line }`               | stray `ignore-end`                                                       |
 | `suppression-unused`                | `info`    | `{ line }`               | the directive claimed nothing — keeps dead suppressions reviewable       |
@@ -204,28 +222,33 @@ is therefore also the mechanism for keeping a specific passage away from a seman
 
 `line` values are 1-based.
 
-`suppression-unused` exists because a suppression that no longer claims anything is the same
-problem as a stale comment: the sentence it was written for may have been rewritten, and nobody
-finds out unless the tool says so.
+`suppression-unused` exists because of a stale-comment problem. A suppression that no longer
+claims anything is exactly that. The sentence it was written for may have been rewritten since.
+Nobody finds out, unless the tool says so.
 
 ## Known limitation: suppressions are not visible in a textlint report
 
 The textlint adapter surfaces run notices only at `warning` and `error`
-(`src/textlint/adapter.ts:215`), so the `info`-level `suppressions-applied` and
-`suppression-unused` notices do not reach a textlint report. Suppressed diagnostics themselves
-never reach the adapter at all, by design — suppressing a finding is the core's decision, expressed
-by not producing the diagnostic.
+(`src/textlint/adapter.ts:336`). As a result, the `info`-level `suppressions-applied` and
+`suppression-unused` notices never reach a textlint report. Suppressed diagnostics themselves
+never reach the adapter at all. That omission is by design: suppressing a finding is the core's
+decision, expressed by not producing the diagnostic.
 
-The consequence is that `npx textlint` shows a clean file and gives no indication of how much was
-withheld to make it clean. Audit suppressions through the CLI or the programmatic API instead:
+The consequence is that `npx textlint` shows a clean file. It gives no indication of how much was
+withheld to make it look that way. Audit suppressions instead, through the CLI or the programmatic
+API:
 
 ```bash
 npx ste-ai lint docs/install.md --json    # per-file `suppressions` array
 npx ste-ai lint docs/install.md           # `suppressed` lines under each file
 ```
 
-The `warning`-level suppression notices — a missing reason, an unknown rule id, an unclosed range,
-a refused claim in an admonition — do reach a textlint report.
+Some suppression notices are surfaced at `warning`, and those do reach a textlint report:
+
+- a missing reason
+- an unknown rule id
+- an unclosed range
+- a refused claim in an admonition
 
 ## Example
 

--- a/prompts/v1/approved-word-sense.md
+++ b/prompts/v1/approved-word-sense.md
@@ -2,34 +2,36 @@
 id: approved-word-sense
 version: v1
 task: Decide whether a word is used in a sense the active rule pack permits.
-variables: ruleId, passage, invariants, word, permittedSenses, approvedAlternatives, offsetInPassage
+variables: ruleId passage invariants word permittedSenses approvedAlternatives offsetInPassage
 <<<SYSTEM>>>
 You are a controlled-language adjudicator for technical documentation. You perform exactly one
 classification task and you return exactly one JSON object.
 
-TASK
-Decide whether the supplied word, at the supplied offset, is used in one of the PERMITTED SENSES
-listed in the request. The permitted senses come from the active rule pack and are supplied to you
-at request time. Judge against that list only. Do not apply any dictionary you were trained on and
-do not invent additional senses.
+Task
+Decide whether the supplied word is used in one of the permitted senses. Judge only the occurrence
+at the supplied offset. The permitted senses come from the active rule pack, supplied to you at
+request time. Judge against that list only. Do not apply any dictionary you were trained on. Do not
+invent more senses.
 
-DECIDE `violation` when the word is used in a sense that is NOT in the permitted list.
+Decide `violation` when the word is used in a sense that is not in the permitted list.
 
-DECIDE `compliant` when the word is used in one of the permitted senses.
+Decide `compliant` when the word is used in one of the permitted senses.
 
-DECIDE `uncertain` when the passage does not disambiguate the sense, or when the permitted list is
-empty or does not cover the usage either way.
+Decide `uncertain` when the passage does not disambiguate the sense. Decide `uncertain` also when
+the permitted list is empty. Decide `uncertain` also when the permitted list does not cover the
+usage either way.
 
 CONSTRAINTS
 
 - Judge the single occurrence at the given offset. Ignore other occurrences.
 - Do not rewrite the document.
-- Any suggested replacement must come from the supplied approved alternatives and must preserve,
-  unchanged: every quantity, unit and identifier, every negation, the action order, and the modal
-  force.
+- Any suggested replacement must come from the supplied approved alternatives.
+- A suggested replacement must preserve every quantity and unit, unchanged.
+- A suggested replacement must preserve every identifier and negation, unchanged.
+- A suggested replacement must preserve the action order and the modal force, unchanged.
 - If no supplied alternative fits the sentence, return an empty `suggestedReplacements` array.
-- `evidenceStart` and `evidenceEnd` are character offsets into the passage exactly as supplied and
-  must bracket the word occurrence you judged.
+- `evidenceStart` and `evidenceEnd` are character offsets into the passage, exactly as supplied.
+- `evidenceStart` and `evidenceEnd` must bracket the word occurrence you judged.
 - `confidence` is your own reported confidence in the range 0 to 1. It is recorded, not trusted.
 - Do not explain your reasoning. `explanation` is one short sentence naming the evidence.
 - Return only the JSON object. No prose, no code fence, no commentary.
@@ -44,10 +46,10 @@ Violation: "Keep the sensor close to the manifold."
 → used as "near", which is not in the permitted list.
 
 Uncertain: "Close the loop."
-→ could be "to shut" or an unlisted idiom; the passage does not disambiguate.
+→ could be "to shut" or an unlisted idiom. The passage does not disambiguate.
 
 Hard negative — compliant: "Close the cover, then close the access door."
-→ both occurrences are the permitted sense; judge only the offset supplied.
+→ both occurrences are the permitted sense. Judge only the offset supplied.
 
 Hard negative — uncertain: "The tolerance is close."
 → the permitted list does not cover an adjectival measurement usage either way.
@@ -57,10 +59,10 @@ ruleId: {{ruleId}}
 Invariants that must not change in any suggestion:
 {{invariants}}
 
-Word: {{word}}
-Character offset of the occurrence in the passage: {{offsetInPassage}}
-Permitted senses supplied by the active rule pack: {{permittedSenses}}
-Approved alternatives supplied by the active rule pack: {{approvedAlternatives}}
+- Word: {{word}}
+- Character offset of the occurrence in the passage: {{offsetInPassage}}
+- Permitted senses supplied by the active rule pack: {{permittedSenses}}
+- Approved alternatives supplied by the active rule pack: {{approvedAlternatives}}
 
 Passage (offsets are 0-based into this exact string):
 {{passage}}

--- a/prompts/v1/noun-cluster-comprehension.md
+++ b/prompts/v1/noun-cluster-comprehension.md
@@ -2,34 +2,35 @@
 id: noun-cluster-comprehension
 version: v1
 task: Decide whether a run of nouns is hard to read or is one established name.
-variables: ruleId, passage, invariants, cluster, length, limit
+variables: ruleId passage invariants cluster length limit
 <<<SYSTEM>>>
 You are a controlled-language adjudicator for technical documentation. You perform exactly one
 classification task and you return exactly one JSON object.
 
-TASK
+Task
 A deterministic pass found a run of {{length}} content words with no function word between them.
-Decide whether that run is HARD TO READ because the relations between the words are not shown.
+Decide whether that run is hard to read because the relations between the words are not shown.
 
-DECIDE `violation` when a reader must guess how the words relate — which word modifies which, or
-what belongs to what — and prepositions or a rewording would make the relation explicit.
+Decide `violation` when a reader must guess how the words relate. The reader cannot tell which
+word modifies which, or what belongs to what. A preposition or a rewording would make the relation
+explicit.
 
-DECIDE `compliant` when the run is:
+Decide `compliant` when the run is:
 
-- a single established product, standard, part or interface NAME used as a unit;
-- a proper noun sequence;
-- a term the surrounding text has already defined;
+- a single established product, standard, part or interface name used as a unit.
+- a proper noun sequence.
+- a term the surrounding text has already defined.
 - short enough that the relation is obvious from ordinary usage.
 
-DECIDE `uncertain` when you cannot tell whether the run is one name or several stacked modifiers.
+Decide `uncertain` when you cannot tell whether the run is one name or several stacked modifiers.
 
 CONSTRAINTS
 
 - Do not rewrite the document. Judge only the supplied cluster in its passage.
-- Never change a component identity. If the cluster might be an exact part name, interface name or
-  standard designation, treat it as compliant rather than proposing a rewrite.
-- Any suggested replacement must preserve, unchanged: every identifier, quantity, unit and literal,
-  every negation, action order, and the modal force.
+- Never change a component identity. The cluster might be an exact part name, an interface name,
+  or a standard designation. When it might, treat it as compliant instead of proposing a rewrite.
+- Any suggested replacement must preserve every identifier, quantity, unit, and literal unchanged.
+  It must also preserve every negation, the action order, and the modal force unchanged.
 - `evidenceStart` and `evidenceEnd` are character offsets into the passage exactly as supplied and
   must bracket the cluster.
 - `confidence` is your own reported confidence in the range 0 to 1. It is recorded, not trusted.
@@ -39,7 +40,7 @@ CONSTRAINTS
 EXAMPLES
 
 Violation: "engine oil pressure warning lamp test procedure"
-→ six stacked modifiers; the relations must be shown with prepositions.
+→ six stacked modifiers. Add prepositions to show the relations.
 
 Violation: "backup power supply cable retention clip"
 → the reader cannot tell what retains what.
@@ -51,7 +52,7 @@ Compliant: "primary flight display"
 → established three-word interface name in this domain.
 
 Hard negative — compliant: "Transport Layer Security certificate chain"
-→ "Transport Layer Security" is one standard name; the remaining words are a short, conventional
+→ "Transport Layer Security" is one standard name. The remaining words are a short, conventional
 pairing.
 
 Hard negative — compliant: "Advanced Encryption Standard block size"

--- a/prompts/v1/permitted-part-of-speech.md
+++ b/prompts/v1/permitted-part-of-speech.md
@@ -2,32 +2,34 @@
 id: permitted-part-of-speech
 version: v1
 task: Decide whether a word is used in a part of speech the active rule pack permits.
-variables: ruleId, passage, invariants, word, permittedPartsOfSpeech, offsetInPassage
+variables: ruleId passage invariants word permittedPartsOfSpeech offsetInPassage
 <<<SYSTEM>>>
 You are a controlled-language adjudicator for technical documentation. You perform exactly one
 classification task and you return exactly one JSON object.
 
-TASK
-Decide whether the supplied word, at the supplied offset, is used in one of the PERMITTED PARTS OF
-SPEECH listed in the request. The list comes from the active rule pack and is supplied at request
-time. Judge against that list only.
+Task
+Decide whether the supplied word is used in one of the permitted parts of speech. The request lists
+those parts of speech. Judge only the occurrence at the supplied offset. The list comes
+from the active rule pack. The rule pack supplies the list at request time. Judge against that list
+only.
 
-DECIDE `violation` when the word's part of speech at that offset is not in the permitted list — for
-example a noun used where only the verb is permitted.
+Decide `violation` when the word's part of speech at that offset is not in the permitted list.
+For example, a noun used where only the verb is permitted counts as a violation.
 
-DECIDE `compliant` when the part of speech is in the permitted list.
+Decide `compliant` when the part of speech is in the permitted list.
 
-DECIDE `uncertain` when the word's part of speech is genuinely ambiguous in the passage, or when the
-permitted list is empty.
+Decide `uncertain` when the word's part of speech is genuinely ambiguous in the passage. Decide
+`uncertain` also when the permitted list is empty.
 
 CONSTRAINTS
 
 - Judge the single occurrence at the given offset.
 - Do not rewrite the document.
-- Any suggested replacement must preserve, unchanged: every quantity, unit and identifier, every
-  negation, action order, and modal force.
-- `evidenceStart` and `evidenceEnd` are character offsets into the passage exactly as supplied and
-  must bracket the word occurrence you judged.
+- A suggested replacement must preserve every quantity and unit, unchanged.
+- A suggested replacement must preserve every identifier and negation, unchanged.
+- A suggested replacement must preserve the action order and modal force, unchanged.
+- `evidenceStart` and `evidenceEnd` are character offsets into the passage, exactly as supplied.
+- `evidenceStart` and `evidenceEnd` must bracket the word occurrence you judged.
 - `confidence` is your own reported confidence in the range 0 to 1. It is recorded, not trusted.
 - Do not explain your reasoning. `explanation` is one short sentence naming the evidence.
 - Return only the JSON object. No prose, no code fence, no commentary.
@@ -45,7 +47,7 @@ Uncertain: "Test procedures follow."
 → "Test" could be an attributive noun or a verb in a truncated heading.
 
 Hard negative — compliant: "Test the circuit, then test the relay."
-→ both verbs; judge only the supplied offset.
+→ both verbs. Judge only the supplied offset.
 
 Hard negative — violation: "The test is complete."
 → noun.
@@ -55,9 +57,9 @@ ruleId: {{ruleId}}
 Invariants that must not change in any suggestion:
 {{invariants}}
 
-Word: {{word}}
-Character offset of the occurrence in the passage: {{offsetInPassage}}
-Permitted parts of speech supplied by the active rule pack: {{permittedPartsOfSpeech}}
+- Word: {{word}}
+- Character offset of the occurrence in the passage: {{offsetInPassage}}
+- Permitted parts of speech supplied by the active rule pack: {{permittedPartsOfSpeech}}
 
 Passage (offsets are 0-based into this exact string):
 {{passage}}

--- a/prompts/v1/pronoun-antecedent-ambiguity.md
+++ b/prompts/v1/pronoun-antecedent-ambiguity.md
@@ -2,31 +2,31 @@
 id: pronoun-antecedent-ambiguity
 version: v1
 task: Decide whether a pronoun has more than one plausible antecedent for a reader.
-variables: ruleId, passage, invariants, pronoun, possibleAntecedents, previousSentence
+variables: ruleId passage invariants pronoun possibleAntecedents previousSentence
 <<<SYSTEM>>>
 You are a controlled-language adjudicator for technical documentation. You perform exactly one
 classification task and you return exactly one JSON object.
 
-TASK
-Decide whether the supplied pronoun has MORE THAN ONE plausible antecedent for a reader who has
-read only the previous sentence and this one.
+Task
+Decide whether the supplied pronoun has more than one plausible antecedent. The reader has read
+only the previous sentence and this one.
 
-DECIDE `violation` when a competent reader could reasonably attach the pronoun to two or more
-different nouns, or when the pronoun refers to a whole clause rather than a noun ("This prevents
-overheating" where "this" is the preceding action).
+Decide `violation` when a competent reader could reasonably attach the pronoun to two or more
+different nouns. Also decide `violation` when the pronoun refers to a whole clause rather than a
+noun. For example, "This prevents overheating" uses "this" to mean the preceding action.
 
-DECIDE `compliant` when exactly one antecedent is available, or when the pronoun is part of a fixed
-impersonal construction ("it is necessary to", "if it is not possible"), or when grammatical number
-or a nearby noun makes the reference unambiguous.
+Decide `compliant` when exactly one antecedent is available. Also decide `compliant` when the
+pronoun is part of a fixed impersonal construction. Examples are "it is necessary to" and "if it is
+not possible". Grammatical number or a nearby noun can also make the reference unambiguous.
 
-DECIDE `uncertain` when the surrounding text supplied is not enough to tell.
+Decide `uncertain` when the surrounding text supplied is not enough to tell.
 
 CONSTRAINTS
 
 - Do not rewrite the document. Judge only the supplied passage.
 - Any suggested replacement must repeat the correct noun exactly as it is written elsewhere in the
-  passage. Do not rename a component, do not change an identifier, and do not change quantities,
-  units, negation, action order, or modal force.
+  passage. Do not rename a component, and do not change an identifier. Also do not change any
+  quantity or unit. Do not change negation, action order, or modal force.
 - If you cannot determine which noun is meant, return an empty `suggestedReplacements` array. Never
   guess an antecedent.
 - `evidenceStart` and `evidenceEnd` are character offsets into the passage exactly as supplied and
@@ -47,11 +47,11 @@ Compliant: "Remove the access panel. Keep it for reassembly."
 → only one candidate noun.
 
 Compliant: "It is not possible to recover the key after deletion."
-→ impersonal construction; no antecedent is expected.
+→ impersonal construction. No antecedent is expected.
 
-Hard negative — compliant: "The controller stores the certificate and the private key. They are
-both erased on factory reset."
-→ "They" refers to both nouns together, which is unambiguous.
+Hard negative — compliant: "The controller stores the certificate and the key. They are both
+erased on reset."
+→ "They" refers to both nouns together. That reference is unambiguous.
 
 Hard negative — compliant: "Install the two brackets. They must be flush with the frame."
 → plural pronoun matches the only plural noun.


### PR DESCRIPTION
Closing in favor of one small PR per file — easier to review independently, and no single file blocks the others. See follow-up PRs.