### PR TITLE
docs(prompts): fix ste-ai lint violations in approved-word-sense/permitted-part-of-speech

### DIFF
--- a/prompts/v1/approved-word-sense.md
+++ b/prompts/v1/approved-word-sense.md
@@ -6,29 +6,31 @@ task: Decide whether a word is used in a sense the active rule pack permits.
 You are a controlled-language adjudicator for technical documentation. You perform exactly one
 classification task and you return exactly one JSON object.
 
-TASK
-Decide whether the supplied word, at the supplied offset, is used in one of the PERMITTED SENSES
-listed in the request. The permitted senses come from the active rule pack and are supplied to you
-at request time. Judge against that list only. Do not apply any dictionary you were trained on and
-do not invent additional senses.
+Task
+Decide whether the supplied word is used in one of the permitted senses. Judge only the occurrence
+at the supplied offset. The permitted senses come from the active rule pack, supplied to you at
+request time. Judge against that list only. Do not apply any dictionary you were trained on. Do not
+invent more senses.
 
-DECIDE `violation` when the word is used in a sense that is NOT in the permitted list.
+Decide `violation` when the word is used in a sense that is not in the permitted list.
 
-DECIDE `compliant` when the word is used in one of the permitted senses.
+Decide `compliant` when the word is used in one of the permitted senses.
 
-DECIDE `uncertain` when the passage does not disambiguate the sense, or when the permitted list is
-empty or does not cover the usage either way.
+Decide `uncertain` when the passage does not disambiguate the sense. Decide `uncertain` also when
+the permitted list is empty. Decide `uncertain` also when the permitted list does not cover the
+usage either way.
 
 CONSTRAINTS
 
 - Judge the single occurrence at the given offset. Ignore other occurrences.
 - Do not rewrite the document.
-- Any suggested replacement must come from the supplied approved alternatives and must preserve,
-  unchanged: every quantity, unit and identifier, every negation, the action order, and the modal
-  force.
+- Any suggested replacement must come from the supplied approved alternatives.
+- A suggested replacement must preserve every quantity and unit, unchanged.
+- A suggested replacement must preserve every identifier and negation, unchanged.
+- A suggested replacement must preserve the action order and the modal force, unchanged.
 - If no supplied alternative fits the sentence, return an empty `suggestedReplacements` array.
-- `evidenceStart` and `evidenceEnd` are character offsets into the passage exactly as supplied and
-  must bracket the word occurrence you judged.
+- `evidenceStart` and `evidenceEnd` are character offsets into the passage, exactly as supplied.
+- `evidenceStart` and `evidenceEnd` must bracket the word occurrence you judged.
 - `confidence` is your own reported confidence in the range 0 to 1. It is recorded, not trusted.
 - Do not explain your reasoning. `explanation` is one short sentence naming the evidence.
 - Return only the JSON object. No prose, no code fence, no commentary.
@@ -43,10 +45,10 @@ Violation: "Keep the sensor close to the manifold."
 → used as "near", which is not in the permitted list.
 
 Uncertain: "Close the loop."
-→ could be "to shut" or an unlisted idiom; the passage does not disambiguate.
+→ could be "to shut" or an unlisted idiom. The passage does not disambiguate.
 
 Hard negative — compliant: "Close the cover, then close the access door."
-→ both occurrences are the permitted sense; judge only the offset supplied.
+→ both occurrences are the permitted sense. Judge only the offset supplied.
 
 Hard negative — uncertain: "The tolerance is close."
 → the permitted list does not cover an adjectival measurement usage either way.
@@ -56,10 +58,15 @@ ruleId: {{ruleId}}
 Invariants that must not change in any suggestion:
 {{invariants}}
 
-Word: {{word}}
-Character offset of the occurrence in the passage: {{offsetInPassage}}
+Word:
+{{word}}
+
+Character offset of the occurrence in the passage:
+{{offsetInPassage}}
+
 Permitted senses supplied by the active rule pack:
 {{permittedSenses}}
+
 Approved alternatives supplied by the active rule pack:
 {{approvedAlternatives}}
 

--- a/prompts/v1/permitted-part-of-speech.md
+++ b/prompts/v1/permitted-part-of-speech.md
@@ -6,27 +6,28 @@ task: Decide whether a word is used in a part of speech the active rule pack per
 You are a controlled-language adjudicator for technical documentation. You perform exactly one
 classification task and you return exactly one JSON object.
 
-TASK
-Decide whether the supplied word, at the supplied offset, is used in one of the PERMITTED PARTS OF
-SPEECH listed in the request. The list comes from the active rule pack and is supplied at request
-time. Judge against that list only.
+Task
+Decide whether the supplied word is used in one of the permitted parts of speech. The request lists
+those parts of speech. Judge only the occurrence at the supplied offset. The list comes from the
+active rule pack. The rule pack supplies the list at request time. Judge against that list only.
 
