### PR TITLE
docs(rule-pack): pin the extension point's behaviour instead of describing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,6 @@ jobs:
 
       - name: Confirm the pre-commit hook manifest is shaped correctly and still works
         run: scripts/ci/check-pre-commit-hook-manifest.sh
+
+      - name: Confirm the worked rule-pack example still prints what its README quotes
+        run: scripts/ci/check-rule-pack-example.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,37 @@ scripts, and documentation, not just adding new ones; a task that changes behavi
 a test, or a `scripts/ci/*.sh` check describing the old behavior in place is incomplete, not
 finished-with-a-follow-up.
 
+## A doc that describes runtime behaviour needs an executable pin, not a careful sentence
+
+Prose cannot fail a build. A page that asserts what the code does is unfalsifiable by CI, so it
+drifts, and the drift is found one claim at a time by whoever reads both sides — usually external
+review, usually several rounds late.
+
+PR #90 is the worked example. It set out to fix lint violations in `docs/rule-pack-import.md` and
+turned into three rounds and six P2 findings, every one of the form "the prose asserts X, the code
+does Y". No round changed any code. Each prose correction was itself unverified, so rounds 2 and 3
+were largely _caused_ by the fix applied in the round before. The root cause was not carelessness:
+the rule-pack extension point had no test coverage at all, and the same false claim was duplicated
+across `docs/rule-pack-import.md`, `README.md` and a doc comment in `src/rule-pack/schema.ts`, so
+correcting one left two.
+
+Therefore, when a change touches a doc that describes behaviour:
+
+- **Pin the claim, do not just reword it.** `test/integration/rule-pack.test.ts` is the model: it
+  exists to make documentation claims fail CI, not to prove a module works.
+- **Generate any exhaustive list.** "It controls only X, Y and Z" goes stale the next time the
+  schema grows a field, and answering that finding in prose buys exactly one round. Derive it and
+  assert it, as `test/architecture/doc-pack-control-surface.test.ts` does.
+- **Grep for the claim before fixing it in one place.** A behavioural assertion is usually
+  duplicated across `README.md`, `docs/`, and a doc comment near the code.
+- **Verify the replacement claim empirically before writing it.** Run the thing. Both the original
+  doc and PR #90's correction of it stated the pack/hard-coded-vocabulary boundary wrongly, in
+  opposite directions, and a five-line probe settled it.
+
+When review findings stop converging — each fix drawing a new or reshaped one — that is the signal
+that the artefact under review is the wrong one. Stop editing the prose and go fix what makes the
+prose unverifiable.
+
 ## Agents share this session's rate limit — retry, don't substitute
 
 A subagent's session/token-limit failure is retryable, not a real task failure — it shares this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,19 +20,7 @@ finished-with-a-follow-up.
 
 ## A doc that describes runtime behaviour needs an executable pin, not a careful sentence
 
-Prose cannot fail a build. A page that asserts what the code does is unfalsifiable by CI, so it
-drifts, and the drift is found one claim at a time by whoever reads both sides — usually external
-review, usually several rounds late.
-
-PR #90 is the worked example. It set out to fix lint violations in `docs/rule-pack-import.md` and
-turned into three rounds and six P2 findings, every one of the form "the prose asserts X, the code
-does Y". No round changed any code. Each prose correction was itself unverified, so rounds 2 and 3
-were largely _caused_ by the fix applied in the round before. The root cause was not carelessness:
-the rule-pack extension point had no test coverage at all, and the same false claim was duplicated
-across `docs/rule-pack-import.md`, `README.md` and a doc comment in `src/rule-pack/schema.ts`, so
-correcting one left two.
-
-Therefore, when a change touches a doc that describes behaviour:
+When a change touches a doc that describes behaviour:
 
 - **Pin the claim, do not just reword it.** `test/integration/rule-pack.test.ts` is the model: it
   exists to make documentation claims fail CI, not to prove a module works.
@@ -41,9 +29,7 @@ Therefore, when a change touches a doc that describes behaviour:
   assert it, as `test/architecture/doc-pack-control-surface.test.ts` does.
 - **Grep for the claim before fixing it in one place.** A behavioural assertion is usually
   duplicated across `README.md`, `docs/`, and a doc comment near the code.
-- **Verify the replacement claim empirically before writing it.** Run the thing. Both the original
-  doc and PR #90's correction of it stated the pack/hard-coded-vocabulary boundary wrongly, in
-  opposite directions, and a five-line probe settled it.
+- **Verify the replacement claim empirically before writing it.** Run the thing.
 
 When review findings stop converging — each fix drawing a new or reshaped one — that is the signal
 that the artefact under review is the wrong one. Stop editing the prose and go fix what makes the

--- a/README.md
+++ b/README.md
@@ -301,19 +301,26 @@ See [`docs/fixtures.md`](docs/fixtures.md).
 
 ## Supplying authorised material
 
-`src/rule-pack/` is the single import boundary. No rule hard-codes vocabulary. The active pack
-supplies:
+`src/rule-pack/` is the single import boundary. The active pack supplies:
 
 - limits
 - word lists
 - term mappings
 - contractions
-- per-rule authority
+- protected technical terms
+- per-rule authority, severity, and default options
 
 Supply a licensed pack, and diagnostics report its authority and citations instead of `provisional`.
+The pack must also be named in `trustedRulePackIds` first. Until then its declared authority is
+capped at `supplementary`.
 
-A pack cannot add a rule. A pack cannot bypass the autofix gate. A pack cannot make the linter print a
-conformance claim. See [`docs/rule-pack-import.md`](docs/rule-pack-import.md).
+Some rules hold trigger vocabulary in code, which no pack field can add to. A pack cannot add a
+rule. A pack cannot bypass the autofix gate. A pack cannot make the linter print a conformance
+claim unless it is trusted, normative, and declares one.
+
+Want to see this work? [`examples/rule-pack/`](examples/rule-pack/) is a complete worked pack. The
+full field list and the exact status rules are in
+[`docs/rule-pack-import.md`](docs/rule-pack-import.md).
 
 ## Development
 

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -5,8 +5,9 @@ package. The active pack supplies the controlled-language dictionary and the num
 Supplying licensed data therefore changes that behaviour without changing a line of rule code.
 
 Do you want to see a pack work before you write one? [`examples/rule-pack/`](../examples/rule-pack/)
-is a complete worked pack with commands that show the same document linted twice. It is linted once
-under the bundled pack, then once under the custom pack.
+is a complete worked pack. It lints the same document under the bundled pack. Then it lints the
+same document under a custom pack, and under that same pack once trusted. See its README for the
+trust gate's effect on each run.
 
 Every behaviour this page describes has a passing assertion in
 [`test/integration/rule-pack.test.ts`](../test/integration/rule-pack.test.ts). That file covers:
@@ -14,14 +15,14 @@ Every behaviour this page describes has a passing assertion in
 - the trust gate.
 - the status split between deterministic and candidate rules.
 - `limits`, `contractions`, and `approvedTechnicalTerms`.
-- per-rule overrides.
+- per-rule `severity`, `enabled`, and `options` — each a default the user's own configuration
+  outranks.
 - relative-path resolution against `baseDir`.
 - pack validation.
 - the autofix gate's refusal of a pack-declared-safe fix.
 
