### PR TITLE
docs(rule-authoring): fix ste-ai lint violations

### DIFF
--- a/docs/rule-authoring.md
+++ b/docs/rule-authoring.md
@@ -9,9 +9,10 @@ This is the only architecturally significant question.
   semantic evaluator, and let it degrade to `review-required` when adjudication is off.
 
 Getting this wrong is the most damaging mistake available. A heuristic reported as
-`deterministic-violation` tells a reader the tool is certain when it is not, and in a safety-relevant
-document that is worse than saying nothing. Every rule that depends on the procedural/descriptive
-classifier, on part of speech, or on meaning belongs in the second category.
+`deterministic-violation` tells a reader the tool is certain when it is not. In a safety-relevant
+document, false certainty is worse than saying nothing. Every rule that depends on the procedural or
+descriptive classifier belongs in the second category. So does any rule that depends on part of
+speech, or on meaning.
 
 ## Skeleton
 
@@ -64,38 +65,40 @@ export const myRule: DeterministicRule<z.output<typeof optionsSchema>> = {
 };
 ```
 
-Register it in `src/deterministic/index.ts` — **append**, do not sort; array order is the run order and
-is part of the tool's deterministic behaviour. Add a `rules[]` entry to
-`src/rule-pack/provisional-pack.ts`, and a section in `docs/provisional-rules.md` matching your
-`sourceRef` anchor.
+Register it in `src/deterministic/index.ts`. **Append** the entry. Do not sort the array. Array order
+is the run order. Array order is also part of the tool's deterministic behaviour. Add a `rules[]`
+entry to `src/rule-pack/provisional-pack.ts`. Also add a section in `docs/provisional-rules.md`
+matching your `sourceRef` anchor.
 
 ## Put every option constraint in the schema, including the ones between fields
 
-The runner validates a rule's options with `optionsSchema.safeParse` before calling `run`, and a
-failure is reported as a `rule-options-invalid` notice that skips only that rule. Nothing wraps
-`run` itself, so a constraint the schema does not express becomes an exception that aborts the
-analysis of the whole document.
+The runner validates a rule's options with `optionsSchema.safeParse` before calling `run`. A failure
+is reported as a `rule-options-invalid` notice that skips only that rule. Nothing wraps `run` itself.
+A constraint the schema does not express becomes an exception. That exception aborts the analysis of
+the whole document.
 
 Per-field `min`/`max` does not cover a constraint that holds _between_ two fields. A pair of bounds
-combined into a range, a regular-expression `{min,max}` quantifier, a slice, or an index needs a
-`.refine()` on the object as well — `abbreviation-introduction` in
-`src/deterministic/rules/mechanics.ts` is the worked example: `{ minLength: 8, maxLength: 3 }`
-satisfies both fields' ranges, and before the refinement it parsed and then threw
-`numbers out of order in {} quantifier` from the `RegExp` constructor (issue #6). Give the
-refinement a `path` so the notice names the offending option.
+combined into a range needs a `.refine()` on the object as well. So does a regular-expression
+`{min,max}` quantifier, a slice, or an index. `abbreviation-introduction` in
+`src/deterministic/rules/mechanics.ts` is the worked example. Its options
+`{ minLength: 8, maxLength: 3 }` satisfy both fields' individual ranges. Before the refinement
+existed, those options still parsed. Then they threw `numbers out of order in {} quantifier` from the
+`RegExp` constructor (issue #6). Give the refinement a `path` so the notice names the offending
+option.
 
 ## Rules you do not implement yourself
 
-The runner applies these after your rule returns, so do not attempt them:
+The runner applies these after your rule returns, so do not try them:
 
-| Do not                              | Because                                                                   |
-| ----------------------------------- | ------------------------------------------------------------------------- |
-| set `severity`                      | `buildDiagnostic()` applies the policy; the runner applies user overrides |
-| check whether a span is protected   | the runner drops diagnostics that point only at protected content         |
-| decide whether a fix may be applied | `gateFix()` runs on every fix, unconditionally                            |
-| suppress `review-required`          | the diagnostic policy decides                                             |
-| call `fetch` or read files          | the boundary test forbids I/O in `src/deterministic`                      |
-| sort or de-duplicate output         | the runner sorts by (start, end, ruleId)                                  |
+| Do not                              | Because                                                                       |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| set `severity`                      | `buildDiagnostic()` applies the policy, and the runner applies user overrides |
+| check whether a span is protected   | the runner drops diagnostics that point only at protected content             |
+| decide whether a fix may be applied | `gateFix()` runs on every fix, unconditionally                                |
+| suppress `review-required`          | the diagnostic policy decides                                                 |
+| call `fetch` or read files          | the boundary test forbids input or output operations in `src/deterministic`   |
+| sort the output                     | the runner sorts by (start, end, ruleId)                                      |
+| de-duplicate the output             | the runner's sort produces one deterministic order on its own                 |
 
 ## Reading text correctly
 
@@ -108,31 +111,44 @@ The runner applies these after your rule returns, so do not attempt them:
 | raw source for a span                  | `doc.text.slice(start, end)`      | offsets are always absolute                                          |
 | a limit or a word list                 | `pack.limits`, `pack.dictionary`  | never hard-code vocabulary                                           |
 
-Never run a regex over `doc.text`. Use `sentence.masked` or `doc.maskedText`; that is what keeps code,
-URLs, identifiers and quantities from being read as prose.
+Never run a regex over `doc.text`. Use `sentence.masked` or `doc.maskedText`. That is what keeps
+code, URLs, identifiers, and quantities from being read as prose.
 
-That contract — read only `sentence.masked` and `sentence.words`, never `doc.text` — is what stays
-stable while the document-reading layer is rearchitected
+That contract — read only `sentence.masked` and `sentence.words`, never `doc.text` — stays stable. It
+holds even while the document-reading layer is rearchitected
 ([issue #25](https://github.com/Jamie-BitFlight/textlint-ASD-ai/issues/25)). A rule that only touches
-already-masked, sentence-level data does not depend on whether a block came from the current regex
-scanner or a future parser-backed reader.
+already-masked, sentence-level data does not depend on the document-reading layer's implementation. It
+behaves the same whether a block came from the current regex scanner or a future parser-backed
+reader.
 
 ## Offering a fix
 
-Set `meta.fixable: true` and attach a `TextFix`. Then expect it to be refused, and make sure the
-diagnostic is still useful without it — the message gains a parenthetical explaining the refusal.
+Set `meta.fixable: true` and attach a `TextFix`. Then expect it to be refused. Make sure the
+diagnostic is still useful without the fix — the message gains a parenthetical explaining the
+refusal.
 
-A fix survives only if it changes no digit, no negation, no modal verb and no ordering word
-(`checkFixSafety`), is outside every admonition, does not overlap a protected region, and does not
-overlap another rule's fix. Two rules disagreeing about the same characters causes **both** fixes to
-be refused.
+A fix survives only if it meets every one of these conditions:
+
+- It changes no digit, no negation, no modal verb, and no ordering word (`checkFixSafety`).
+- It is outside every admonition.
+- It does not overlap a protected region.
+- It does not overlap another rule's fix.
+
+Two rules disagreeing about the same characters causes **both** fixes to be refused.
 
 For a fix driven by pack data, gate it on the pack's own `safeSubstitution` flag and say so in
 `rationale`. Never infer that a substitution is safe.
 
-Rules that must not offer a fix at all: anything touching quantities, tolerances, commands,
-identifiers, procedural order, modal verbs, ambiguous references, or safety-sensitive content. That is
-policy, not preference — see [`diagnostic-policy.md`](./diagnostic-policy.md#autofix-policy).
+Some rule categories must never offer a fix at all:
+
+- anything touching quantities or tolerances
+- commands or identifiers
+- procedural order
+- modal verbs
+- ambiguous references
+- safety-sensitive content
+
+That is policy, not preference — see [`diagnostic-policy.md`](./diagnostic-policy.md#autofix-policy).
 
 ## Emitting a candidate instead
 
@@ -152,23 +168,22 @@ candidates.push({
 });
 ```
 
