### PR TITLE
test(evaluation): audit evaluation.test.ts (N14) — positive controls, recall/F1 withholding coverage

### DIFF
--- a/test/unit/evaluation.test.ts
+++ b/test/unit/evaluation.test.ts
@@ -350,6 +350,10 @@ describe('recall/F1 withholding below the gold-positive floor', () => {
     // The withheld cell reports the count, not the computed ratio -- `recall` above is a real
     // number (0.75), so its formatted form appearing here would mean the withholding never applied.
     expect(text).not.toContain('0.750');
+    // f1Cell is withheld by the same condition as recallCell, but independently -- a regression
+    // that withholds recall correctly while still printing F1's own number (0.774) would satisfy
+    // every assertion above.
+    expect(text).not.toContain('0.774');
   });
 
   it('reports recall and F1 as numbers exactly at the threshold', () => {

--- a/test/unit/evaluation.test.ts
+++ b/test/unit/evaluation.test.ts
@@ -6,6 +6,9 @@ import {
   evaluateSemanticEvaluators,
   formatEvaluationReport,
   goldLabelFor,
+  MIN_POSITIVES_FOR_RECALL,
+  type EvaluationReport,
+  type EvaluatorMetrics,
 } from '../../src/evaluation/evaluate.js';
 import type { Annotation } from '../../src/fixture-tools/annotation-schema.js';
 import { fixtureManifestSchema } from '../../src/fixture-tools/manifest-schema.js';
@@ -239,7 +242,11 @@ describe('evaluation run', () => {
       config: { semantic: { enabled: true, cache: false, maxRepairAttempts: 0 } },
       transport,
     });
-    if (report.cases.length === 0) return;
+    // Positive control: the heldout fixtures really do produce candidates for this scripted
+    // transport to fail on. Without this, an early return on an empty result (the shape this test
+    // used to have) would let the fixture corpus shrink to zero heldout candidates and this test
+    // would keep passing while asserting nothing.
+    expect(report.cases.length).toBeGreaterThan(0);
     expect(report.overall.failureRate).toBeGreaterThan(0);
     expect(report.cases.every((c) => c.prediction === 'failed')).toBe(true);
   });
@@ -264,6 +271,9 @@ describe('evaluation run', () => {
     });
     const m = report.overall;
     const decided = m.truePositives + m.falsePositives + m.trueNegatives + m.falseNegatives;
+    // Positive control: at least one case really was decided, so the inequality below is not
+    // vacuously satisfied by every count being zero.
+    expect(decided).toBeGreaterThan(0);
     expect(decided).toBeLessThanOrEqual(m.labelled);
     expect(m.labelled + m.unlabelled).toBe(report.cases.length);
   });
@@ -290,6 +300,64 @@ describe('evaluation run', () => {
       transport,
     });
     expect(transport.requests).toHaveLength(0);
+  });
+});
+
+function metrics(overrides: Partial<EvaluatorMetrics> = {}): EvaluatorMetrics {
+  return {
+    evaluatorId: 'passive-voice-adjudication',
+    truePositives: 0,
+    falsePositives: 0,
+    trueNegatives: 0,
+    falseNegatives: 0,
+    precision: 0.8,
+    recall: 0.75,
+    f1: 0.774,
+    uncertainRate: 0,
+    failureRate: 0,
+    unlabelled: 0,
+    labelled: 20,
+    goldPositives: 20,
+    goldNegatives: 0,
+    latencyMs: { p50: 0, p90: 0, p99: 0, mean: 0 },
+    ...overrides,
+  };
+}
+
+function buildReport(perEvaluator: readonly EvaluatorMetrics[]): EvaluationReport {
+  const overall = perEvaluator[0];
+  if (overall === undefined) throw new Error('at least one evaluator required');
+  return {
+    split: 'heldout',
+    model: 'm',
+    promptVersion: 'v1',
+    endpoint: 'http://x',
+    generatedAt: new Date(0).toISOString(),
+    fixtures: ['f'],
+    overall,
+    perEvaluator,
+    cases: [],
+  };
+}
+
+describe('recall/F1 withholding below the gold-positive floor', () => {
+  it('withholds recall and F1 just below the threshold', () => {
+    const m = metrics({ goldPositives: MIN_POSITIVES_FOR_RECALL - 1 });
+    const text = formatEvaluationReport(buildReport([m]));
+    expect(text).toContain(
+      `recall withheld for ${m.evaluatorId}: ${MIN_POSITIVES_FOR_RECALL - 1} gold positive(s)`,
+    );
+    // The withheld cell reports the count, not the computed ratio -- `recall` above is a real
+    // number (0.75), so its formatted form appearing here would mean the withholding never applied.
+    expect(text).not.toContain('0.750');
+  });
+
+  it('reports recall and F1 as numbers exactly at the threshold', () => {
+    const m = metrics({ goldPositives: MIN_POSITIVES_FOR_RECALL, recall: 0.75, f1: 0.774 });
+    const text = formatEvaluationReport(buildReport([m]));
+    expect(text).not.toContain(`recall withheld for ${m.evaluatorId}`);
+    expect(text).toContain('0.750');
+    expect(text).toContain('0.774');
   });
 });
 


### PR DESCRIPTION
## What

N14 from the original vitest-suite-quality-perf plan (PR #77): `test/unit/evaluation.test.ts` was the third-largest file in the measured baseline (4.6s, 19 tests) but no audit had covered it before that PR merged. This is the deferred follow-up.

## Findings and fixes

**Two assertions that could pass vacuously:**
- `'reports a failure rate rather than silently dropping failed requests'` had an early `return` when `report.cases.length === 0`. A probe script against the real heldout fixtures confirmed this is currently a *latent* hazard, not a live no-op (cases.length is always 52 today) — but a shrunk fixture corpus would silently make this test assert nothing. Replaced the early return with an explicit `expect(report.cases.length).toBeGreaterThan(0)` positive control.
- `'excludes unlabelled candidates from the confusion matrix'` asserted `decided <= labelled` without ever proving `decided > 0`. Added that positive control.

**The larger gap — zero coverage of `MIN_POSITIVES_FOR_RECALL`:** this constant and the report-formatting logic that withholds recall/F1 below it is the module's own stated reason for existing (see its docblock and the `EvaluatorMetrics.goldPositives` comment: "recall computed over three positives is a ratio, not a measurement"). A probe against the real heldout fixtures showed `goldPositives` of 0/1/1/2 per evaluator — every real run trips this withholding — yet no test exercised it.

Added two tests built directly against hand-crafted `EvaluatorMetrics`/`EvaluationReport` values (both already-exported types, so no need to drive fixtures to an artificial 10+ gold positives): one just below the threshold (withheld), one exactly at it (reported as numbers). This pins the exact boundary.

## Verification

- Mutated the withholding condition (`goldPositives < MIN_POSITIVES_FOR_RECALL` → `<=`) and confirmed the new boundary test fails, then reverted — `git diff --stat src/` is empty.
- `vp check`: clean.
- `vp test`: 641/641 passing (30 files), up from 639 on `main`.

## Test plan
- [x] `vp check` passes
- [x] `vp test` passes (full suite)
- [x] Mutation-verified the new boundary assertions against the withholding condition they cover


---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVxydRFLKJVt6L6TYaxiK)_