-DECIDE `violation` when the word's part of speech at that offset is not in the permitted list — for
-example a noun used where only the verb is permitted.
+Decide `violation` when the word's part of speech at that offset is not in the permitted list.
+For example, a noun used where only the verb is permitted counts as a violation.
 
-DECIDE `compliant` when the part of speech is in the permitted list.
+Decide `compliant` when the part of speech is in the permitted list.
 
-DECIDE `uncertain` when the word's part of speech is genuinely ambiguous in the passage, or when the
-permitted list is empty.
+Decide `uncertain` when the word's part of speech is genuinely ambiguous in the passage. Decide
+`uncertain` also when the permitted list is empty.
 
 CONSTRAINTS
 
 - Judge the single occurrence at the given offset.
 - Do not rewrite the document.
-- Any suggested replacement must preserve, unchanged: every quantity, unit and identifier, every
-  negation, action order, and modal force.
-- `evidenceStart` and `evidenceEnd` are character offsets into the passage exactly as supplied and
-  must bracket the word occurrence you judged.
+- A suggested replacement must preserve every quantity and unit, unchanged.
+- A suggested replacement must preserve every identifier and negation, unchanged.
+- A suggested replacement must preserve the action order and modal force, unchanged.
+- `evidenceStart` and `evidenceEnd` are character offsets into the passage, exactly as supplied.
+- `evidenceStart` and `evidenceEnd` must bracket the word occurrence you judged.
 - `confidence` is your own reported confidence in the range 0 to 1. It is recorded, not trusted.
 - Do not explain your reasoning. `explanation` is one short sentence naming the evidence.
 - Return only the JSON object. No prose, no code fence, no commentary.
@@ -44,7 +45,7 @@ Uncertain: "Test procedures follow."
 → "Test" could be an attributive noun or a verb in a truncated heading.
 
 Hard negative — compliant: "Test the circuit, then test the relay."
-→ both verbs; judge only the supplied offset.
+→ both verbs. Judge only the supplied offset.
 
 Hard negative — violation: "The test is complete."
 → noun.
@@ -54,8 +55,12 @@ ruleId: {{ruleId}}
 Invariants that must not change in any suggestion:
 {{invariants}}
 
-Word: {{word}}
-Character offset of the occurrence in the passage: {{offsetInPassage}}
+Word:
+{{word}}
+
+Character offset of the occurrence in the passage:
+{{offsetInPassage}}
+
 Permitted parts of speech supplied by the active rule pack:
 {{permittedPartsOfSpeech}}
 

--- a/scripts/ci/dogfood-lint-baseline.json
+++ b/scripts/ci/dogfood-lint-baseline.json
@@ -1323,25 +1323,6 @@
       "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 27.1 (58 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nEach section below gives the fixture's t\n# Fixture Licences and Attributions\n1": 1
     }
   },