-It does not assert every combination. One limit field stands in for all five. One contraction
-stands in for the mechanism. Read that file when you need the exact answer rather than the
-summary.
+It does not assert every combination. One `limits` field stands in for the mechanism, and so does
+one `contractions` entry. Read that file when you need the exact answer rather than the summary.
 
 ## What a pack controls
 

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -8,9 +8,20 @@ Do you want to see a pack work before you write one? [`examples/rule-pack/`](../
 is a complete worked pack with commands that show the same document linted twice. It is linted once
 under the bundled pack, then once under the custom pack.
 
-Every behaviour this page describes is pinned by
-[`test/integration/rule-pack.test.ts`](../test/integration/rule-pack.test.ts). Read that file when
-you need the exact answer rather than the summary.
+Every behaviour this page describes has a passing assertion in
+[`test/integration/rule-pack.test.ts`](../test/integration/rule-pack.test.ts). That file covers:
+
+- the trust gate.
+- the status split between deterministic and candidate rules.
+- `limits`, `contractions`, and `approvedTechnicalTerms`.
+- per-rule overrides.
+- relative-path resolution against `baseDir`.
+- pack validation.
+- the autofix gate's refusal of a pack-declared-safe fix.
+
+It does not assert every combination. One limit field stands in for all five. One contraction
+stands in for the mechanism. Read that file when you need the exact answer rather than the
+summary.
 
 ## What a pack controls
 

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -124,8 +124,9 @@ falls back to the provisional pack silently.
     "version": "3.1.0",
 
     // 'normative' asserts that this pack carries the rule data of a standard AND that you are
-    // licensed to supply it. The linter never sets this itself. It becomes the `ruleStatus` on
-    // every diagnostic and replaces the `[provisional]` tag in messages.
+    // licensed to supply it. The linter never sets this itself. It is capped at `supplementary`
+    // until the operator trusts this pack. See "The trust gate" and "What status a diagnostic
+    // reports" below for what it becomes on each rule path once trusted.
     "authority": "normative",
 
     "licence": "Proprietary — Acme internal use only, licence AC-2026-004",

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -21,23 +21,53 @@ A pack changes only what the schema exposes. Do not edit the table below by hand
 
 <!-- pack-control-surface:begin -->
 
-| Field                    | What it controls                                                      |
-| ------------------------ | --------------------------------------------------------------------- |
-| `approvedTechnicalTerms` | Literal names protected from matching, rewriting, and the heuristics. |
-| `contractions`           | The contraction expansions `no-contractions` offers.                  |
-| `dictionary`             | The controlled-language word lists.                                   |
-| `dictionary.approved`    | Terms whose permitted sense the semantic evaluators may check.        |
-| `dictionary.preferred`   | Term mappings `preferred-terminology` reports.                        |
-| `dictionary.unapproved`  | Terms `unapproved-vocabulary` reports, with their alternatives.       |
-| `limits`                 | The numeric thresholds. Grade levels, cluster length, step count.     |
-| `metadata`               | Identity, declared authority, licence, and the conformance claim.     |
-| `rules`                  | Per-rule authority and defaults.                                      |
-| `rules[].enabled`        | Whether the rule runs at all.                                         |
-| `rules[].options`        | Default options, below anything the user configures.                  |
-| `rules[].ruleId`         | Which registered rule the entry applies to.                           |
-| `rules[].severity`       | Default severity, below anything the user configures.                 |
-| `rules[].sourceRef`      | The citation a deterministic diagnostic reports.                      |
-| `rules[].status`         | The authority a deterministic diagnostic reports.                     |
+| Field                                      | What it controls                                                                             |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `approvedTechnicalTerms`                   | Literal names protected from matching, rewriting, and the heuristics.                        |
+| `contractions`                             | The contraction expansions `no-contractions` offers.                                         |
+| `contractions[].from`                      | The contraction.                                                                             |
+| `contractions[].note`                      | Optional context shown with the diagnostic.                                                  |
+| `contractions[].safeSubstitution`          | True only if the expansion is always safe to autofix.                                        |
+| `contractions[].to`                        | The expansion.                                                                               |
+| `dictionary`                               | The controlled-language word lists.                                                          |
+| `dictionary.approved`                      | Terms whose permitted sense the semantic evaluators may check.                               |
+| `dictionary.approved[].partsOfSpeech`      | Optional. Parts of speech the approval covers.                                               |
+| `dictionary.approved[].senses`             | Optional. Senses the approval covers.                                                        |
+| `dictionary.approved[].term`               | The approved term.                                                                           |
+| `dictionary.preferred`                     | Term mappings `preferred-terminology` reports.                                               |
+| `dictionary.preferred[].from`              | The discouraged term.                                                                        |
+| `dictionary.preferred[].note`              | Optional context shown with the diagnostic.                                                  |
+| `dictionary.preferred[].safeSubstitution`  | True only if the substitution is always safe.                                                |
+| `dictionary.preferred[].to`                | The preferred term.                                                                          |
+| `dictionary.unapproved`                    | Terms `unapproved-vocabulary` reports, with their alternatives.                              |
+| `dictionary.unapproved[].alternatives`     | Terms the diagnostic suggests instead.                                                       |
+| `dictionary.unapproved[].note`             | Optional context shown with the diagnostic.                                                  |
+| `dictionary.unapproved[].partOfSpeech`     | Optional. The part of speech this entry covers.                                              |
+| `dictionary.unapproved[].safeSubstitution` | True only if `alternatives[0]` cannot change technical meaning. Gates autofix.               |
+| `dictionary.unapproved[].term`             | The unapproved term.                                                                         |
+| `limits`                                   | The numeric thresholds. Grade levels, cluster length, step count.                            |
+| `limits.descriptiveMaxGradeLevel`          | As above, for descriptive sentences.                                                         |
+| `limits.maxNounClusterLength`              | Word-count limit `noun-cluster-candidate` reports.                                           |
+| `limits.maxSentencesPerProceduralStep`     | Sentence-count limit `list-instruction-structure` reports per numbered step.                 |
+| `limits.proceduralMaxGradeLevel`           | Grade level above which a procedural sentence is reported.                                   |
+| `limits.sentenceReadabilityFloorWords`     | Sentences shorter than this are never grade-scored.                                          |
+| `metadata`                                 | Identity, declared authority, licence, and the conformance claim.                            |
+| `metadata.authority`                       | The pack's declared authority. Capped at `supplementary` until the operator trusts the pack. |
+| `metadata.conformanceClaim`                | One of none, partial, or declared-by-supplier. Gates the `--json` conformance field.         |
+| `metadata.id`                              | The identifier `trustedRulePackIds` must match. Not the pack's name or path.                 |
+| `metadata.licence`                         | What the supplier asserts you may distribute, for the audit trail.                           |
+| `metadata.name`                            | A human-readable label. Cosmetic. Nothing matches on it.                                     |
+| `metadata.notice`                          | Optional notice text, for the audit trail.                                                   |
+| `metadata.retrievedAt`                     | Optional. When the source data was retrieved, for the audit trail.                           |
+| `metadata.source`                          | Where the data came from, per the supplier, for the audit trail.                             |
+| `metadata.version`                         | The pack's own version string, for the audit trail.                                          |
+| `rules`                                    | Per-rule authority and defaults.                                                             |
+| `rules[].enabled`                          | Whether the rule runs at all.                                                                |
+| `rules[].options`                          | Default options, below anything the user configures.                                         |
+| `rules[].ruleId`                           | Which registered rule the entry applies to.                                                  |
+| `rules[].severity`                         | Default severity, below anything the user configures.                                        |
+| `rules[].sourceRef`                        | The citation a deterministic diagnostic reports.                                             |
+| `rules[].status`                           | The authority a deterministic diagnostic reports.                                            |
 
 <!-- pack-control-surface:end -->
 

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -1,17 +1,59 @@
 # Importing an authorised rule pack
 
-This is the **only** supported route by which normative controlled-language data enters the package.
-No rule hard-codes vocabulary: every word list, term mapping and numeric limit is read from the
-active pack, so supplying licensed data changes behaviour without changing a line of rule code.
+This page describes the only supported route by which normative controlled-language data enters the
+package. The active pack supplies the controlled-language dictionary and the numeric limits.
+Supplying licensed data therefore changes that behaviour without changing a line of rule code.
+
+Do you want to see a pack work before you write one? [`examples/rule-pack/`](../examples/rule-pack/)
+is a complete worked pack with commands that show the same document linted twice. It is linted once
+under the bundled pack, then once under the custom pack.
+
+Every behaviour this page describes is pinned by
+[`test/integration/rule-pack.test.ts`](../test/integration/rule-pack.test.ts). Read that file when
+you need the exact answer rather than the summary.
+
+## What a pack controls
+
+A pack changes only what the schema exposes. This table is generated from `rulePackSchema` and
+checked against the schema on every run of the test suite. See
+`test/architecture/doc-pack-control-surface.test.ts`.
+
+<!-- pack-control-surface:begin -->
+
+| Field                    | What it controls                                                      |
+| ------------------------ | --------------------------------------------------------------------- |
+| `approvedTechnicalTerms` | Literal names protected from matching, rewriting, and the heuristics. |
+| `contractions`           | The contraction expansions `no-contractions` offers.                  |
+| `dictionary`             | The controlled-language word lists.                                   |
+| `dictionary.approved`    | Terms whose permitted sense the semantic evaluators may check.        |
+| `dictionary.preferred`   | Term mappings `preferred-terminology` reports.                        |
+| `dictionary.unapproved`  | Terms `unapproved-vocabulary` reports, with their alternatives.       |
+| `limits`                 | The numeric thresholds. Grade levels, cluster length, step count.     |
+| `metadata`               | Identity, declared authority, licence, and the conformance claim.     |
+| `rules`                  | Per-rule authority and defaults.                                      |
+| `rules[].enabled`        | Whether the rule runs at all.                                         |
+| `rules[].options`        | Default options, below anything the user configures.                  |
+| `rules[].ruleId`         | Which registered rule the entry applies to.                           |
+| `rules[].severity`       | Default severity, below anything the user configures.                 |
+| `rules[].sourceRef`      | The citation a deterministic diagnostic reports.                      |
+| `rules[].status`         | The authority a deterministic diagnostic reports.                     |
+
+<!-- pack-control-surface:end -->
+
+Some rules also hold trigger vocabulary in code. The `PARTICIPLES`, `PRONOUNS`, and
+`BARE_DEMONSTRATIVE_FOLLOWERS` lists in
+[`src/deterministic/rules/candidate-rules.ts`](../src/deterministic/rules/candidate-rules.ts) are
+examples. A pack cannot add a word to those lists. A pack can still stop one from firing, because
+`approvedTechnicalTerms` protects a token before any rule scans it. The limitation runs one way
+only.
 
 ## Before you start
 
-Supplying a pack is a licensing decision. This project makes no determination about what you are
-permitted to include, and adds no conformance wording of its own. See
-[`DISCLAIMER.md`](./DISCLAIMER.md).
+Supplying a pack is a licensing decision. This project makes no determination about what you may
+include. It adds no conformance wording of its own. See [`DISCLAIMER.md`](./DISCLAIMER.md).
 
-Do not commit a proprietary pack to a public repository. Keep it outside the tree and point at it,
-or hold it in a private artefact store.
+Do not commit a proprietary pack to a public repository. Keep it outside the tree. Point the
+configuration at it. Alternatively, store it in a private artefact repository.
 
 ## The schema
 
@@ -125,32 +167,71 @@ await analyseText(source, { config: { rulePack: myPackObject } });
 Relative paths resolve against the textlint config base directory, or against `baseDir` for the
 programmatic API.
 
-## What changes when you supply a normative pack
+## The trust gate
 
-|                                  | Bundled provisional pack                  | Normative pack                          |
-| -------------------------------- | ----------------------------------------- | --------------------------------------- |
-| `meta.status` reported per rule  | `provisional`                             | the pack's `rules[].status`             |
-| Message tag                      | `[provisional]`                           | `[normative]`                           |
-| `sourceRef`                      | `provisional:docs/provisional-rules.md#…` | the pack's citation                     |
-| `packPermitsConformanceClaim()`  | `false`                                   | `true` if `conformanceClaim !== 'none'` |
-| Vocabulary, limits, contractions | small authored set                        | yours                                   |
+A pack cannot elevate itself. Schema validation proves the shape of a pack, never where it came
+from. Any JSON file can declare `authority: "normative"`.
 
-Rule _code_ does not change. Rules whose trigger cannot be expressed in the pack schema stay
-provisional regardless of what the pack declares — a pack cannot promote a heuristic by asserting
-authority over it.
+An imported pack is therefore untrusted until the operator names its `metadata.id` in
+`trustedRulePackIds`. An untrusted pack still supplies its dictionary and its limits. Its claim to
+normative standing is capped at `supplementary`. The match is on `metadata.id` alone. The pack name
+and the file path do not count.
+
+## What status a diagnostic reports
+
+Two rule paths report status differently. This surprises pack authors, so read the table before you
+write `rules[]`.
+
+A deterministic rule reports a violation directly. A candidate rule instead hands the passage to a
+semantic evaluator. The passage is reported as `review-required` when no evaluator ran.
+
+| Rule entry            | Deterministic diagnostic           | Candidate (`review-required`) |
+| --------------------- | ---------------------------------- | ----------------------------- |
+| listed in `rules[]`   | the entry's `status`, trust-capped | ignored. Pack-wide authority  |
+| absent from `rules[]` | `provisional`, the rule default    | pack-wide authority           |
+| `sourceRef` reported  | the entry's `sourceRef`            | never reported                |
+
+Read the second column downwards. Omitting a rule from `rules[]` leaves it `provisional` even under
+a trusted normative pack. Read the third column downwards. Omitting a rule changes nothing there,
+because `rules[].status` never applied in the first place.
+
+`runDeterministicRules()` in `src/core/runner.ts` applies the per-rule status to diagnostics only.
+Candidates bypass it. `src/analysis/analyse.ts` stamps them later with the pack-wide authority from
+`verifiedAuthority()`.
+
+Two consequences follow. A trusted pack promotes a heuristic candidate rule to `normative` even
+when the pack lists that rule as `provisional`. The rule's trigger logic is unchanged and stays
+heuristic. Nothing gates promotion on whether a trigger is expressible in the schema.
+
+Rule _code_ does not change in either case.
 
 ## What the pack cannot do
 
-- It cannot add a new rule. A new rule needs code; see [`rule-authoring.md`](./rule-authoring.md).
-- It cannot grant a fix that the autofix gate refuses. `safeSubstitution: true` is necessary but not
-  sufficient: `checkFixSafety()` and `gateFix()` still run, and still refuse anything that changes a
-  digit, a negation, a modal, an ordering word, or that sits in an admonition.
-- It cannot make the linter print conformance wording. Nothing in the codebase emits a conformance
-  claim; `conformanceClaim` only records what the supplier asserts, for the audit trail.
+- It cannot add a new rule. A new rule needs code. See [`rule-authoring.md`](./rule-authoring.md).
+- It cannot add a word to a trigger list held in rule code. See `What a pack controls` above.
+- It cannot grant a fix that the autofix gate refuses. `safeSubstitution: true` is necessary, but it
+  is not enough. `checkFixSafety()` and `gateFix()` still run. They still refuse a fix that changes
+  any of the following.
+  - a digit.
+  - a negation.
+  - a modal.
+  - an ordering word.
+
+  They also refuse a fix that sits in an admonition.
+
+- It cannot make the linter print conformance wording on its own. The `--json` output does carry a
+  `conformance.claim` field. That field is gated by `packPermitsConformanceClaim()` in
+  `src/rule-pack/loader.ts`, which needs all three of the following.
+  - The pack declares `authority: "normative"`.
+  - Its `conformanceClaim` is not `"none"`.
+  - Its `metadata.id` is in `trustedRulePackIds`.
+
+  The JSON output reports `"none"` for any pack that fails one of them. The declared value stays in
+  `metadata.conformanceClaim` for the audit trail.
 
 ## Extending the schema
 
-If your pack carries data the schema cannot express — a part-of-speech table, per-rule exception
-lists, a sense inventory — extend `src/rule-pack/schema.ts` and the consuming rule together, and add
-a test that the new field actually changes behaviour. Do not smuggle data through
-`rules[].options`: that path is unvalidated beyond the rule's own options schema.
+Your pack might carry data the schema cannot express. A part-of-speech table, per-rule exception
+lists, or a sense inventory are examples. In that case, extend `src/rule-pack/schema.ts` and the
+consuming rule together. Add a test that confirms the new field changes behaviour. Do not smuggle
+data through `rules[].options`. That path is unvalidated beyond the rule's own options schema.

--- a/docs/rule-pack-import.md
+++ b/docs/rule-pack-import.md
@@ -14,9 +14,10 @@ you need the exact answer rather than the summary.
 
 ## What a pack controls
 
-A pack changes only what the schema exposes. This table is generated from `rulePackSchema` and
-checked against the schema on every run of the test suite. See
-`test/architecture/doc-pack-control-surface.test.ts`.
+A pack changes only what the schema exposes. Do not edit the table below by hand.
+`scripts/lib/pack-control-surface.ts` renders it from `rulePackSchema`. Regenerate it with
+`npx tsx scripts/write-pack-control-surface.ts`.
+`test/architecture/doc-pack-control-surface.test.ts` compares the two and fails when they differ.
 
 <!-- pack-control-surface:begin -->
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,10 @@ Do you want the minimal config for a real project instead? See the root
 [`README.md`](../README.md#install) `Install` section. The files here are the full reference, not
 the quickest path.
 
+Do you want to replace the bundled vocabulary with your own? That is a rule pack, and
+[`rule-pack/`](./rule-pack/) is a complete worked one. It lints one document under the bundled
+pack, then under a custom pack. You see exactly what changes.
+
 ## Try it
 
 Run these commands from the repository root.

--- a/examples/rule-pack/README.md
+++ b/examples/rule-pack/README.md
@@ -1,0 +1,95 @@
+# A worked rule pack
+
+A rule pack is how you replace the bundled vocabulary with your own. This directory holds a
+complete one. The commands below lint the same document three times to show what changes.
+
+| File             | Purpose                                                          |
+| ---------------- | ---------------------------------------------------------------- |
+| `acme-pack.json` | The pack. A small controlled vocabulary for a fictional company. |
+| `sample.md`      | A document with deliberate violations of that vocabulary.        |
+| `untrusted.json` | Configuration that loads the pack, and does not trust it.        |
+| `trusted.json`   | The same, with the pack named in `trustedRulePackIds`.           |
+
+Run every command from the repository root. Run `vp install` and `vp pack` first, because these
+commands use the built CLI.
+
+## 1. The bundled pack
+
+```bash
+node dist/cli/main.js lint examples/rule-pack/sample.md --deterministic-only
+```
+
+One error. The bundled dictionary flags `Utilise`, because that word is in its unapproved list. It
+knows nothing about the Acme vocabulary, so `De-energise` and `Actuate` pass.
+
+## 2. Your pack, loaded but untrusted
+
+```bash
+node dist/cli/main.js lint examples/rule-pack/sample.md \
+  --config examples/rule-pack/untrusted.json --deterministic-only
+```
+
+Three errors, and they are different errors.
+
+- `De-energise` and `Actuate` are now reported. Your pack lists them.
+- `torque wrench` is now reported. Your pack prefers `torque tool`.
+- `Utilise` is **no longer** reported.
+- `Acme WidgetPro` is never reported. `approvedTechnicalTerms` protects it.
+
+That third point is the one to remember. **A pack replaces the dictionary. It does not add to it.**
+Anything the bundled pack used to catch is gone unless your pack lists it too. Do you want to keep
+the general-English checks? Copy the entries you want out of `src/rule-pack/provisional-pack.ts`.
+
+## 3. Your pack, trusted
+
+```bash
+node dist/cli/main.js lint examples/rule-pack/sample.md \
+  --config examples/rule-pack/trusted.json --deterministic-only --json
+```
+
+The findings are identical. What changes is the authority reported for them. Compare the
+`conformance` block against the untrusted run:
+
+```jsonc
+// untrusted.json
+"conformance": {
+  "claim": "none",
+  "packAuthority": "supplementary",
+  "disclaimer": "This tool does not certify conformance with any controlled-language standard."
+}
+
+// trusted.json
+"conformance": {
+  "claim": "declared-by-supplier",
+  "packAuthority": "normative",
+  "disclaimer": "This tool does not certify conformance with any controlled-language standard."
+}
+```
+
+A pack cannot elevate itself. It declares `authority: "normative"` in both runs. Any JSON file can
+declare that, so the declaration alone buys nothing. The operator must name the pack's
+`metadata.id` in `trustedRulePackIds` before the linter acts on it. Until then the pack's data is
+used and its authority is capped at `supplementary`.
+
+The human-readable output still ends with `Provisional rules only; no conformance claim.` in every
+run, including the trusted one. That line is unconditional today. See
+[`docs/DISCLAIMER.md`](../../docs/DISCLAIMER.md) and
+`docs/design/64-layered-rule-packs/02-authority-trust.md`, which record why it under-claims on
+purpose. Read the `--json` output when you need the authority the linter actually acted on.
+
+## What to copy
+
+Copy `acme-pack.json`. Four fields then need your own values.
+
+- `metadata.id` is the string `trustedRulePackIds` must match. The pack name and the file path do
+  not count.
+- `metadata.licence` and `metadata.source` record what you are entitled to supply.
+- `dictionary` holds your terms.
+- `rules[]` takes one entry per rule whose authority or defaults you want to set.
+
+Leave `metadata.authority` as `provisional` until you are actually supplying licensed data.
+[`docs/rule-pack-import.md`](../../docs/rule-pack-import.md) covers the full field list and the
+licence obligations. Do not commit a proprietary pack to a public repository.
+
+The output of every command above is pinned by `test/integration/rule-pack.test.ts`, so this page
+cannot drift from what the commands print.

--- a/examples/rule-pack/README.md
+++ b/examples/rule-pack/README.md
@@ -19,8 +19,8 @@ commands use the built CLI.
 node dist/cli/main.js lint examples/rule-pack/sample.md --deterministic-only
 ```
 
-One error. The bundled dictionary flags `Utilise`, because that word is in its unapproved list. It
-knows nothing about the Acme vocabulary, so `De-energise` and `Actuate` pass.
+The bundled dictionary flags `Utilise`, because that word is in its unapproved list. It knows
+nothing about the Acme vocabulary, so `De-energise` and `Actuate` pass.
 
 ## 2. Your pack, loaded but untrusted
 
@@ -29,7 +29,7 @@ node dist/cli/main.js lint examples/rule-pack/sample.md \
   --config examples/rule-pack/untrusted.json --deterministic-only
 ```
 
-Three errors, and they are different errors.
+Different errors this time.
 
 - `De-energise` and `Actuate` are now reported. Your pack lists them.
 - `torque wrench` is now reported. Your pack prefers `torque tool`.
@@ -83,9 +83,8 @@ Copy `acme-pack.json`. The generated table in
 [`docs/rule-pack-import.md`](../../docs/rule-pack-import.md#what-a-pack-controls) is the schema's
 complete field inventory. It is not a list of fields this example populated.
 
-This pack sets most fields to a value specific to Acme. It leaves a few optional ones at their
-default: `rules[].options`, and the `note` field on one `dictionary.preferred` entry and the one
-`contractions` entry. None of the three has content worth writing for this scenario.
+This pack sets most fields to a value specific to Acme. A few optional fields are left at their
+default, because nothing about this scenario needs them changed.
 
 Go through the table row by row. For each field, ask one question. Does your pack's real content
 give this a value worth setting? Or does the default already say what you mean? An empty `note` and

--- a/examples/rule-pack/README.md
+++ b/examples/rule-pack/README.md
@@ -79,17 +79,21 @@ purpose. Read the `--json` output when you need the authority the linter actuall
 
 ## What to copy
 
-Copy `acme-pack.json`. Four fields then need your own values.
+Copy `acme-pack.json`. Do not stop at a handful of fields. The generated table in
+[`docs/rule-pack-import.md`](../../docs/rule-pack-import.md#what-a-pack-controls) is the complete
+list. Every row on it is a field this example set to a value specific to Acme. Go through the
+table. For each row, decide whether your pack needs its own value, or the placeholder is fine to
+keep.
 
-- `metadata.id` is the string `trustedRulePackIds` must match. The pack name and the file path do
-  not count.
-- `metadata.licence` and `metadata.source` record what you are entitled to supply.
-- `dictionary` holds your terms.
-- `rules[]` takes one entry per rule whose authority or defaults you want to set.
+Two are worth calling out because getting them wrong is easy to miss until later.
 
-Leave `metadata.authority` as `provisional` until you are actually supplying licensed data.
-[`docs/rule-pack-import.md`](../../docs/rule-pack-import.md) covers the full field list and the
-licence obligations. Do not commit a proprietary pack to a public repository.
+- `metadata.id` is the exact string `trustedRulePackIds` must match. The pack name and the file
+  path do not count — see the trust gate above.
+- `metadata.authority` should stay `provisional` until you are actually supplying licensed data.
+  Declaring `normative` early makes the pack lie about itself, even while it stays untrusted.
+
+`docs/rule-pack-import.md` also covers the licence obligations. Do not commit a proprietary pack to
+a public repository.
 
 `scripts/ci/check-rule-pack-example.sh` runs each command above through the real command-line tool.
 It uses these same files. It asserts the counts and the `conformance` values this page quotes. It

--- a/examples/rule-pack/README.md
+++ b/examples/rule-pack/README.md
@@ -79,18 +79,28 @@ purpose. Read the `--json` output when you need the authority the linter actuall
 
 ## What to copy
 
-Copy `acme-pack.json`. Do not stop at a handful of fields. The generated table in
-[`docs/rule-pack-import.md`](../../docs/rule-pack-import.md#what-a-pack-controls) is the complete
-list. Every row on it is a field this example set to a value specific to Acme. Go through the
-table. For each row, decide whether your pack needs its own value, or the placeholder is fine to
-keep.
+Copy `acme-pack.json`. The generated table in
+[`docs/rule-pack-import.md`](../../docs/rule-pack-import.md#what-a-pack-controls) is the schema's
+complete field inventory. It is not a list of fields this example populated.
+
+This pack sets most fields to a value specific to Acme. It leaves a few optional ones at their
+default: `rules[].options`, and the `note` field on one `dictionary.preferred` entry and the one
+`contractions` entry. None of the three has content worth writing for this scenario.
+
+Go through the table row by row. For each field, ask one question. Does your pack's real content
+give this a value worth setting? Or does the default already say what you mean? An empty `note` and
+an absent one behave identically. There is no placeholder to fill in either case.
 
 Two are worth calling out because getting them wrong is easy to miss until later.
 
 - `metadata.id` is the exact string `trustedRulePackIds` must match. The pack name and the file
   path do not count — see the trust gate above.
-- `metadata.authority` should stay `provisional` until you are actually supplying licensed data.
-  Declaring `normative` early makes the pack lie about itself, even while it stays untrusted.
+- `metadata.authority: "normative"` asserts two things at once. The pack carries a standard's rule
+  data. You are licensed to supply it. This example declares it because Acme wrote its own
+  maintenance standard. See the `notice` field in `acme-pack.json`. See also
+  `docs/DISCLAIMER.md`'s "a licence that permits it". Authorship is that licensed condition, not an
+  exception to it. Declaring `normative` without either fact true makes the pack lie about itself,
+  even while it stays untrusted and capped at `supplementary`.
 
 `docs/rule-pack-import.md` also covers the licence obligations. Do not commit a proprietary pack to
 a public repository.

--- a/examples/rule-pack/README.md
+++ b/examples/rule-pack/README.md
@@ -91,5 +91,7 @@ Leave `metadata.authority` as `provisional` until you are actually supplying lic
 [`docs/rule-pack-import.md`](../../docs/rule-pack-import.md) covers the full field list and the
 licence obligations. Do not commit a proprietary pack to a public repository.
 
-The output of every command above is pinned by `test/integration/rule-pack.test.ts`, so this page
-cannot drift from what the commands print.
+`scripts/ci/check-rule-pack-example.sh` runs each command above through the real command-line tool.
+It uses these same files. It asserts the counts and the `conformance` values this page quotes. It
+runs in continuous integration. The page therefore cannot drift from what the commands print.
+`test/integration/rule-pack.test.ts` covers the same pack through the programmatic interface.

--- a/examples/rule-pack/acme-pack.json
+++ b/examples/rule-pack/acme-pack.json
@@ -4,11 +4,11 @@
     "name": "Acme maintenance controlled-English pack",
     "version": "1.0.0",
     "authority": "normative",
-    "licence": "Example only. Authored for this repository, not derived from any standard.",
-    "source": "Authored as a worked example for docs/rule-pack-import.md.",
+    "licence": "Acme Industries internal document, ACME-MAINT-STD-2026. Internal use only.",
+    "source": "ACME-MAINT-STD-2026, Acme Industries' own internal controlled-English maintenance standard.",
     "retrievedAt": "2026-08-26",
     "conformanceClaim": "declared-by-supplier",
-    "notice": "Example pack. It carries no real controlled-language standard and confers no conformance."
+    "notice": "Acme, Acme WidgetPro, and ACME-MAINT-STD-2026 are fictional, authored for this example. The scenario is not: a licensee may declare normative authority over a standard it owns and authors itself, without a third party's licence. See docs/DISCLAIMER.md, \"a licence that permits it\" -- this pack is that case."
   },
 
   "limits": {

--- a/examples/rule-pack/acme-pack.json
+++ b/examples/rule-pack/acme-pack.json
@@ -1,0 +1,65 @@
+{
+  "metadata": {
+    "id": "acme-maintenance-2026",
+    "name": "Acme maintenance controlled-English pack",
+    "version": "1.0.0",
+    "authority": "normative",
+    "licence": "Example only. Authored for this repository, not derived from any standard.",
+    "source": "Authored as a worked example for docs/rule-pack-import.md.",
+    "retrievedAt": "2026-08-26",
+    "conformanceClaim": "declared-by-supplier",
+    "notice": "Example pack. It carries no real controlled-language standard and confers no conformance."
+  },
+
+  "limits": {
+    "proceduralMaxGradeLevel": 7,
+    "descriptiveMaxGradeLevel": 8,
+    "sentenceReadabilityFloorWords": 20,
+    "maxNounClusterLength": 3,
+    "maxSentencesPerProceduralStep": 1
+  },
+
+  "dictionary": {
+    "approved": [
+      { "term": "open", "partsOfSpeech": ["verb"], "senses": ["to move to the open position"] }
+    ],
+
+    "unapproved": [
+      {
+        "term": "actuate",
+        "alternatives": ["open"],
+        "safeSubstitution": false,
+        "partOfSpeech": "verb",
+        "note": "Ambiguous on this equipment: 'actuate' is used for both open and close."
+      },
+      {
+        "term": "de-energise",
+        "alternatives": ["switch off"],
+        "safeSubstitution": false,
+        "partOfSpeech": "verb"
+      }
+    ],
+
+    "preferred": [{ "from": "torque wrench", "to": "torque tool", "safeSubstitution": true }]
+  },
+
+  "contractions": [{ "from": "don't", "to": "do not", "safeSubstitution": true }],
+
+  "approvedTechnicalTerms": ["Acme WidgetPro", "PRAGMA"],
+
+  "rules": [
+    {
+      "ruleId": "unapproved-vocabulary",
+      "status": "normative",
+      "sourceRef": "ACME-MAINT-STD-2026 clause 4.2",
+      "enabled": true,
+      "severity": "error"
+    },
+    {
+      "ruleId": "preferred-terminology",
+      "status": "normative",
+      "sourceRef": "ACME-MAINT-STD-2026 clause 4.3",
+      "enabled": true
+    }
+  ]
+}

--- a/examples/rule-pack/sample.md
+++ b/examples/rule-pack/sample.md
@@ -1,0 +1,9 @@
+# Acme WidgetPro service procedure
+
+De-energise the control panel before you open the housing.
+
+Actuate the main isolation valve.
+
+Utilise the torque wrench on each of the four bolts.
+
+The Acme WidgetPro housing is inspected by a technician every twelve months.

--- a/examples/rule-pack/trusted.json
+++ b/examples/rule-pack/trusted.json
@@ -1,0 +1,4 @@
+{
+  "rulePack": "examples/rule-pack/acme-pack.json",
+  "trustedRulePackIds": ["acme-maintenance-2026"]
+}

--- a/examples/rule-pack/untrusted.json
+++ b/examples/rule-pack/untrusted.json
@@ -1,0 +1,3 @@
+{
+  "rulePack": "examples/rule-pack/acme-pack.json"
+}

--- a/scripts/ci/check-rule-pack-example.sh
+++ b/scripts/ci/check-rule-pack-example.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Run the commands `examples/rule-pack/README.md` documents, and assert the results that page
+# quotes.
+#
+# This exists because external review on PR #105 pointed out a real gap: the integration tests read
+# `acme-pack.json` themselves and hand an inline object to `analyseTextDeterministic()`. They never
+# load `untrusted.json` or `trusted.json` through `--config`, and never invoke the CLI. So CLI
+# argument handling, shared-config loading, relative `rulePack` path resolution and output rendering
+# could all break while those tests stayed green -- and the page claims its commands are pinned.
+#
+# What is checked here is therefore the documented entry point, end to end, with the shipped files:
+# the finding counts the page quotes, the fact that a custom pack *replaces* the bundled dictionary
+# rather than adding to it, and the trust gate's effect on the JSON `conformance` block.
+#
+# Usage: scripts/ci/check-rule-pack-example.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+cli="dist/cli/main.js"
+sample="examples/rule-pack/sample.md"
+
+if [ ! -f "$cli" ]; then
+  echo "$cli is missing. Run 'vp pack' first." >&2
+  exit 2
+fi
+
+for file in "$sample" examples/rule-pack/acme-pack.json examples/rule-pack/untrusted.json \
+  examples/rule-pack/trusted.json; do
+  if [ ! -f "$file" ]; then
+    echo "$file is missing; examples/rule-pack/README.md documents it." >&2
+    exit 2
+  fi
+done
+
+fail() {
+  echo "examples/rule-pack/README.md is stale: $1" >&2
+  exit 1
+}
+
+# `lint` exits 1 whenever errors are present, which is the documented behaviour, so the exit status
+# is captured rather than allowed to kill the script under `set -e`.
+run_lint() {
+  local output
+  set +e
+  output="$(node "$cli" lint "$sample" "$@" 2>&1)"
+  set -e
+  printf '%s' "$output"
+}
+
+error_count() {
+  printf '%s' "$1" | grep -oE '^[0-9]+ error' | grep -oE '[0-9]+' || echo "unknown"
+}
+
+# 1. The bundled pack. The page says one error, on "Utilise".
+bundled="$(run_lint --deterministic-only)"
+[ "$(error_count "$bundled")" = "1" ] ||
+  fail "the bundled pack reported $(error_count "$bundled") error(s), not the documented 1"
+printf '%s' "$bundled" | grep -q 'Utilise' ||
+  fail 'the bundled pack no longer reports "Utilise"'
+
+# 2. The custom pack, untrusted. The page says three errors, and that "Utilise" is gone because a
+#    pack replaces the dictionary rather than adding to it. That claim is the point of the example.
+untrusted="$(run_lint --config examples/rule-pack/untrusted.json --deterministic-only)"
+[ "$(error_count "$untrusted")" = "3" ] ||
+  fail "the custom pack reported $(error_count "$untrusted") error(s), not the documented 3"
+
+for term in 'De-energise' 'Actuate' 'torque tool'; do
+  printf '%s' "$untrusted" | grep -q "$term" ||
+    fail "the custom pack no longer reports \"$term\""
+done
+
+printf '%s' "$untrusted" | grep -q 'Utilise' &&
+  fail 'the custom pack now reports "Utilise"; the page says a pack replaces the dictionary'
+
+printf '%s' "$untrusted" | grep -q 'WidgetPro' &&
+  fail 'approvedTechnicalTerms no longer protects "Acme WidgetPro"'
+
+# 3. The trust gate, read from the JSON output the page quotes. The findings are identical either
+#    way; what changes is the authority the linter acted on.
+conformance() {
+  set +e
+  node "$cli" lint "$sample" --config "$1" --deterministic-only --json 2>/dev/null |
+    node -e "let s='';process.stdin.on('data',(d)=>{s+=d}).on('end',()=>{const c=JSON.parse(s).conformance;console.log(c.claim+' '+c.packAuthority)})"
+  set -e
+}
+
+untrusted_claim="$(conformance examples/rule-pack/untrusted.json)"
+[ "$untrusted_claim" = "none supplementary" ] ||
+  fail "untrusted conformance was \"$untrusted_claim\", not the documented \"none supplementary\""
+
+trusted_claim="$(conformance examples/rule-pack/trusted.json)"
+[ "$trusted_claim" = "declared-by-supplier normative" ] ||
+  fail "trusted conformance was \"$trusted_claim\", not the documented \"declared-by-supplier normative\""
+
+echo "examples/rule-pack/README.md: all documented commands produce the results the page quotes."

--- a/scripts/ci/check-rule-pack-example.sh
+++ b/scripts/ci/check-rule-pack-example.sh
@@ -9,6 +9,15 @@
 # argument handling, shared-config loading, relative `rulePack` path resolution and output rendering
 # could all break while those tests stayed green -- and the page claims its commands are pinned.
 #
+# A second round of review then caught this script's own gap: it captured the CLI's stdout and
+# grepped it for expected substrings, but never checked the exit code. `docs/configuration.md`
+# documents exit 3 for "any error-level run notice" -- a protected-pattern failure, or a rule
+# skipped for invalid options -- and that path can still print a diagnostic count and terms that
+# happen to match what this script greps for, while the run itself is not the clean success the
+# page claims. Every assertion below now checks the exit code the page documents (1: errors
+# present) in addition to the output, so a masked infrastructure failure fails loudly instead of
+# passing on a coincidental string match.
+#
 # What is checked here is therefore the documented entry point, end to end, with the shipped files:
 # the finding counts the page quotes, the fact that a custom pack *replaces* the bundled dictionary
 # rather than adding to it, and the trust gate's effect on the JSON `conformance` block.
@@ -36,18 +45,28 @@ for file in "$sample" examples/rule-pack/acme-pack.json examples/rule-pack/untru
 done
 
 fail() {
-  echo "examples/rule-pack/README.md is stale: $1" >&2
+  printf 'examples/rule-pack/README.md is stale: %s\n' "$1" >&2
   exit 1
 }
 
-# `lint` exits 1 whenever errors are present, which is the documented behaviour, so the exit status
-# is captured rather than allowed to kill the script under `set -e`.
+# docs/configuration.md's exit-code table: 1 means "errors present". Every command this script
+# documents is expected to find the vocabulary violations it demonstrates, so 1 is the only exit
+# code that means the run actually did what the page says. `run_lint` sets two globals rather than
+# returning a string, because a bash function cannot hand back an exit code and captured output
+# together without one of them going through global state.
+LAST_STATUS=""
+LAST_OUTPUT=""
+
 run_lint() {
-  local output
   set +e
-  output="$(node "$cli" lint "$sample" "$@" 2>&1)"
+  LAST_OUTPUT="$(node "$cli" lint "$sample" "$@" 2>&1)"
+  LAST_STATUS=$?
   set -e
-  printf '%s' "$output"
+}
+
+require_exit_1() {
+  [ "$LAST_STATUS" = "1" ] ||
+    fail "\`$*\` exited $LAST_STATUS, not the documented 1 (errors present). Output:\n$LAST_OUTPUT"
 }
 
 error_count() {
@@ -55,7 +74,9 @@ error_count() {
 }
 
 # 1. The bundled pack. The page says one error, on "Utilise".
-bundled="$(run_lint --deterministic-only)"
+run_lint --deterministic-only
+require_exit_1 lint "$sample" --deterministic-only
+bundled="$LAST_OUTPUT"
 [ "$(error_count "$bundled")" = "1" ] ||
   fail "the bundled pack reported $(error_count "$bundled") error(s), not the documented 1"
 printf '%s' "$bundled" | grep -q 'Utilise' ||
@@ -63,7 +84,9 @@ printf '%s' "$bundled" | grep -q 'Utilise' ||
 
 # 2. The custom pack, untrusted. The page says three errors, and that "Utilise" is gone because a
 #    pack replaces the dictionary rather than adding to it. That claim is the point of the example.
-untrusted="$(run_lint --config examples/rule-pack/untrusted.json --deterministic-only)"
+run_lint --config examples/rule-pack/untrusted.json --deterministic-only
+require_exit_1 lint "$sample" --config examples/rule-pack/untrusted.json --deterministic-only
+untrusted="$LAST_OUTPUT"
 [ "$(error_count "$untrusted")" = "3" ] ||
   fail "the custom pack reported $(error_count "$untrusted") error(s), not the documented 3"
 
@@ -79,12 +102,27 @@ printf '%s' "$untrusted" | grep -q 'WidgetPro' &&
   fail 'approvedTechnicalTerms no longer protects "Acme WidgetPro"'
 
 # 3. The trust gate, read from the JSON output the page quotes. The findings are identical either
-#    way; what changes is the authority the linter acted on.
+#    way; what changes is the authority the linter acted on. `--json` follows the same exit-code
+#    contract as the human-readable output, so it is checked the same way: capture the exit status
+#    alongside stdout, fail on anything but the documented 1, and only then parse the JSON.
 conformance() {
+  local output status
   set +e
-  node "$cli" lint "$sample" --config "$1" --deterministic-only --json 2>/dev/null |
-    node -e "let s='';process.stdin.on('data',(d)=>{s+=d}).on('end',()=>{const c=JSON.parse(s).conformance;console.log(c.claim+' '+c.packAuthority)})"
+  output="$(node "$cli" lint "$sample" --config "$1" --deterministic-only --json)"
+  status=$?
   set -e
+
+  [ "$status" = "1" ] ||
+    fail "\`lint $sample --config $1 --json\` exited $status, not the documented 1"
+
+  printf '%s' "$output" | node -e "
+    let raw = '';
+    process.stdin.on('data', (chunk) => { raw += chunk; });
+    process.stdin.on('end', () => {
+      const conformance = JSON.parse(raw).conformance;
+      console.log(conformance.claim + ' ' + conformance.packAuthority);
+    });
+  "
 }
 
 untrusted_claim="$(conformance examples/rule-pack/untrusted.json)"

--- a/scripts/ci/check-rule-pack-example.sh
+++ b/scripts/ci/check-rule-pack-example.sh
@@ -18,9 +18,17 @@
 # present) in addition to the output, so a masked infrastructure failure fails loudly instead of
 # passing on a coincidental string match.
 #
+# A third round dropped the page's hard-coded error counts ("One error." / "Three errors.") after
+# review established they carried no information the surrounding text and bullets didn't already
+# state -- deleting them changed nothing a reader could learn. This script's own count assertions
+# came out with them: they existed only to pin a claim the page no longer makes, and keeping them
+# would have reintroduced the same problem in shell instead of prose -- a number with no live source
+# that someone has to remember to update by hand.
+#
 # What is checked here is therefore the documented entry point, end to end, with the shipped files:
-# the finding counts the page quotes, the fact that a custom pack *replaces* the bundled dictionary
-# rather than adding to it, and the trust gate's effect on the JSON `conformance` block.
+# the specific terms each run reports or stops reporting, the fact that a custom pack *replaces* the
+# bundled dictionary rather than adding to it, and the trust gate's effect on the JSON `conformance`
+# block.
 #
 # Usage: scripts/ci/check-rule-pack-example.sh
 set -euo pipefail
@@ -69,26 +77,18 @@ require_exit_1() {
     fail "\`$*\` exited $LAST_STATUS, not the documented 1 (errors present). Output:\n$LAST_OUTPUT"
 }
 
-error_count() {
-  printf '%s' "$1" | grep -oE '^[0-9]+ error' | grep -oE '[0-9]+' || echo "unknown"
-}
-
-# 1. The bundled pack. The page says one error, on "Utilise".
+# 1. The bundled pack. It flags "Utilise" and nothing about the Acme vocabulary.
 run_lint --deterministic-only
 require_exit_1 lint "$sample" --deterministic-only
 bundled="$LAST_OUTPUT"
-[ "$(error_count "$bundled")" = "1" ] ||
-  fail "the bundled pack reported $(error_count "$bundled") error(s), not the documented 1"
 printf '%s' "$bundled" | grep -q 'Utilise' ||
   fail 'the bundled pack no longer reports "Utilise"'
 
-# 2. The custom pack, untrusted. The page says three errors, and that "Utilise" is gone because a
-#    pack replaces the dictionary rather than adding to it. That claim is the point of the example.
+# 2. The custom pack, untrusted. "Utilise" is gone because a pack replaces the dictionary rather
+#    than adding to it -- that claim is the point of the example.
 run_lint --config examples/rule-pack/untrusted.json --deterministic-only
 require_exit_1 lint "$sample" --config examples/rule-pack/untrusted.json --deterministic-only
 untrusted="$LAST_OUTPUT"
-[ "$(error_count "$untrusted")" = "3" ] ||
-  fail "the custom pack reported $(error_count "$untrusted") error(s), not the documented 3"
 
 for term in 'De-energise' 'Actuate' 'torque tool'; do
   printf '%s' "$untrusted" | grep -q "$term" ||

--- a/scripts/lib/pack-control-surface.ts
+++ b/scripts/lib/pack-control-surface.ts
@@ -81,6 +81,17 @@ const DESCRIPTIONS: Readonly<Record<string, string>> = {
   'rules[].options': 'Default options, below anything the user configures.',
 };
 
+// Not a legitimate depth for this schema — `rulePackSchema` bottoms out within a handful of
+// levels. It exists only to turn a genuinely cyclic or pathological schema into a loud failure
+// instead of an infinite recursion or a silent truncation. An earlier version used a silent
+// truncation point instead (`if (depth > MAX_DEPTH) return;`): a field nested past it would vanish
+// from the inventory with every test still green, defeating the "exhaustive" claim the same way
+// the name-based special-casing this file replaced did. `unwrapToCore()` had its own separate
+// version of that same bug, found in the same review round: a wrapper nested past its own depth
+// bound returned still-wrapped instead of throwing, with the identical silent-vanishing effect one
+// call site up. Both functions now share this one throwing bound.
+const RUNAWAY_RECURSION_DEPTH = 50;
+
 /**
  * Read one property without asserting a shape onto a Zod internal.
  *
@@ -93,17 +104,27 @@ function readProperty(value: unknown, key: string): unknown {
   return Reflect.get(value, key);
 }
 
-/** Strip `optional`/`default`/`nullable` wrappers to reach the schema they wrap. */
+/**
+ * Strip `optional`/`default`/`nullable` wrappers to reach the schema they wrap.
+ *
+ * Throws past `RUNAWAY_RECURSION_DEPTH` rather than returning the still-wrapped schema, for the
+ * same reason `collectFields()` does below: a silent cutoff here would make `objectShape()` and
+ * `arrayElement()` see a wrapper as a leaf, and a field wrapped that deep would vanish from the
+ * inventory with every test still green.
+ */
 function unwrapToCore(schema: unknown): unknown {
   let current = schema;
 
-  for (let depth = 0; depth < 8; depth += 1) {
+  for (let depth = 0; depth < RUNAWAY_RECURSION_DEPTH; depth += 1) {
     const inner = readProperty(readProperty(current, 'def'), 'innerType');
     if (inner === undefined) return current;
     current = inner;
   }
 
-  return current;
+  throw new Error(
+    `schema wrapper depth exceeded ${RUNAWAY_RECURSION_DEPTH} levels — rulePackSchema is not ` +
+      'expected to wrap a field this deep; check for a cyclic reference.',
+  );
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -122,15 +143,6 @@ function arrayElement(schema: unknown): unknown {
   const def = readProperty(core, 'def');
   return readProperty(def, 'type') === 'array' ? readProperty(def, 'element') : undefined;
 }
-
-// Not a legitimate depth for this schema — `rulePackSchema` bottoms out within a handful of
-// levels. It exists only to turn a genuinely cyclic or pathological schema into a loud failure
-// instead of an infinite recursion. An earlier version used this as a silent truncation point
-// instead (`if (depth > MAX_DEPTH) return;`): a field nested past it would vanish from the
-// inventory with every test still green, defeating the "exhaustive" claim the same way the
-// name-based special-casing this file replaced did. Throwing here keeps that failure mode
-// impossible rather than merely unlikely.
-const RUNAWAY_RECURSION_DEPTH = 50;
 
 /**
  * Recurse into `schema` and append every reachable field path to `out`.

--- a/scripts/lib/pack-control-surface.ts
+++ b/scripts/lib/pack-control-surface.ts
@@ -1,0 +1,144 @@
+import { rulePackSchema } from '../../src/rule-pack/schema.js';
+
+/**
+ * Render the pack control-surface table in `docs/rule-pack-import.md` from `rulePackSchema`.
+ *
+ * The page has to tell a pack author what a pack can and cannot change. Every hand-maintained
+ * version of that list went stale the moment the schema grew a field, and external review caught it
+ * one omission at a time. So the table is produced here rather than typed into the page: run
+ * `npx tsx scripts/write-pack-control-surface.ts` to write it, and
+ * `test/architecture/doc-pack-control-surface.test.ts` fails when the page and this renderer
+ * disagree.
+ *
+ * A new schema field with no entry in `DESCRIPTIONS` throws rather than rendering a blank cell.
+ * That is the ratchet: adding a field forces you to say what it controls.
+ */
+
+export const BEGIN = '<!-- pack-control-surface:begin -->';
+export const END = '<!-- pack-control-surface:end -->';
+
+const DESCRIPTIONS: Readonly<Record<string, string>> = {
+  approvedTechnicalTerms: 'Literal names protected from matching, rewriting, and the heuristics.',
+  contractions: 'The contraction expansions `no-contractions` offers.',
+  dictionary: 'The controlled-language word lists.',
+  'dictionary.approved': 'Terms whose permitted sense the semantic evaluators may check.',
+  'dictionary.preferred': 'Term mappings `preferred-terminology` reports.',
+  'dictionary.unapproved': 'Terms `unapproved-vocabulary` reports, with their alternatives.',
+  limits: 'The numeric thresholds. Grade levels, cluster length, step count.',
+  metadata: 'Identity, declared authority, licence, and the conformance claim.',
+  rules: 'Per-rule authority and defaults.',
+  'rules[].enabled': 'Whether the rule runs at all.',
+  'rules[].options': 'Default options, below anything the user configures.',
+  'rules[].ruleId': 'Which registered rule the entry applies to.',
+  'rules[].severity': 'Default severity, below anything the user configures.',
+  'rules[].sourceRef': 'The citation a deterministic diagnostic reports.',
+  'rules[].status': 'The authority a deterministic diagnostic reports.',
+};
+
+/**
+ * Read one property without asserting a shape onto a Zod internal.
+ *
+ * Zod's `def` layout is not part of its public contract, so this walks it defensively: a missing or
+ * renamed key yields `undefined` and the caller stops, rather than throwing somewhere less obvious.
+ * `controlSurfaceFields()` returning a short or empty list is what surfaces that, via the guard
+ * assertion in the test.
+ */
+function readProperty(value: unknown, key: string): unknown {
+  if (typeof value !== 'object' || value === null) return undefined;
+  return Reflect.get(value, key);
+}
+
+function shapeKeys(value: unknown): string[] {
+  const shape = readProperty(value, 'shape');
+  if (typeof shape !== 'object' || shape === null) return [];
+  return Object.keys(shape);
+}
+
+/** `z.array(x).default([])` wraps the element type more than once; reach the element schema. */
+function unwrapArray(value: unknown): unknown {
+  let current = value;
+
+  for (let depth = 0; depth < 8; depth += 1) {
+    const def = readProperty(current, 'def');
+    if (def === undefined) return current;
+
+    const element = readProperty(def, 'element');
+    if (readProperty(def, 'type') === 'array' && element !== undefined) {
+      current = element;
+      continue;
+    }
+
+    const inner = readProperty(def, 'innerType');
+    if (inner === undefined) return current;
+    current = inner;
+  }
+
+  return current;
+}
+
+/** Every field a pack author can set, in the notation the documentation uses. */
+export function controlSurfaceFields(): string[] {
+  const fields: string[] = [];
+
+  for (const [key, value] of Object.entries(rulePackSchema.shape)) {
+    fields.push(key);
+
+    // One level down for the two containers whose members the documentation names individually.
+    // Anything deeper is described by the schema excerpt on the page, not by this table.
+    if (key !== 'dictionary' && key !== 'rules') continue;
+
+    const inner = key === 'rules' ? unwrapArray(value) : value;
+    const prefix = key === 'rules' ? 'rules[]' : key;
+    for (const child of shapeKeys(inner)) fields.push(`${prefix}.${child}`);
+  }
+
+  return fields.toSorted();
+}
+
+/** The markdown table body, between the two markers, with a blank line on each side. */
+export function renderControlSurfaceTable(): string {
+  const fields = controlSurfaceFields();
+  const missing = fields.filter((field) => DESCRIPTIONS[field] === undefined);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `No description for pack field(s): ${missing.join(', ')}. ` +
+        'Add one to DESCRIPTIONS in scripts/lib/pack-control-surface.ts, then re-run ' +
+        'npx tsx scripts/write-pack-control-surface.ts',
+    );
+  }
+
+  const cells = fields.map((field) => ({ field: `\`${field}\``, what: DESCRIPTIONS[field] ?? '' }));
+  const fieldWidth = Math.max(...cells.map((c) => c.field.length), 'Field'.length);
+  const whatWidth = Math.max(...cells.map((c) => c.what.length), 'What it controls'.length);
+
+  const row = (left: string, right: string): string =>
+    `| ${left.padEnd(fieldWidth)} | ${right.padEnd(whatWidth)} |`;
+
+  // The leading and trailing blank lines are what the repository's formatter produces around a
+  // fenced-off table. Emitting them here keeps `vp check` and this renderer agreeing: without them
+  // the formatter reflows the block on commit and the generated table stops matching the page.
+  return [
+    '',
+    '',
+    row('Field', 'What it controls'),
+    `| ${'-'.repeat(fieldWidth)} | ${'-'.repeat(whatWidth)} |`,
+    ...cells.map((c) => row(c.field, c.what)),
+    '',
+    '',
+  ].join('\n');
+}
+
+/** Replace the marked block in `markdown`, or throw when the markers are absent. */
+export function withRenderedTable(markdown: string): string {
+  const start = markdown.indexOf(BEGIN);
+  const end = markdown.indexOf(END);
+
+  if (start === -1 || end <= start) {
+    throw new Error(`Document is missing the ${BEGIN} / ${END} markers.`);
+  }
+
+  return (
+    markdown.slice(0, start + BEGIN.length) + renderControlSurfaceTable() + markdown.slice(end)
+  );
+}

--- a/scripts/lib/pack-control-surface.ts
+++ b/scripts/lib/pack-control-surface.ts
@@ -123,7 +123,14 @@ function arrayElement(schema: unknown): unknown {
   return readProperty(def, 'type') === 'array' ? readProperty(def, 'element') : undefined;
 }
 
-const MAX_DEPTH = 6;
+// Not a legitimate depth for this schema — `rulePackSchema` bottoms out within a handful of
+// levels. It exists only to turn a genuinely cyclic or pathological schema into a loud failure
+// instead of an infinite recursion. An earlier version used this as a silent truncation point
+// instead (`if (depth > MAX_DEPTH) return;`): a field nested past it would vanish from the
+// inventory with every test still green, defeating the "exhaustive" claim the same way the
+// name-based special-casing this file replaced did. Throwing here keeps that failure mode
+// impossible rather than merely unlikely.
+const RUNAWAY_RECURSION_DEPTH = 50;
 
 /**
  * Recurse into `schema` and append every reachable field path to `out`.
@@ -134,7 +141,12 @@ const MAX_DEPTH = 6;
  * under it to enumerate. Anything else — string, number, boolean, enum, `z.record` — is a leaf too.
  */
 function collectFields(schema: unknown, path: string, depth: number, out: string[]): void {
-  if (depth > MAX_DEPTH) return;
+  if (depth > RUNAWAY_RECURSION_DEPTH) {
+    throw new Error(
+      `schema walk exceeded ${RUNAWAY_RECURSION_DEPTH} levels at "${path}" — rulePackSchema is ` +
+        'not expected to nest this deep; check for a cyclic reference.',
+    );
+  }
 
   const shape = objectShape(schema);
   if (shape !== undefined) {

--- a/scripts/lib/pack-control-surface.ts
+++ b/scripts/lib/pack-control-surface.ts
@@ -10,29 +10,75 @@ import { rulePackSchema } from '../../src/rule-pack/schema.js';
  * `test/architecture/doc-pack-control-surface.test.ts` fails when the page and this renderer
  * disagree.
  *
- * A new schema field with no entry in `DESCRIPTIONS` throws rather than rendering a blank cell.
- * That is the ratchet: adding a field forces you to say what it controls.
+ * The walk below is generic, not name-based. An earlier version special-cased `dictionary` and
+ * `rules` and stopped after one level, so a field added under `metadata`, `limits`, or inside a
+ * `dictionary.unapproved` entry changed nothing here and passed every test. `collectFields()`
+ * instead recurses into every object shape and every array-of-object element, at any depth,
+ * bottoming out only at a genuine leaf (string, number, boolean, enum, or an unvalidated
+ * `z.record`, which `rules[].options` is by design — see "Extending the schema" on the page).
+ *
+ * A new leaf with no entry in `DESCRIPTIONS` throws rather than rendering a blank cell. That is the
+ * ratchet: adding a field forces you to say what it controls.
  */
 
 export const BEGIN = '<!-- pack-control-surface:begin -->';
 export const END = '<!-- pack-control-surface:end -->';
 
 const DESCRIPTIONS: Readonly<Record<string, string>> = {
-  approvedTechnicalTerms: 'Literal names protected from matching, rewriting, and the heuristics.',
-  contractions: 'The contraction expansions `no-contractions` offers.',
+  metadata: 'Identity, declared authority, licence, and the conformance claim.',
+  'metadata.id': "The identifier `trustedRulePackIds` must match. Not the pack's name or path.",
+  'metadata.name': 'A human-readable label. Cosmetic. Nothing matches on it.',
+  'metadata.version': "The pack's own version string, for the audit trail.",
+  'metadata.authority':
+    "The pack's declared authority. Capped at `supplementary` until the operator trusts the pack.",
+  'metadata.licence': 'What the supplier asserts you may distribute, for the audit trail.',
+  'metadata.source': 'Where the data came from, per the supplier, for the audit trail.',
+  'metadata.retrievedAt': 'Optional. When the source data was retrieved, for the audit trail.',
+  'metadata.conformanceClaim':
+    'One of none, partial, or declared-by-supplier. Gates the `--json` conformance field.',
+  'metadata.notice': 'Optional notice text, for the audit trail.',
+
+  limits: 'The numeric thresholds. Grade levels, cluster length, step count.',
+  'limits.proceduralMaxGradeLevel': 'Grade level above which a procedural sentence is reported.',
+  'limits.descriptiveMaxGradeLevel': 'As above, for descriptive sentences.',
+  'limits.sentenceReadabilityFloorWords': 'Sentences shorter than this are never grade-scored.',
+  'limits.maxNounClusterLength': 'Word-count limit `noun-cluster-candidate` reports.',
+  'limits.maxSentencesPerProceduralStep':
+    'Sentence-count limit `list-instruction-structure` reports per numbered step.',
+
   dictionary: 'The controlled-language word lists.',
   'dictionary.approved': 'Terms whose permitted sense the semantic evaluators may check.',
-  'dictionary.preferred': 'Term mappings `preferred-terminology` reports.',
+  'dictionary.approved[].term': 'The approved term.',
+  'dictionary.approved[].partsOfSpeech': 'Optional. Parts of speech the approval covers.',
+  'dictionary.approved[].senses': 'Optional. Senses the approval covers.',
   'dictionary.unapproved': 'Terms `unapproved-vocabulary` reports, with their alternatives.',
-  limits: 'The numeric thresholds. Grade levels, cluster length, step count.',
-  metadata: 'Identity, declared authority, licence, and the conformance claim.',
+  'dictionary.unapproved[].term': 'The unapproved term.',
+  'dictionary.unapproved[].alternatives': 'Terms the diagnostic suggests instead.',
+  'dictionary.unapproved[].note': 'Optional context shown with the diagnostic.',
+  'dictionary.unapproved[].safeSubstitution':
+    'True only if `alternatives[0]` cannot change technical meaning. Gates autofix.',
+  'dictionary.unapproved[].partOfSpeech': 'Optional. The part of speech this entry covers.',
+  'dictionary.preferred': 'Term mappings `preferred-terminology` reports.',
+  'dictionary.preferred[].from': 'The discouraged term.',
+  'dictionary.preferred[].to': 'The preferred term.',
+  'dictionary.preferred[].safeSubstitution': 'True only if the substitution is always safe.',
+  'dictionary.preferred[].note': 'Optional context shown with the diagnostic.',
+
+  contractions: 'The contraction expansions `no-contractions` offers.',
+  'contractions[].from': 'The contraction.',
+  'contractions[].to': 'The expansion.',
+  'contractions[].safeSubstitution': 'True only if the expansion is always safe to autofix.',
+  'contractions[].note': 'Optional context shown with the diagnostic.',
+
+  approvedTechnicalTerms: 'Literal names protected from matching, rewriting, and the heuristics.',
+
   rules: 'Per-rule authority and defaults.',
-  'rules[].enabled': 'Whether the rule runs at all.',
-  'rules[].options': 'Default options, below anything the user configures.',
   'rules[].ruleId': 'Which registered rule the entry applies to.',
-  'rules[].severity': 'Default severity, below anything the user configures.',
-  'rules[].sourceRef': 'The citation a deterministic diagnostic reports.',
   'rules[].status': 'The authority a deterministic diagnostic reports.',
+  'rules[].sourceRef': 'The citation a deterministic diagnostic reports.',
+  'rules[].enabled': 'Whether the rule runs at all.',
+  'rules[].severity': 'Default severity, below anything the user configures.',
+  'rules[].options': 'Default options, below anything the user configures.',
 };
 
 /**
@@ -40,40 +86,84 @@ const DESCRIPTIONS: Readonly<Record<string, string>> = {
  *
  * Zod's `def` layout is not part of its public contract, so this walks it defensively: a missing or
  * renamed key yields `undefined` and the caller stops, rather than throwing somewhere less obvious.
- * `controlSurfaceFields()` returning a short or empty list is what surfaces that, via the guard
- * assertion in the test.
+ * `controlSurfaceFields()` returning a short list is what surfaces that, via the guard test.
  */
 function readProperty(value: unknown, key: string): unknown {
   if (typeof value !== 'object' || value === null) return undefined;
   return Reflect.get(value, key);
 }
 
-function shapeKeys(value: unknown): string[] {
-  const shape = readProperty(value, 'shape');
-  if (typeof shape !== 'object' || shape === null) return [];
-  return Object.keys(shape);
-}
-
-/** `z.array(x).default([])` wraps the element type more than once; reach the element schema. */
-function unwrapArray(value: unknown): unknown {
-  let current = value;
+/** Strip `optional`/`default`/`nullable` wrappers to reach the schema they wrap. */
+function unwrapToCore(schema: unknown): unknown {
+  let current = schema;
 
   for (let depth = 0; depth < 8; depth += 1) {
-    const def = readProperty(current, 'def');
-    if (def === undefined) return current;
-
-    const element = readProperty(def, 'element');
-    if (readProperty(def, 'type') === 'array' && element !== undefined) {
-      current = element;
-      continue;
-    }
-
-    const inner = readProperty(def, 'innerType');
+    const inner = readProperty(readProperty(current, 'def'), 'innerType');
     if (inner === undefined) return current;
     current = inner;
   }
 
   return current;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** The schema's field map, if it is (or wraps) a `z.object(...)`; `undefined` for anything else. */
+function objectShape(schema: unknown): Record<string, unknown> | undefined {
+  const shape = readProperty(unwrapToCore(schema), 'shape');
+  return isPlainObject(shape) ? shape : undefined;
+}
+
+/** The element schema, if this is (or wraps) a `z.array(...)`; `undefined` for anything else. */
+function arrayElement(schema: unknown): unknown {
+  const core = unwrapToCore(schema);
+  const def = readProperty(core, 'def');
+  return readProperty(def, 'type') === 'array' ? readProperty(def, 'element') : undefined;
+}
+
+const MAX_DEPTH = 6;
+
+/**
+ * Recurse into `schema` and append every reachable field path to `out`.
+ *
+ * An object schema contributes one path per key. An array of objects contributes one path per key
+ * of its element, suffixed `[]` on the array's own path. An array of a scalar (`approvedTerms`,
+ * `alternatives`) is a leaf: its own path is already pushed by the caller, and there is nothing
+ * under it to enumerate. Anything else — string, number, boolean, enum, `z.record` — is a leaf too.
+ */
+function collectFields(schema: unknown, path: string, depth: number, out: string[]): void {
+  if (depth > MAX_DEPTH) return;
+
+  const shape = objectShape(schema);
+  if (shape !== undefined) {
+    for (const [key, child] of Object.entries(shape)) {
+      const childPath = `${path}.${key}`;
+      out.push(childPath);
+      collectFields(child, childPath, depth + 1, out);
+    }
+    return;
+  }
+
+  const element = arrayElement(schema);
+  if (element === undefined) return;
+
+  const elementShape = objectShape(element);
+  if (elementShape === undefined) return; // array of a scalar: `path` is already the leaf.
+
+  const arrayPath = `${path}[]`;
+  for (const [key, child] of Object.entries(elementShape)) {
+    const childPath = `${arrayPath}.${key}`;
+    out.push(childPath);
+    collectFields(child, childPath, depth + 1, out);
+  }
+}
+
+// A raw `|` inside a description would split the markdown table into phantom columns, so it is
+// escaped defensively here rather than trusted to stay out of DESCRIPTIONS by convention alone.
+function escapeTableCell(text: string): string {
+  return text.replaceAll('|', '\\|');
 }
 
 /** Every field a pack author can set, in the notation the documentation uses. */
@@ -82,14 +172,7 @@ export function controlSurfaceFields(): string[] {
 
   for (const [key, value] of Object.entries(rulePackSchema.shape)) {
     fields.push(key);
-
-    // One level down for the two containers whose members the documentation names individually.
-    // Anything deeper is described by the schema excerpt on the page, not by this table.
-    if (key !== 'dictionary' && key !== 'rules') continue;
-
-    const inner = key === 'rules' ? unwrapArray(value) : value;
-    const prefix = key === 'rules' ? 'rules[]' : key;
-    for (const child of shapeKeys(inner)) fields.push(`${prefix}.${child}`);
+    collectFields(value, key, 1, fields);
   }
 
   return fields.toSorted();
@@ -108,7 +191,10 @@ export function renderControlSurfaceTable(): string {
     );
   }
 
-  const cells = fields.map((field) => ({ field: `\`${field}\``, what: DESCRIPTIONS[field] ?? '' }));
+  const cells = fields.map((field) => ({
+    field: `\`${field}\``,
+    what: escapeTableCell(DESCRIPTIONS[field] ?? ''),
+  }));
   const fieldWidth = Math.max(...cells.map((c) => c.field.length), 'Field'.length);
   const whatWidth = Math.max(...cells.map((c) => c.what.length), 'What it controls'.length);
 

--- a/scripts/write-pack-control-surface.ts
+++ b/scripts/write-pack-control-surface.ts
@@ -1,0 +1,24 @@
+/**
+ * Write the pack control-surface table into `docs/rule-pack-import.md`.
+ *
+ * Usage: npx tsx scripts/write-pack-control-surface.ts
+ *
+ * The page claims the table is generated. This is what generates it, so that claim stays true.
+ * `test/architecture/doc-pack-control-surface.test.ts` fails when the committed page and this
+ * renderer disagree, which is what turns "run the generator" from a convention into a build gate.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { withRenderedTable } from './lib/pack-control-surface.js';
+
+const DOC = resolve(import.meta.dirname, '..', 'docs', 'rule-pack-import.md');
+
+const before = readFileSync(DOC, 'utf8');
+const after = withRenderedTable(before);
+
+if (before === after) {
+  console.log(`${DOC} is already up to date.`);
+} else {
+  writeFileSync(DOC, after);
+  console.log(`Rewrote the control-surface table in ${DOC}.`);
+}

--- a/src/rule-pack/schema.ts
+++ b/src/rule-pack/schema.ts
@@ -4,9 +4,20 @@ import { z } from 'zod';
  * Rule-pack schema — the **only** supported route by which normative controlled-language data
  * enters this package.
  *
- * Nothing in `src/deterministic` hard-codes vocabulary. Every word list, term mapping and numeric
- * limit is read from a pack that satisfies this schema, so an authorised licensee can supply the
- * real dictionary and rule data without changing a line of rule code.
+ * The controlled-language dictionary, the term mappings and the numeric limits are read from a
+ * pack that satisfies this schema, so an authorised licensee can supply the real dictionary and
+ * rule data without changing a line of rule code.
+ *
+ * That is not the same as "no rule hard-codes vocabulary", which this comment used to claim and
+ * which is false: `src/deterministic/rules/candidate-rules.ts` holds `PARTICIPLES`, `PRONOUNS` and
+ * `BARE_DEMONSTRATIVE_FOLLOWERS` in code, and no field here reaches them. A pack can suppress one
+ * of those triggers, because `approvedTechnicalTerms` protects a token before any rule scans it,
+ * but it cannot add a word to the list. The limitation runs one way only.
+ *
+ * Do not restate the control surface in prose here or anywhere else. It is generated from this
+ * schema into `docs/rule-pack-import.md` and enforced by
+ * `test/architecture/doc-pack-control-surface.test.ts`; every hand-maintained version of the list
+ * has gone stale and been caught in review.
  *
  * See `docs/rule-pack-import.md` for the import procedure and the licence obligations.
  */

--- a/test/architecture/doc-pack-control-surface.test.ts
+++ b/test/architecture/doc-pack-control-surface.test.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
-import { rulePackSchema } from '../../src/rule-pack/schema.js';
+import {
+  BEGIN,
+  END,
+  controlSurfaceFields,
+  renderControlSurfaceTable,
+} from '../../scripts/lib/pack-control-surface.js';
 
 /**
- * The pack control surface, derived rather than asserted.
+ * The pack control surface, generated rather than asserted.
  *
  * `docs/rule-pack-import.md` has to tell a pack author what a pack can and cannot change. Every
  * previous attempt to write that as a hand-maintained sentence went stale the moment the schema
@@ -13,78 +18,18 @@ import { rulePackSchema } from '../../src/rule-pack/schema.js';
  * `approvedTechnicalTerms`, `contractions`, and the per-rule `enabled`, `severity` and `sourceRef`
  * fields — while the same page's own example block used them.
  *
- * Answering that finding again in prose would buy one round. The list is generated from
- * `rulePackSchema` instead, and this test fails if the documentation and the schema disagree in
- * either direction. Adding a field to the schema without documenting it is now a build failure,
- * and so is documenting a field that does not exist.
+ * Answering that finding again in prose would buy one round. `scripts/lib/pack-control-surface.ts`
+ * renders the table from `rulePackSchema` instead, and this test compares the committed page
+ * against that renderer byte for byte. A schema field added without a description throws in the
+ * renderer; a field added without regenerating the page fails here; and an edit to the page that
+ * the renderer would not produce fails here too, so the page cannot be hand-tuned back out of sync.
  */
 
 const DOC = resolve(import.meta.dirname, '..', '..', 'docs', 'rule-pack-import.md');
-const BEGIN = '<!-- pack-control-surface:begin -->';
-const END = '<!-- pack-control-surface:end -->';
+const REGENERATE = 'npx tsx scripts/write-pack-control-surface.ts';
 
-/**
- * Read one property without asserting a shape onto a Zod internal.
- *
- * Zod's `def` layout is not part of its public contract, so this walks it defensively: a missing
- * or renamed key yields `undefined` and the caller stops, rather than throwing somewhere less
- * obvious. The two assertions at the bottom of this file are what catch that, by failing when the
- * derived surface stops looking like a real one.
- */
-function readProperty(value: unknown, key: string): unknown {
-  if (typeof value !== 'object' || value === null) return undefined;
-  return Reflect.get(value, key);
-}
-
-function shapeKeys(value: unknown): string[] {
-  const shape = readProperty(value, 'shape');
-  if (typeof shape !== 'object' || shape === null) return [];
-  return Object.keys(shape);
-}
-
-/** `z.array(x).default([])` wraps the element type more than once; reach the element schema. */
-function unwrapArray(value: unknown): unknown {
-  let current = value;
-
-  for (let depth = 0; depth < 8; depth += 1) {
-    const def = readProperty(current, 'def');
-    if (def === undefined) return current;
-
-    const element = readProperty(def, 'element');
-    if (readProperty(def, 'type') === 'array' && element !== undefined) {
-      current = element;
-      continue;
-    }
-
-    const inner = readProperty(def, 'innerType');
-    if (inner === undefined) return current;
-    current = inner;
-  }
-
-  return current;
-}
-
-/** Every field a pack author can set, in the notation the documentation uses. */
-function schemaControlSurface(): string[] {
-  const surface: string[] = [];
-
-  for (const [key, value] of Object.entries(rulePackSchema.shape)) {
-    surface.push(key);
-
-    // One level down for the two containers whose members the documentation names individually.
-    // Anything deeper is described by the schema excerpt on the page, not by this table.
-    if (key !== 'dictionary' && key !== 'rules') continue;
-
-    const inner = key === 'rules' ? unwrapArray(value) : value;
-    const prefix = key === 'rules' ? 'rules[]' : key;
-    for (const child of shapeKeys(inner)) surface.push(`${prefix}.${child}`);
-  }
-
-  return surface.toSorted();
-}
-
-/** The identifiers the documentation lists in the generated block's first column. */
-function documentedControlSurface(): string[] {
+/** The exact text the page carries between the two markers. */
+function committedBlock(): string {
   const markdown = readFileSync(DOC, 'utf8');
   const start = markdown.indexOf(BEGIN);
   const end = markdown.indexOf(END);
@@ -92,31 +37,34 @@ function documentedControlSurface(): string[] {
   expect(start, `${DOC} is missing ${BEGIN}`).toBeGreaterThan(-1);
   expect(end, `${DOC} is missing ${END}`).toBeGreaterThan(start);
 
-  const block = markdown.slice(start + BEGIN.length, end);
-  const documented: string[] = [];
-
-  for (const line of block.split('\n')) {
-    const row = line.trim();
-    if (!row.startsWith('|')) continue;
-    const firstColumn = row.split('|')[1]?.trim() ?? '';
-    const identifier = /^`([^`]+)`$/.exec(firstColumn)?.[1];
-    if (identifier !== undefined) documented.push(identifier);
-  }
-
-  return documented.toSorted();
+  return markdown.slice(start + BEGIN.length, end);
 }
 
 describe('documented pack control surface', () => {
-  it('lists every field the schema exposes, and no field it does not', () => {
-    expect(documentedControlSurface()).toStrictEqual(schemaControlSurface());
+  it('matches what the generator produces from the schema', () => {
+    expect(committedBlock(), `${DOC} is stale. Run: ${REGENERATE}`).toBe(
+      renderControlSurfaceTable(),
+    );
   });
 
   it('derives a non-trivial surface, so a silently empty match cannot pass', () => {
-    // Guards the assertion above: two empty lists are equal, and would make this file decorative.
-    const surface = schemaControlSurface();
+    // Guards the assertion above. Zod's `def` layout is not public API, so a version bump could
+    // make the walk return nothing; two empty tables compare equal and would leave this file
+    // decorative. These are the fields whose omission caused the original review findings.
+    const fields = controlSurfaceFields();
 
-    expect(surface.length).toBeGreaterThan(10);
-    expect(surface).toContain('approvedTechnicalTerms');
-    expect(surface).toContain('rules[].severity');
+    expect(fields.length).toBeGreaterThan(10);
+    expect(fields).toContain('approvedTechnicalTerms');
+    expect(fields).toContain('contractions');
+    expect(fields).toContain('rules[].severity');
+    expect(fields).toContain('rules[].sourceRef');
+  });
+
+  it('refuses to render a field it has no description for', () => {
+    // The ratchet: adding a schema field forces you to say what it controls, rather than silently
+    // rendering a blank cell that reads as "this does nothing".
+    const described = renderControlSurfaceTable();
+
+    for (const field of controlSurfaceFields()) expect(described).toContain(`\`${field}\``);
   });
 });

--- a/test/architecture/doc-pack-control-surface.test.ts
+++ b/test/architecture/doc-pack-control-surface.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import { rulePackSchema } from '../../src/rule-pack/schema.js';
+
+/**
+ * The pack control surface, derived rather than asserted.
+ *
+ * `docs/rule-pack-import.md` has to tell a pack author what a pack can and cannot change. Every
+ * previous attempt to write that as a hand-maintained sentence went stale the moment the schema
+ * grew a field, and external review kept catching it one omission at a time: an "only the
+ * dictionary, the limits, and per-rule options and authority" claim silently dropped
+ * `approvedTechnicalTerms`, `contractions`, and the per-rule `enabled`, `severity` and `sourceRef`
+ * fields — while the same page's own example block used them.
+ *
+ * Answering that finding again in prose would buy one round. The list is generated from
+ * `rulePackSchema` instead, and this test fails if the documentation and the schema disagree in
+ * either direction. Adding a field to the schema without documenting it is now a build failure,
+ * and so is documenting a field that does not exist.
+ */
+
+const DOC = resolve(import.meta.dirname, '..', '..', 'docs', 'rule-pack-import.md');
+const BEGIN = '<!-- pack-control-surface:begin -->';
+const END = '<!-- pack-control-surface:end -->';
+
+/**
+ * Read one property without asserting a shape onto a Zod internal.
+ *
+ * Zod's `def` layout is not part of its public contract, so this walks it defensively: a missing
+ * or renamed key yields `undefined` and the caller stops, rather than throwing somewhere less
+ * obvious. The two assertions at the bottom of this file are what catch that, by failing when the
+ * derived surface stops looking like a real one.
+ */
+function readProperty(value: unknown, key: string): unknown {
+  if (typeof value !== 'object' || value === null) return undefined;
+  return Reflect.get(value, key);
+}
+
+function shapeKeys(value: unknown): string[] {
+  const shape = readProperty(value, 'shape');
+  if (typeof shape !== 'object' || shape === null) return [];
+  return Object.keys(shape);
+}
+
+/** `z.array(x).default([])` wraps the element type more than once; reach the element schema. */
+function unwrapArray(value: unknown): unknown {
+  let current = value;
+
+  for (let depth = 0; depth < 8; depth += 1) {
+    const def = readProperty(current, 'def');
+    if (def === undefined) return current;
+
+    const element = readProperty(def, 'element');
+    if (readProperty(def, 'type') === 'array' && element !== undefined) {
+      current = element;
+      continue;
+    }
+
+    const inner = readProperty(def, 'innerType');
+    if (inner === undefined) return current;
+    current = inner;
+  }
+
+  return current;
+}
+
+/** Every field a pack author can set, in the notation the documentation uses. */
+function schemaControlSurface(): string[] {
+  const surface: string[] = [];
+
+  for (const [key, value] of Object.entries(rulePackSchema.shape)) {
+    surface.push(key);
+
+    // One level down for the two containers whose members the documentation names individually.
+    // Anything deeper is described by the schema excerpt on the page, not by this table.
+    if (key !== 'dictionary' && key !== 'rules') continue;
+
+    const inner = key === 'rules' ? unwrapArray(value) : value;
+    const prefix = key === 'rules' ? 'rules[]' : key;
+    for (const child of shapeKeys(inner)) surface.push(`${prefix}.${child}`);
+  }
+
+  return surface.toSorted();
+}
+
+/** The identifiers the documentation lists in the generated block's first column. */
+function documentedControlSurface(): string[] {
+  const markdown = readFileSync(DOC, 'utf8');
+  const start = markdown.indexOf(BEGIN);
+  const end = markdown.indexOf(END);
+
+  expect(start, `${DOC} is missing ${BEGIN}`).toBeGreaterThan(-1);
+  expect(end, `${DOC} is missing ${END}`).toBeGreaterThan(start);
+
+  const block = markdown.slice(start + BEGIN.length, end);
+  const documented: string[] = [];
+
+  for (const line of block.split('\n')) {
+    const row = line.trim();
+    if (!row.startsWith('|')) continue;
+    const firstColumn = row.split('|')[1]?.trim() ?? '';
+    const identifier = /^`([^`]+)`$/.exec(firstColumn)?.[1];
+    if (identifier !== undefined) documented.push(identifier);
+  }
+
+  return documented.toSorted();
+}
+
+describe('documented pack control surface', () => {
+  it('lists every field the schema exposes, and no field it does not', () => {
+    expect(documentedControlSurface()).toStrictEqual(schemaControlSurface());
+  });
+
+  it('derives a non-trivial surface, so a silently empty match cannot pass', () => {
+    // Guards the assertion above: two empty lists are equal, and would make this file decorative.
+    const surface = schemaControlSurface();
+
+    expect(surface.length).toBeGreaterThan(10);
+    expect(surface).toContain('approvedTechnicalTerms');
+    expect(surface).toContain('rules[].severity');
+  });
+});

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1,0 +1,450 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import { analyseTextDeterministic } from '../../src/analysis/analyse.js';
+import { packPermitsConformanceClaim, parseRulePack } from '../../src/rule-pack/loader.js';
+
+/**
+ * The rule pack is this package's only extension point, and until this file existed it had no test
+ * coverage at all: nothing in `test/` referenced `rulePack`, `trustedRulePackIds`,
+ * `verifiedAuthority` or `packPermitsConformanceClaim`. Its entire specification lived as prose in
+ * `docs/rule-pack-import.md`, `README.md` and a doc comment in `src/rule-pack/schema.ts`.
+ *
+ * Three of those four artefacts drifted from the code and from each other, and external review
+ * found the drift one claim at a time across three rounds of PR #90 — six findings, every one of
+ * the form "the prose asserts X, the code does Y". Prose cannot fail a build, so each correction
+ * was itself unverified and introduced the next inaccuracy.
+ *
+ * What is pinned here is therefore not "the pack loader works". It is every behavioural claim the
+ * documentation makes, expressed so that a future change to the behaviour fails CI instead of
+ * silently making the documentation wrong again. When a claim here changes, the doc changes with
+ * it; `test/architecture/doc-pack-control-surface.test.ts` enforces the other direction, so a
+ * schema field cannot be added without the page that documents it being updated too.
+ */
+
+const PACK_ID = 'acme-test-pack';
+
+/** Matches `test/e2e/example-config.test.ts`: a real runtime check, not an assumption. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** A minimal valid pack. Zod fills the rest; overrides replace whole top-level keys. */
+function pack(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    metadata: {
+      id: PACK_ID,
+      name: 'Acme test pack',
+      version: '1.0.0',
+      authority: 'normative',
+      licence: 'Proprietary — test fixture',
+      source: 'Authored for this test. Not derived from any standard.',
+      conformanceClaim: 'declared-by-supplier',
+    },
+    limits: {
+      proceduralMaxGradeLevel: 7,
+      descriptiveMaxGradeLevel: 8,
+      sentenceReadabilityFloorWords: 20,
+      maxNounClusterLength: 3,
+      maxSentencesPerProceduralStep: 1,
+    },
+    dictionary: {
+      approved: [],
+      unapproved: [{ term: 'utilise', alternatives: ['use'] }],
+      preferred: [],
+    },
+    contractions: [],
+    approvedTechnicalTerms: [],
+    rules: [
+      { ruleId: 'unapproved-vocabulary', status: 'normative', sourceRef: 'ACME-DOC-1 clause 4' },
+      {
+        ruleId: 'passive-voice-candidate',
+        status: 'provisional',
+        sourceRef: 'ACME-DOC-1 clause 9',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** A deterministic violation of `unapproved-vocabulary`, per the pack's dictionary above. */
+const VOCABULARY_DOC = 'Utilise the bracket.\n';
+/** Triggers `passive-voice-candidate`, which emits a candidate rather than a diagnostic. */
+const PASSIVE_DOC = 'The bracket is removed by the technician.\n';
+
+function analyse(text: string, config: Record<string, unknown>) {
+  return analyseTextDeterministic(text, { config: config });
+}
+
+function only(text: string, config: Record<string, unknown>, ruleId: string) {
+  const found = analyse(text, config).diagnostics.filter((d) => d.ruleId === ruleId);
+  expect(found, `expected exactly one ${ruleId} diagnostic`).toHaveLength(1);
+  return found[0]!;
+}
+
+describe('rule pack: the trust gate', () => {
+  it('caps an untrusted pack at supplementary however it declares itself', () => {
+    // Schema validation proves shape, never provenance: any JSON file can assert
+    // `authority: "normative"`, so a pack cannot elevate itself.
+    const diagnostic = only(VOCABULARY_DOC, { rulePack: pack() }, 'unapproved-vocabulary');
+
+    expect(diagnostic.ruleStatus).toBe('supplementary');
+  });
+
+  it('honours a declared status only once the operator names the pack as trusted', () => {
+    const diagnostic = only(
+      VOCABULARY_DOC,
+      { rulePack: pack(), trustedRulePackIds: [PACK_ID] },
+      'unapproved-vocabulary',
+    );
+
+    expect(diagnostic.ruleStatus).toBe('normative');
+    expect(diagnostic.meta).toMatchObject({ sourceRef: 'ACME-DOC-1 clause 4' });
+  });
+
+  it('matches the trust entry against metadata.id, not the pack name or file path', () => {
+    const diagnostic = only(
+      VOCABULARY_DOC,
+      { rulePack: pack(), trustedRulePackIds: ['Acme test pack'] },
+      'unapproved-vocabulary',
+    );
+
+    expect(diagnostic.ruleStatus).toBe('supplementary');
+  });
+});
+
+describe('rule pack: status propagation differs by rule path', () => {
+  /**
+   * The asymmetry below is the behaviour external review flagged twice on PR #90, and it is the
+   * reason a pack author cannot reason about `rules[].status` alone.
+   *
+   * `runDeterministicRules()` applies the pack's per-rule status to `output.diagnostics` only
+   * (`src/core/runner.ts`). Candidates bypass that entirely and are stamped later with the
+   * pack-*wide* `verifiedAuthority()` (`src/analysis/analyse.ts`). So omitting a rule from
+   * `rules[]` moves its reported status in opposite directions depending on which path it takes.
+   */
+
+  it('falls back to the rule default when a deterministic rule is absent from rules[]', () => {
+    const diagnostic = only(
+      VOCABULARY_DOC,
+      { rulePack: pack({ rules: [] }), trustedRulePackIds: [PACK_ID] },
+      'unapproved-vocabulary',
+    );
+
+    // Trusted, normative pack — and still provisional, because nothing in `rules[]` named the rule.
+    expect(diagnostic.ruleStatus).toBe('provisional');
+    expect(diagnostic.meta).not.toHaveProperty('sourceRef');
+  });
+
+  it('ignores rules[].status for a candidate rule and applies pack-wide authority instead', () => {
+    // The pack lists this rule as `provisional`. The reported status is `normative` regardless.
+    const diagnostic = only(
+      PASSIVE_DOC,
+      { rulePack: pack(), trustedRulePackIds: [PACK_ID] },
+      'passive-voice-candidate',
+    );
+
+    expect(diagnostic.category).toBe('review-required');
+    expect(diagnostic.ruleStatus).toBe('normative');
+  });
+
+  it('drops rules[].sourceRef entirely on the candidate path', () => {
+    // A pack's citation reaches a deterministic diagnostic but never a review-required one.
+    const diagnostic = only(
+      PASSIVE_DOC,
+      { rulePack: pack(), trustedRulePackIds: [PACK_ID] },
+      'passive-voice-candidate',
+    );
+
+    expect(diagnostic.meta).not.toHaveProperty('sourceRef');
+    expect(diagnostic.meta).toMatchObject({ evaluatorId: 'passive-voice-adjudication' });
+  });
+
+  it('still caps the candidate path at supplementary for an untrusted pack', () => {
+    const diagnostic = only(PASSIVE_DOC, { rulePack: pack() }, 'passive-voice-candidate');
+
+    expect(diagnostic.ruleStatus).toBe('supplementary');
+  });
+});
+
+describe('rule pack: what the pack actually controls', () => {
+  it('supplies the vocabulary a deterministic rule matches on', () => {
+    const clean = analyse(VOCABULARY_DOC, {
+      rulePack: pack({ dictionary: { approved: [], unapproved: [], preferred: [] } }),
+    });
+
+    expect(clean.diagnostics.filter((d) => d.ruleId === 'unapproved-vocabulary')).toHaveLength(0);
+  });
+
+  it('protects approvedTechnicalTerms from vocabulary matching', () => {
+    // This is pack-controlled vocabulary in every practical sense: it silences a finding the same
+    // pack's own `dictionary.unapproved` produces. Any "the pack only controls the dictionary"
+    // wording that omits it is wrong.
+    const result = analyse(VOCABULARY_DOC, {
+      rulePack: pack({ approvedTechnicalTerms: ['Utilise'] }),
+      trustedRulePackIds: [PACK_ID],
+    });
+
+    expect(result.diagnostics.filter((d) => d.ruleId === 'unapproved-vocabulary')).toHaveLength(0);
+  });
+
+  it('sets a default severity that user configuration overrides', () => {
+    const packRules = [
+      {
+        ruleId: 'unapproved-vocabulary',
+        status: 'normative',
+        sourceRef: 'ACME-DOC-1 clause 4',
+        severity: 'warning',
+      },
+    ];
+
+    const fromPack = only(
+      VOCABULARY_DOC,
+      { rulePack: pack({ rules: packRules }), trustedRulePackIds: [PACK_ID] },
+      'unapproved-vocabulary',
+    );
+    expect(fromPack.severity).toBe('warning');
+
+    const fromUser = only(
+      VOCABULARY_DOC,
+      {
+        rulePack: pack({ rules: packRules }),
+        trustedRulePackIds: [PACK_ID],
+        rules: { 'unapproved-vocabulary': { severity: 'info' } },
+      },
+      'unapproved-vocabulary',
+    );
+    expect(fromUser.severity, 'user configuration outranks the pack').toBe('info');
+  });
+
+  it('turns a rule off through rules[].enabled', () => {
+    const result = analyse(VOCABULARY_DOC, {
+      rulePack: pack({
+        rules: [
+          {
+            ruleId: 'unapproved-vocabulary',
+            status: 'normative',
+            sourceRef: 'ACME-DOC-1 clause 4',
+            enabled: false,
+          },
+        ],
+      }),
+      trustedRulePackIds: [PACK_ID],
+    });
+
+    expect(result.diagnostics.filter((d) => d.ruleId === 'unapproved-vocabulary')).toHaveLength(0);
+  });
+});
+
+describe('rule pack: what the pack cannot control', () => {
+  it('cannot extend a hard-coded trigger list', () => {
+    // `PRONOUNS` in `src/deterministic/rules/candidate-rules.ts` is hard-coded and holds
+    // `it/they/them/this/these/those/which/its/their`. "He" is absent, and no pack field adds it:
+    // declaring it in the dictionary produces an unrelated vocabulary finding, never a pronoun
+    // one. An authorised licensee therefore cannot supply this rule's trigger vocabulary the way
+    // they supply the dictionary — the claim `src/rule-pack/schema.ts` used to deny.
+    const result = analyse('Remove the bracket and the filter. He is damaged.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [{ term: 'he', alternatives: ['the technician'] }],
+          preferred: [],
+        },
+      }),
+      trustedRulePackIds: [PACK_ID],
+    });
+
+    expect(
+      result.diagnostics.filter((d) => d.ruleId === 'ambiguous-pronoun-candidate'),
+    ).toHaveLength(0);
+  });
+
+  it('can nonetheless suppress a hard-coded trigger by protecting the token', () => {
+    // The limitation above is one-directional, which is the part the prose kept getting wrong.
+    // A pack cannot add a trigger word, but `approvedTechnicalTerms` protects a token from being
+    // scanned at all, so it can remove one. "A pack cannot change those lists" overstates it.
+    const flagged = analyse('Remove the bracket and the filter. It is damaged.\n', {
+      rulePack: pack(),
+      trustedRulePackIds: [PACK_ID],
+    });
+    expect(
+      flagged.diagnostics.filter((d) => d.ruleId === 'ambiguous-pronoun-candidate'),
+    ).toHaveLength(1);
+
+    const protectedRun = analyse('Remove the bracket and the filter. It is damaged.\n', {
+      rulePack: pack({ approvedTechnicalTerms: ['It'] }),
+      trustedRulePackIds: [PACK_ID],
+    });
+    expect(
+      protectedRun.diagnostics.filter((d) => d.ruleId === 'ambiguous-pronoun-candidate'),
+    ).toHaveLength(0);
+  });
+
+  it('cannot add a rule that does not exist in code', () => {
+    const result = analyse(VOCABULARY_DOC, {
+      rulePack: pack({
+        rules: [
+          { ruleId: 'acme-invented-rule', status: 'normative', sourceRef: 'ACME-DOC-1 clause 99' },
+        ],
+      }),
+      trustedRulePackIds: [PACK_ID],
+    });
+
+    expect(result.diagnostics.filter((d) => d.ruleId === 'acme-invented-rule')).toHaveLength(0);
+  });
+});
+
+describe('rule pack: the conformance claim gate', () => {
+  /**
+   * Three conditions, all required. The doc claimed for a while that nothing emits a conformance
+   * claim at all; the CLI does emit one, through this gate, so the truth table is pinned here.
+   */
+  const cases: ReadonlyArray<{
+    readonly name: string;
+    readonly authority: string;
+    readonly claim: string;
+    readonly trusted: readonly string[];
+    readonly expected: boolean;
+  }> = [
+    {
+      name: 'normative + claim + trusted',
+      authority: 'normative',
+      claim: 'declared-by-supplier',
+      trusted: [PACK_ID],
+      expected: true,
+    },
+    {
+      name: 'normative + claim, untrusted',
+      authority: 'normative',
+      claim: 'declared-by-supplier',
+      trusted: [],
+      expected: false,
+    },
+    {
+      name: 'normative + trusted, but claim is none',
+      authority: 'normative',
+      claim: 'none',
+      trusted: [PACK_ID],
+      expected: false,
+    },
+    {
+      name: 'claim + trusted, but authority is supplementary',
+      authority: 'supplementary',
+      claim: 'partial',
+      trusted: [PACK_ID],
+      expected: false,
+    },
+  ];
+
+  for (const { name, authority, claim, trusted, expected } of cases) {
+    it(`${expected ? 'permits' : 'refuses'} a claim: ${name}`, () => {
+      const parsed = parseRulePack(
+        pack({
+          metadata: {
+            id: PACK_ID,
+            name: 'Acme test pack',
+            version: '1.0.0',
+            authority,
+            licence: 'Proprietary — test fixture',
+            source: 'Authored for this test.',
+            conformanceClaim: claim,
+          },
+        }),
+        'test',
+      );
+
+      expect(packPermitsConformanceClaim(parsed, trusted)).toBe(expected);
+    });
+  }
+
+  it('refuses a claim for the bundled provisional pack', () => {
+    const result = analyse(VOCABULARY_DOC, {});
+    const bundled = result.diagnostics.filter((d) => d.ruleId === 'unapproved-vocabulary');
+
+    // The bundled pack declares `provisional` authority and `conformanceClaim: 'none'`, so it
+    // fails the gate on two of the three conditions independently of any trust list.
+    for (const diagnostic of bundled) expect(diagnostic.ruleStatus).toBe('provisional');
+  });
+});
+
+describe('the shipped example pack', () => {
+  /**
+   * `examples/rule-pack/` is documentation that executes, in the same sense as
+   * `test/e2e/example-config.test.ts`: its README quotes finding counts, and a reader who copies
+   * the directory expects to see them. These assertions are those quoted numbers. Change the
+   * example and this fails until the README agrees again.
+   */
+
+  const EXAMPLE = resolve(import.meta.dirname, '..', '..', 'examples', 'rule-pack');
+
+  function examplePack(): Record<string, unknown> {
+    const parsed: unknown = JSON.parse(readFileSync(resolve(EXAMPLE, 'acme-pack.json'), 'utf8'));
+    if (!isRecord(parsed)) {
+      throw new TypeError('examples/rule-pack/acme-pack.json is not a JSON object');
+    }
+    return parsed;
+  }
+
+  const sample = () => readFileSync(resolve(EXAMPLE, 'sample.md'), 'utf8');
+
+  function errorIds(config: Record<string, unknown>): string[] {
+    return analyse(sample(), config)
+      .diagnostics.filter((d) => d.category === 'deterministic-violation')
+      .map((d) => d.ruleId)
+      .toSorted();
+  }
+
+  it('parses against the real schema', () => {
+    expect(() => parseRulePack(examplePack(), 'examples/rule-pack/acme-pack.json')).not.toThrow();
+  });
+
+  it('reports one error under the bundled pack', () => {
+    // "Utilise" only. The bundled dictionary knows nothing of the Acme vocabulary.
+    expect(errorIds({})).toStrictEqual(['unapproved-vocabulary']);
+  });
+
+  it('reports three errors under the example pack, and no longer flags Utilise', () => {
+    // A pack *replaces* the dictionary rather than adding to it. This is the single fact readers
+    // most often get wrong, so the example is built to show it rather than assert it.
+    const ids = errorIds({ rulePack: examplePack() });
+
+    expect(ids).toStrictEqual([
+      'preferred-terminology',
+      'unapproved-vocabulary',
+      'unapproved-vocabulary',
+    ]);
+
+    const messages = analyse(sample(), { rulePack: examplePack() }).diagnostics.map(
+      (d) => d.message,
+    );
+    expect(messages.some((m) => m.includes('Utilise'))).toBe(false);
+  });
+
+  it('protects the product name through approvedTechnicalTerms', () => {
+    const messages = analyse(sample(), { rulePack: examplePack() }).diagnostics.map(
+      (d) => d.message,
+    );
+
+    expect(messages.some((m) => m.includes('WidgetPro'))).toBe(false);
+  });
+
+  it('reports supplementary until trusted, and normative once trusted', () => {
+    const untrusted = analyse(sample(), { rulePack: examplePack() }).diagnostics.filter(
+      (d) => d.ruleId === 'unapproved-vocabulary',
+    );
+    for (const diagnostic of untrusted) expect(diagnostic.ruleStatus).toBe('supplementary');
+
+    const trusted = analyse(sample(), {
+      rulePack: examplePack(),
+      trustedRulePackIds: ['acme-maintenance-2026'],
+    }).diagnostics.filter((d) => d.ruleId === 'unapproved-vocabulary');
+    for (const diagnostic of trusted) expect(diagnostic.ruleStatus).toBe('normative');
+  });
+
+  it('permits a conformance claim only once the operator trusts it', () => {
+    const parsed = parseRulePack(examplePack(), 'example');
+
+    expect(packPermitsConformanceClaim(parsed, [])).toBe(false);
+    expect(packPermitsConformanceClaim(parsed, ['acme-maintenance-2026'])).toBe(true);
+  });
+});

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -509,6 +509,37 @@ describe('rule pack: limits, contractions, path resolution, and the autofix gate
     expect(tightened, 'a near-zero limit must flag the same sentence').toHaveLength(1);
   });
 
+  it('applies rules[].options as a default that user configuration outranks', () => {
+    // docs/rule-pack-import.md's control-surface table: "rules[].options — Default options, below
+    // anything the user configures." Three layers, in ascending precedence: the rule's own default
+    // (here, pack.limits.descriptiveMaxGradeLevel, since neither options source sets one), the
+    // pack's rules[].options, and the user's own rules[] config.
+    const packOptions = {
+      ruleId: 'sentence-length-descriptive',
+      status: 'provisional',
+      sourceRef: 'ACME-DOC-1 clause 1',
+      options: { maxGradeLevel: 20 },
+    };
+
+    const fallsBackToPackLimits = analyse(DESCRIPTIVE_SENTENCE, {
+      rulePack: pack({ limits: limitsWith({ descriptiveMaxGradeLevel: 8 }), rules: [] }),
+    }).diagnostics.filter((d) => d.ruleId === 'sentence-length-descriptive');
+    expect(fallsBackToPackLimits, 'no rules[].options: falls back to pack.limits').toHaveLength(1);
+
+    const usesPackOptions = analyse(DESCRIPTIVE_SENTENCE, {
+      rulePack: pack({ rules: [packOptions] }),
+    }).diagnostics.filter((d) => d.ruleId === 'sentence-length-descriptive');
+    expect(usesPackOptions, 'rules[].options.maxGradeLevel=20 permits this sentence').toHaveLength(
+      0,
+    );
+
+    const userOutranksPack = analyse(DESCRIPTIVE_SENTENCE, {
+      rulePack: pack({ rules: [packOptions] }),
+      rules: { 'sentence-length-descriptive': { maxGradeLevel: 1 } },
+    }).diagnostics.filter((d) => d.ruleId === 'sentence-length-descriptive');
+    expect(userOutranksPack, 'user config overrides the pack default of 20').toHaveLength(1);
+  });
+
   it('drives no-contractions from contractions[]', () => {
     const text = "The technician confirms it's ready.\n";
 

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -13,12 +13,8 @@ import {
  * The rule pack is this package's only extension point, and until this file existed it had no test
  * coverage at all: nothing in `test/` referenced `rulePack`, `trustedRulePackIds`,
  * `verifiedAuthority` or `packPermitsConformanceClaim`. Its entire specification lived as prose in
- * `docs/rule-pack-import.md`, `README.md` and a doc comment in `src/rule-pack/schema.ts`.
- *
- * Three of those four artefacts drifted from the code and from each other, and external review
- * found the drift one claim at a time across three rounds of PR #90 — six findings, every one of
- * the form "the prose asserts X, the code does Y". Prose cannot fail a build, so each correction
- * was itself unverified and introduced the next inaccuracy.
+ * `docs/rule-pack-import.md`, `README.md` and a doc comment in `src/rule-pack/schema.ts`, which let
+ * the same behavioural claim drift from the code and from each other, independently, undetected.
  *
  * What is pinned here is therefore not "the pack loader works". It is every behavioural claim the
  * documentation makes, expressed so that a future change to the behaviour fails CI instead of

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1,8 +1,13 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 import { analyseTextDeterministic } from '../../src/analysis/analyse.js';
-import { packPermitsConformanceClaim, parseRulePack } from '../../src/rule-pack/loader.js';
+import {
+  RulePackError,
+  packPermitsConformanceClaim,
+  parseRulePack,
+} from '../../src/rule-pack/loader.js';
 
 /**
  * The rule pack is this package's only extension point, and until this file existed it had no test
@@ -80,6 +85,33 @@ function only(text: string, config: Record<string, unknown>, ruleId: string) {
   const found = analyse(text, config).diagnostics.filter((d) => d.ruleId === ruleId);
   expect(found, `expected exactly one ${ruleId} diagnostic`).toHaveLength(1);
   return found[0]!;
+}
+
+/** `pack()`'s default limits, so a test overriding one field doesn't have to restate the rest. */
+function limitsWith(overrides: Record<string, number>): Record<string, number> {
+  return {
+    proceduralMaxGradeLevel: 7,
+    descriptiveMaxGradeLevel: 8,
+    sentenceReadabilityFloorWords: 20,
+    maxNounClusterLength: 3,
+    maxSentencesPerProceduralStep: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * The thrown value, or `undefined` if `fn` did not throw.
+ *
+ * Kept out of a try/catch at the call site so the assertions on the result are never inside a
+ * conditional block — `vitest/no-conditional-expect` forbids `expect()` inside `catch`.
+ */
+function caughtError(fn: () => void): unknown {
+  try {
+    fn();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
 }
 
 describe('rule pack: the trust gate', () => {
@@ -446,5 +478,144 @@ describe('the shipped example pack', () => {
 
     expect(packPermitsConformanceClaim(parsed, [])).toBe(false);
     expect(packPermitsConformanceClaim(parsed, ['acme-maintenance-2026'])).toBe(true);
+  });
+});
+
+describe('rule pack: limits, contractions, path resolution, and the autofix gate', () => {
+  /**
+   * External review on this PR named four claims the page makes that nothing above exercised:
+   * `limits`, `contractions`, resolving a relative `rulePack` path against `baseDir`, and the
+   * autofix gate refusing a fix despite a pack's `safeSubstitution: true`. Removing the blanket "is
+   * pinned by" claim would have been the cheaper fix; this is the other one, closing the gap
+   * instead of describing it.
+   */
+
+  // Estimated Flesch-Kincaid grade 15.4 (28 words) under the bundled reader — comfortably between
+  // the two limit values exercised below, and confirmed empirically rather than assumed: see the
+  // identical sentence in test/unit/rules.test.ts's "applies the descriptive limit" case.
+  const DESCRIPTIVE_SENTENCE =
+    'The controller monitors the supply voltage and the ambient temperature and then reports ' +
+    'both of these values to the host system over the diagnostic bus once every second.\n';
+
+  it('drives sentence-length-descriptive from limits.descriptiveMaxGradeLevel', () => {
+    const atDefault = analyse(DESCRIPTIVE_SENTENCE, {
+      rulePack: pack({ limits: limitsWith({ descriptiveMaxGradeLevel: 20 }) }),
+    }).diagnostics.filter((d) => d.ruleId === 'sentence-length-descriptive');
+    expect(atDefault, 'a permissive limit must not flag this sentence').toHaveLength(0);
+
+    const tightened = analyse(DESCRIPTIVE_SENTENCE, {
+      rulePack: pack({ limits: limitsWith({ descriptiveMaxGradeLevel: 1 }) }),
+    }).diagnostics.filter((d) => d.ruleId === 'sentence-length-descriptive');
+    expect(tightened, 'a near-zero limit must flag the same sentence').toHaveLength(1);
+  });
+
+  it('drives no-contractions from contractions[]', () => {
+    const text = "The technician confirms it's ready.\n";
+
+    const withoutEntry = analyse(text, { rulePack: pack({ contractions: [] }) }).diagnostics.filter(
+      (d) => d.ruleId === 'no-contractions',
+    );
+    expect(withoutEntry).toHaveLength(0);
+
+    const withEntry = analyse(text, {
+      rulePack: pack({
+        contractions: [{ from: "it's", to: 'it is', safeSubstitution: true }],
+      }),
+    }).diagnostics.filter((d) => d.ruleId === 'no-contractions');
+    expect(withEntry).toHaveLength(1);
+  });
+
+  it('throws RulePackError with the failing field path, never falling back silently', () => {
+    // docs/rule-pack-import.md, "The schema": "A pack that fails validation throws RulePackError
+    // with the failing field paths. The linter never falls back to the provisional pack silently."
+    const invalid = pack({
+      metadata: {
+        id: PACK_ID,
+        name: 'Acme test pack',
+        version: '1.0.0',
+        authority: 'not-a-real-status',
+        licence: 'Proprietary — test fixture',
+        source: 'Authored for this test. Not derived from any standard.',
+        conformanceClaim: 'declared-by-supplier',
+      },
+    });
+
+    const error = caughtError(() => analyse(VOCABULARY_DOC, { rulePack: invalid }));
+
+    expect(error).toBeInstanceOf(RulePackError);
+    expect(error).toHaveProperty('message', expect.stringContaining('metadata.authority'));
+  });
+
+  describe('relative rulePack path resolution against baseDir', () => {
+    let dir: string;
+
+    it('loads a relative rulePack path resolved against baseDir', () => {
+      dir = mkdtempSync(join(tmpdir(), 'ste-ai-rule-pack-basedir-'));
+      writeFileSync(join(dir, 'pack.json'), JSON.stringify(pack()));
+
+      const result = analyseTextDeterministic(VOCABULARY_DOC, {
+        config: { rulePack: './pack.json' },
+        baseDir: dir,
+      });
+
+      expect(result.diagnostics.filter((d) => d.ruleId === 'unapproved-vocabulary')).toHaveLength(
+        1,
+      );
+
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('fails clearly when the relative path does not resolve under that baseDir', () => {
+      const otherDir = mkdtempSync(join(tmpdir(), 'ste-ai-rule-pack-basedir-missing-'));
+
+      expect(() =>
+        analyseTextDeterministic(VOCABULARY_DOC, {
+          config: { rulePack: './pack.json' },
+          baseDir: otherDir,
+        }),
+      ).toThrow(/Cannot read rule pack/);
+
+      rmSync(otherDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('the autofix gate outranks a pack declaring safeSubstitution: true', () => {
+    // `docs/rule-pack-import.md`, "What the pack cannot do": safeSubstitution: true is necessary
+    // but not sufficient. checkFixSafety() (src/core/rule.ts) still refuses a fix that changes a
+    // digit, a negation, a modal, or an ordering word, regardless of what the pack asserts.
+
+    it('applies a fix the pack marks safe when checkFixSafety agrees', () => {
+      const result = analyse('Utilise the bracket.\n', {
+        rulePack: pack({
+          dictionary: {
+            approved: [],
+            unapproved: [{ term: 'utilise', alternatives: ['use'], safeSubstitution: true }],
+            preferred: [],
+          },
+        }),
+      });
+
+      const diagnostic = result.diagnostics.find((d) => d.ruleId === 'unapproved-vocabulary');
+      expect(diagnostic?.fix).toBeDefined();
+      expect(diagnostic?.fix?.text).toBe('Use');
+    });
+
+    it('refuses the same pack-declared-safe fix when it would change negation', () => {
+      const result = analyse('The bracket is not usable.\n', {
+        rulePack: pack({
+          dictionary: {
+            approved: [],
+            unapproved: [{ term: 'not usable', alternatives: ['usable'], safeSubstitution: true }],
+            preferred: [],
+          },
+        }),
+      });
+
+      const diagnostic = result.diagnostics.find((d) => d.ruleId === 'unapproved-vocabulary');
+      expect(diagnostic, 'the violation is still reported').toBeDefined();
+      expect(diagnostic?.fix, 'no fix reaches the caller').toBeUndefined();
+      expect(diagnostic?.message).toContain('No automatic fix');
+      expect(diagnostic?.message).toContain('changes negation');
+    });
   });
 });


### PR DESCRIPTION
**Supersedes #90.** That branch is stale (based on `b6d23ec`; main is now `d30696d`), and its three open findings need changes outside the one file it touches. This carries its prose corrections forward onto current main.

## Why #90 did not converge

Three rounds, six P2 findings, every one of the form *"the prose asserts X, the code does Y"*. No round changed any code, so each prose correction was itself unverified and introduced the next inaccuracy — rounds 2 and 3 were largely caused by the fix applied in the round before.

Root cause, verified rather than assumed:

```
grep -rl "rulePack|parseRulePack|verifiedAuthority|trustedRulePackIds|packPermitsConformanceClaim" test/
→ (no matches)
```

The rule pack is this package's only extension point and had **no test coverage at all**. Its whole specification was prose in three files that could drift independently, and the same false claim (`"no rule hard-codes vocabulary"`) sat in `docs/rule-pack-import.md`, `README.md`, and a doc comment in `src/rule-pack/schema.ts`. Fixing one left two. Codex was doing by hand, one round at a time, the job a test suite should do once.

## What changed

**Make the claims executable.**

- `test/integration/rule-pack.test.ts` (25 tests) pins every documented behaviour: the trust gate, the conformance truth table, per-rule override precedence, and the status asymmetry review flagged twice.
- `test/architecture/doc-pack-control-surface.test.ts` derives the control surface from `rulePackSchema` and fails when the doc and schema disagree *in either direction*. The "your exhaustive list is not exhaustive" finding class cannot recur, because the list is generated rather than maintained by hand. Verified it fails on drift, naming the exact missing field.

**The status asymmetry, stated precisely.** `rules[].status` reaches deterministic diagnostics but is dropped for candidates, which take pack-*wide* authority. So omitting a rule from `rules[]` moves its status in opposite directions on the two paths:

| Rule entry | Deterministic | Candidate |
| --- | --- | --- |
| listed in `rules[]` | the entry's `status`, trust-capped | **ignored** — pack-wide |
| absent from `rules[]` | `provisional` (rule default) | pack-wide |
| `sourceRef` | the entry's `sourceRef` | never reported |

**Correct the claims at their source.** Including `src/rule-pack/schema.ts:7` and `README.md:295` — the latter still carried the false claim and nobody had flagged it.

**A third inaccuracy the reviews missed.** The boundary was stated wrongly in *both* directions. A pack cannot *extend* a hard-coded trigger list, but `approvedTechnicalTerms` does let it *suppress* one. So the original doc's "no rule hard-codes vocabulary" and #90's correction "a pack cannot change those lists" are both wrong. Established with a probe before rewriting, not from reading.

**A worked example.** `examples/rule-pack/` lints one document under the bundled pack, then a custom pack, then a trusted one. It demonstrates that a pack **replaces** the dictionary rather than adding to it — the fact readers most often get wrong. Its README's outputs are pinned by the tests, so the page cannot drift from what the commands print.

`docs/rule-pack-import.md` now reports **0 lint errors, down from 10** — PR #90's original goal.

## Deliberately not changed

`src/cli/main.ts:277` prints `Provisional rules only; no conformance claim.` unconditionally, which under-claims for a trusted normative pack. `docs/design/64-layered-rule-packs/02-authority-trust.md:713` already identifies this, judges it conservative rather than a soundness bug, and defers it to the layering work; `docs/DISCLAIMER.md:43` promises the current wording. Changing it would touch a legally load-bearing disclaimer and pre-empt a designed-but-unbuilt feature. The example documents the discrepancy instead.

## Verification

| Check | Result |
| --- | --- |
| `vp test` | 681 passed (33 files) |
| `vp check` | format, lint, types clean |
| 5 × `scripts/ci/*.sh` | all pass |
| Own linter on changed docs | `rule-pack-import.md` 10 → 0 errors; no regressions elsewhere |

Example commands re-run against the rebuilt `dist/`; output matches the README exactly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5U1ETFYgG7FYr2vevxN5B)_