### PR TITLE
docs(publishing): fix ste-ai lint violations

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,31 +1,40 @@
 # Publishing to npm
 
-Publishing uses two workflows. A push to `main` runs `.github/workflows/release-tag.yml`, where
-semantic-release evaluates the Conventional Commit history, updates `package.json` and
-`package-lock.json`, commits those versions, and creates the next `v`-prefixed tag on that release
-commit. That tag starts `.github/workflows/publish.yml`, which verifies that the checked-out package
-version matches the tag, creates a GitHub release with generated notes, builds the package with Vite+
-Pack, and publishes the contents selected by `package.json`. The npm publish uses trusted publishing
-(OIDC), so it does not need a long-lived `NPM_TOKEN` secret.
+Publishing uses two workflows. A push to `main` runs `.github/workflows/release-tag.yml`. This
+workflow runs semantic-release over the Conventional Commit history. The workflow updates
+`package.json` and `package-lock.json`, then commits those version changes. The workflow then
+creates the next `v`-prefixed tag on that release commit.
+
+That tag starts `.github/workflows/publish.yml`. This second workflow verifies that the checked-out
+package version matches the tag. The workflow creates a GitHub release with generated notes and
+builds the package with Vite+ Pack. The workflow then publishes the contents selected by
+`package.json`.
+
+The npm publish uses trusted publishing (OIDC). Trusted publishing does not need a long-lived
+`NPM_TOKEN` secret.
 
 ## One-time npm setup
 
-The package does not exist on npm yet. A maintainer must bootstrap it once before npm can attach a
-trusted publisher:
+The package does not exist on npm yet. A maintainer must bootstrap the package once before npm can
+attach a trusted publisher:
 
 1. Sign in to npm with an account that owns the package name and has two-factor authentication
    enabled.
-2. From a clean checkout of the commit to release, run `vp install --frozen-lockfile`, `vp check`,
-   `vp test`, and `vp pack`.
-3. Confirm the tarball with `npm pack --dry-run`, then run `npm publish --access public`. This is the
-   only publish that needs interactive npm authentication. Provenance starts with the subsequent
-   CI publishes because the local bootstrap does not have GitHub's OIDC identity.
-4. On npmjs.com, open **Packages → textlint-rule-preset-ste-ai → Settings → Trusted Publisher** and
+2. Start from a clean checkout of the commit to release.
+3. Run `vp install --frozen-lockfile`, then `vp check`, then `vp test`, then `vp pack`.
+4. Confirm the tarball with `npm pack --dry-run`.
+5. Run `npm publish --access public`.
+6. This manual step is the only publish that requires you to log in to npm interactively.
+7. The local bootstrap does not have GitHub's OIDC identity.
+8. Provenance therefore starts with the subsequent Continuous Integration (CI) publishes.
+9. On npmjs.com, open **Packages → textlint-rule-preset-ste-ai → Settings → Trusted Publisher** and
    select **GitHub Actions**.
-5. Enter organization or user `Jamie-BitFlight`, repository `textlint-rule-preset-ste-ai`, workflow
-   filename `publish.yml`, and environment `npm`. Allow the **npm publish** action.
-6. After verifying trusted publishing, set publishing access to **Require two-factor authentication
-   and disallow tokens**. The workflow uses short-lived OIDC credentials and does not need a token.
+10. Enter organization or user `Jamie-BitFlight`, repository `textlint-rule-preset-ste-ai`, workflow
+    filename `publish.yml`, and environment `npm`.
+11. Allow the **npm publish** action.
+12. After verifying trusted publishing, set publishing access to **Require two-factor authentication
+    and disallow tokens**.
+13. The workflow uses short-lived OIDC credentials and does not need a token.
 
 ## One-time GitHub setup
 
@@ -33,30 +42,37 @@ Create a GitHub environment named `npm` under **Settings → Environments**. Add
 other deployment protection rules if releases should require explicit approval. Do not add an npm
 token secret.
 