-`payload` is the redaction mechanism: `buildEvaluatorRequest()` transmits only the keys the evaluator
-declares in `payloadKeys` and throws if the prompt references a key the evaluator does not declare.
-Extra keys are dropped, and there is a test asserting an internal note in a payload never reaches the
-model.
+`payload` is the redaction mechanism. `buildEvaluatorRequest()` transmits only the keys the evaluator
+declares in `payloadKeys`. It throws if the prompt references a key the evaluator does not declare.
+Extra keys are dropped. A test asserts that an internal note in a payload never reaches the model.
 
-Use `sentence.masked` for `passage`, not `sentence.raw`, unless the evaluator genuinely needs the
-literals and you have thought about what that transmits.
+Use `sentence.masked` for `passage`. Do not use `sentence.raw`, except when the evaluator genuinely
+needs the literals. Before you do, think about what that transmits.
 
 ## Tests a rule needs
 
 `test/unit/rules.test.ts` has a `describe` block per rule. A new rule needs, at minimum:
 
-1. **positive** — the violation is found, and the reported span quotes the right text;
-2. **negative** — the near-miss case is _not_ found;
-3. **protected content** — the same wording inside inline code, a fence, a URL or a path is ignored;
-4. **options** — each option changes behaviour, and `{}` parses;
-5. **fix** — the fix text is exact, and the refusal cases produce no fix;
+1. **positive** — the violation is found, and the reported span quotes the right text.
+2. **negative** — the near-miss case is _not_ found.
+3. **protected content** — the same wording inside inline code, a fence, a URL, or a path is ignored.
+4. **options** — each option changes behaviour, and `{}` parses.
+5. **fix** — the fix text is exact, and the refusal cases produce no fix.
 6. **admonition** — nothing is fixed inside a warning.
 
 Then check the corpus-wide invariants still hold:
@@ -178,8 +193,8 @@ vp test test/fixtures      # no diagnostic lands in a code fence; no fix lands i
 vp test test/architecture  # boundaries intact
 ```
 
-If your rule fires on the `hard-negative` fixtures, that is a signal to investigate before shipping —
-those excerpts were selected because a naive linter flags them wrongly.
+If your rule fires on the `hard-negative` fixtures, investigate before shipping. Those excerpts were
+selected because a naive linter flags them wrongly.
 
 ## Honesty requirements
 


### PR DESCRIPTION
Part of a repo-wide pass making this project's own docs pass its own linter. Before: 31 errors. After: 0. Verified the fix-safety/de-duplication claims against `src/core/runner.ts` before phrasing them, and fixed inconsistent list-item terminal punctuation in `test/unit/rules.test.ts`'s referenced numbered list.

Verified: `node dist/cli/main.js lint docs/rule-authoring.md --deterministic-only` → exit 0. `vp check --no-lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ukt8p4f3K9mX7FHWbMK17)_