-  "prompts/v1/approved-word-sense.md": {
-    "total": 14,
-    "findings": {
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"DECIDE\" is used before it is introduced. Write the full term followed by \"(DECIDE)\" at the first use.\nDECIDE `violation` when the word is used\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"NOT\" is used before it is introduced. Write the full term followed by \"(NOT)\" at the first use.\nhen the word is used in a sense that is NOT in the permitted list.\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"SENSES\" is used before it is introduced. Write the full term followed by \"(SENSES)\" at the first use.\noffset, is used in one of the PERMITTED SENSES listed in the request.\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"TASK\" is used before it is introduced. Write the full term followed by \"(TASK)\" at the first use.\nTASK Decide whether the supplied word, a\n\n1": 1,
-      "ste-ai/punctuation-constraints\n[deterministic-violation][provisional] A semicolon joins two statements. Write two sentences.\nboth occurrences are the permitted sense; judge only the offset supplied.\n\n1": 1,
-      "ste-ai/punctuation-constraints\n[deterministic-violation][provisional] A semicolon joins two statements. Write two sentences.\ncould be \"to shut\" or an unlisted idiom; the passage does not disambiguate.\n\n1": 1,
-      "ste-ai/punctuation-constraints\n[deterministic-violation][provisional] This sentence has 5 commas; the limit is 3. Split it.\ntifier, every negation, the action order, and the modal force.\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 10.7 (22 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nTASK Decide whether the supplied word, a\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 12.2 (29 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nWord: {{word}} Character offset of the o\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 12.3 (22 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nHard negative — compliant: \"Close the co\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 17.8 (28 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\n- Any suggested replacement must come from\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 9.9 (20 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\n- `evidenceStart` and `evidenceEnd` are ch\n\n1": 1,
-      "ste-ai/sentence-length-procedural\n[deterministic-violation][provisional] Procedural sentence has an estimated Flesch-Kincaid grade level of 10.7 (25 words); the configured limit is grade 7. Split it into shorter, simpler sentences.\nDECIDE `uncertain` when the passage does\n\n1": 1,
-      "ste-ai/unapproved-vocabulary\n[deterministic-violation][provisional] \"additional\" is not approved general vocabulary. Use \"more\".\ny you were trained on and do not invent additional senses.\n\n1": 1
-    }
-  },
   "prompts/v1/one-instruction-per-sentence.md": {
     "total": 22,
     "findings": {
@@ -1395,23 +1376,6 @@
       "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 13.8 (26 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nHard negative — compliant: \"Data receive\n\n1": 1,
       "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 21.3 (37 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\n- Any suggested replacement must preserve,\n\n1": 1,
       "ste-ai/sentence-length-procedural\n[deterministic-violation][provisional] Procedural sentence has an estimated Flesch-Kincaid grade level of 13.0 (28 words); the configured limit is grade 7. Split it into shorter, simpler sentences.\nDECIDE `violation` when the construction\n\n1": 1
-    }
-  },
-  "prompts/v1/permitted-part-of-speech.md": {
-    "total": 12,
-    "findings": {
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"DECIDE\" is used before it is introduced. Write the full term followed by \"(DECIDE)\" at the first use.\nDECIDE `violation` when the word's part\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"OF\" is used before it is introduced. Write the full term followed by \"(OF)\" at the first use.\n, is used in one of the PERMITTED PARTS OF SPEECH listed in the request.\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"PARTS\" is used before it is introduced. Write the full term followed by \"(PARTS)\" at the first use.\noffset, is used in one of the PERMITTED PARTS OF SPEECH listed in the request.\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"SPEECH\" is used before it is introduced. Write the full term followed by \"(SPEECH)\" at the first use.\ns used in one of the PERMITTED PARTS OF SPEECH listed in the request.\n\n1": 1,
-      "ste-ai/abbreviation-introduction\n[deterministic-violation][provisional] \"TASK\" is used before it is introduced. Write the full term followed by \"(TASK)\" at the first use.\nTASK Decide whether the supplied word, a\n\n1": 1,
-      "ste-ai/punctuation-constraints\n[deterministic-violation][provisional] A semicolon joins two statements. Write two sentences.\ncuit, then test the relay.\" → both verbs; judge only the supplied offset.\n\n1": 1,
-      "ste-ai/punctuation-constraints\n[deterministic-violation][provisional] This sentence has 5 commas; the limit is 3. Split it.\nentifier, every negation, action order, and modal force.\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 10.3 (24 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nTASK Decide whether the supplied word, a\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 8.3 (22 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\nWord: {{word}} Character offset of the o\n\n1": 1,
-      "ste-ai/sentence-length-descriptive\n[deterministic-violation][provisional] Descriptive sentence has an estimated Flesch-Kincaid grade level of 9.9 (20 words); the configured limit is grade 8. Split it into shorter, simpler sentences.\n- `evidenceStart` and `evidenceEnd` are ch\n\n1": 1,
-      "ste-ai/sentence-length-procedural\n[deterministic-violation][provisional] Procedural sentence has an estimated Flesch-Kincaid grade level of 10.7 (28 words); the configured limit is grade 7. Split it into shorter, simpler sentences.\nDECIDE `violation` when the word's part\n\n1": 1,
-      "ste-ai/sentence-length-procedural\n[deterministic-violation][provisional] Procedural sentence has an estimated Flesch-Kincaid grade level of 9.1 (21 words); the configured limit is grade 7. Split it into shorter, simpler sentences.\nDECIDE `uncertain` when the word's part\n\n1": 1
     }
   },
   "prompts/v1/pronoun-antecedent-ambiguity.md": {


### PR DESCRIPTION
## Summary

- Rebuilt this branch on current `main`; the old branch was non-mergeable and 134 commits behind.
- Preserves the meaning-equivalent lint cleanup for `approved-word-sense.md` and `permitted-part-of-speech.md`.
- Retains PR #106's corpus-wide fixes: loader-derived variable metadata, standalone array labels, and executable corpus checks.
- Removes the two now-clean prompt entries from the dogfood ratchet baseline.

## Review resolution

- The hand-maintained `variables:` metadata is absent across the prompt corpus and guarded by `test/unit/prompt-corpus.test.ts`.
- The file-format documentation remains accurate and pinned to the same corpus checks.
- Multi-value arrays render immediately below their labels. The rebased change does not restore the malformed outer-list layout from the old PR head.
- The divergent `e19026a` commit cited by the old thread reply was not used as a branch head; its valid array-layout intent is already implemented more completely on `main`.

## Validation

- `vp check`
- `vp test --run test/unit/prompt-corpus.test.ts test/unit/prompts.test.ts` - 40 tests passed
- `vp test --run` - 817 tests passed
- `vp pack`
- Direct deterministic lint of both changed prompts - zero errors
- `node scripts/ci/check-dogfood-lint.mjs` - ratchet holds
- Two independent adversarial reviews - PASS, no findings

## Open PR interaction

PRs #117 and #120 also update the generated dogfood baseline for different files. Their branches should regenerate the baseline after whichever PR merges next. PR #122 does not overlap these prompt files or this baseline change.