-Create a GitHub App that can write repository contents, install it on this repository, and allow the
-App to bypass the `main` branch rule for semantic-release's version commit. Configure these Actions
-values:
+Create a GitHub App that can write repository contents. Install the App on this repository. Allow
+the App to bypass the `main` branch rule for semantic-release's version commit. Configure these
+Actions values:
 
 - Repository variable `RELEASE_APP_ID`: the App ID.
 - Repository secret `RELEASE_APP_PRIVATE_KEY`: a private key generated for the App.
 
 The App token is necessary because GitHub suppresses new workflow runs for tags created with a
-workflow's built-in `GITHUB_TOKEN`. The App-created semantic-release tag is allowed to trigger the
-separate publish workflow. The tag workflow ignores semantic-release's own `chore(release)` commit,
-which prevents the version commit from starting another release calculation without suppressing the
-tag-triggered publish workflow.
+workflow's built-in `GITHUB_TOKEN`. The App-created semantic-release tag can trigger the separate
+publish workflow. The tag workflow ignores semantic-release's own `chore(release)` commit. This
+exclusion stops the version commit from starting another release calculation. The tag-triggered
+publish workflow still runs. That workflow triggers off the tag, not off the commit.
 
 ## Publishing a version
 
-1. Merge Conventional Commits to `main`: `fix:` creates a patch, `feat:` creates a minor, and a
-   breaking change creates a major release. Commits without a release-bearing type do not create a
-   tag.
-2. Confirm **Create semantic release tag** created a `chore(release)` commit with updated package and
-   lockfile versions, then tagged that exact commit.
-3. The tag automatically starts **Publish package**, which confirms `package.json` already matches
-   the tag, runs the checks and tests, creates the GitHub release notes, and publishes to npm.
-4. Approve the `npm` environment deployment if GitHub requests it.
-5. Confirm the workflow completed and verify the version and provenance badge on npmjs.com.
+1. Merge Conventional Commits to `main`.
+2. A `fix:` commit creates a patch release.
+3. A `feat:` commit creates a minor release.
+4. A breaking change creates a major release.
+5. Commits without a release-bearing type do not create a tag.
+6. Confirm **Create semantic release tag** created a `chore(release)` commit with the updated
+   versions.
+7. Confirm **Create semantic release tag** tagged that exact commit.
+8. The tag automatically starts **Publish package**.
+9. **Publish package** confirms that `package.json` already matches the tag.
+10. **Publish package** runs the checks and tests.
+11. **Publish package** creates the GitHub release notes.
+12. **Publish package** publishes the package to npm.
+13. Approve the `npm` environment deployment if GitHub requests approval.
+14. Confirm the workflow completed.
+15. Verify the version and provenance badge on npmjs.com.
 
-npm rejects publishing a version that already exists. If a workflow must be retried after npm
-accepted the package, publish a new version rather than rerunning the same release.
+npm rejects publishing a version that already exists. If npm already accepted the package, retry
+with a new version. Do not rerun the same release.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -15,8 +15,11 @@ The npm publish uses trusted publishing (OIDC). Trusted publishing does not need
 
 ## One-time npm setup
 
-The package does not exist on npm yet. A maintainer must bootstrap the package once before npm can
-attach a trusted publisher:
+Check `npm view textlint-rule-preset-ste-ai` first. An existing package means this section is
+already done.
+
+If the package has not been published to npm yet, a maintainer must bootstrap it once. This lets
+npm attach a trusted publisher:
 
 1. Sign in to npm with an account that owns the package name and has two-factor authentication
    enabled.


### PR DESCRIPTION
Part of a repo-wide pass making this project's own docs pass its own linter. Before: 20 errors. After: 0. Gave every numbered release step one instruction per sentence.

Verified: `node dist/cli/main.js lint docs/publishing.md --deterministic-only` → exit 0. `vp check --no-lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ukt8p4f3K9mX7FHWbMK17)_