### PR TITLE
Ship a .pre-commit-hooks.yaml manifest; document Husky/prek usage

### DIFF
--- a/.claude/skills/ste-ai-prose-style/SKILL.md
+++ b/.claude/skills/ste-ai-prose-style/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ste-ai-prose-style
+description: Write or edit prose in this repository so it passes this project's own textlint preset on the first draft. Use before writing or editing any Markdown documentation file here — README.md, docs/*.md, AGENTS.md, CLAUDE.md, examples/README.md.
+---
+
+# Writing prose that already passes this repo's own linter
+
+This repository lints its own documentation with its own preset, `ste-ai`. Every existing doc
+holds to zero hard errors. Reaching that after a full draft costs avoidable rewrite passes.
+Reaching it while drafting does not.
+
+## Before writing a sentence
+
+Hold four numeric limits in mind, not just at review time.
+
+1. Grade level.
+   - The configured Flesch-Kincaid limit is 8 for descriptive prose.
+   - It is 7 for procedural steps.
+   - One independent clause per sentence stays under this reliably.
+   - A sentence joined by "and," "which," or "so" often does not.
+2. Commas.
+   - The limit is 3 per sentence.
+   - A sentence needing a fourth comma needs to split into two sentences instead.
+3. Abbreviations.
+   - Introduce the full term before its abbreviation, at each document's first use.
+   - State the abbreviation once, in a plain sentence, outside any list.
+4. Semicolons.
+   - Never join two independent clauses with one.
+   - Write two sentences instead.
+
+The abbreviation introduction itself belongs in flowing prose, never inside a list item. A pull
+request (PR) is the working example this skill itself uses. Every later mention in this document
+can then write "PR" alone.
+
+## Lists
+
+Give every item in a list the same trailing punctuation. Either every item ends with a full stop,
+or none do.
+
+## After drafting
+
+Run the real linter before considering a doc finished, not only before pushing:
+
+```bash
+node_modules/.bin/textlint <path>
+```
+
+A hard `error`-level finding at that point means the draft still needs a rewrite to the limits
+above. It does not mean the finding is safe to leave for later.
+
+## What this does not cover
+
+`review-required` findings (`info`-level, from candidate rules like `passive-voice-candidate`) are
+expected in every doc in this repository. Semantic adjudication runs, or it does not, per
+`docs/diagnostic-policy.md`. Zero hard errors is the bar. Zero `info` findings is not.

--- a/.claude/skills/ste-ai-prose-style/SKILL.md
+++ b/.claude/skills/ste-ai-prose-style/SKILL.md
@@ -5,13 +5,7 @@ description: Write or edit prose in this repository so it passes this project's 
 
 # Writing prose that already passes this repo's own linter
 
-This repository lints its own documentation with its own preset, `ste-ai`. Every existing doc
-holds to zero hard errors. Reaching that after a full draft costs avoidable rewrite passes.
-Reaching it while drafting does not.
-
-## Before writing a sentence
-
-Hold four numeric limits in mind, not just at review time.
+Hold four numeric limits in mind while drafting, not just at review time.
 
 1. Grade level.
    - The configured Flesch-Kincaid limit is 8 for descriptive prose.
@@ -28,10 +22,6 @@ Hold four numeric limits in mind, not just at review time.
    - Never join two independent clauses with one.
    - Write two sentences instead.
 
-The abbreviation introduction itself belongs in flowing prose, never inside a list item. A pull
-request (PR) is the working example this skill itself uses. Every later mention in this document
-can then write "PR" alone.
-
 ## Lists
 
 Give every item in a list the same trailing punctuation. Either every item ends with a full stop,
@@ -46,7 +36,7 @@ node_modules/.bin/textlint <path>
 ```
 
 A hard `error`-level finding at that point means the draft still needs a rewrite to the limits
-above. It does not mean the finding is safe to leave for later.
+above.
 
 ## What this does not cover
 

--- a/.claude/skills/ste-ai-prose-style/SKILL.md
+++ b/.claude/skills/ste-ai-prose-style/SKILL.md
@@ -5,41 +5,26 @@ description: Write or edit prose in this repository so it passes this project's 
 
 # Writing prose that already passes this repo's own linter
 
-Hold four numeric limits in mind while drafting, not just at review time.
+Draft toward these shapes. The exact numbers belong to the active rule pack, not to this skill.
+The linter reports them live.
 
-1. Grade level.
-   - The configured Flesch-Kincaid limit is 8 for descriptive prose.
-   - It is 7 for procedural steps.
-   - One independent clause per sentence stays under this reliably.
-   - A sentence joined by "and," "which," or "so" often does not.
-2. Commas.
-   - The limit is 3 per sentence.
-   - A sentence needing a fourth comma needs to split into two sentences instead.
-3. Abbreviations.
-   - Introduce the full term before its abbreviation, at each document's first use.
-   - State the abbreviation once, in a plain sentence, outside any list.
-4. Semicolons.
-   - Never join two independent clauses with one.
-   - Write two sentences instead.
-
-## Lists
-
-Give every item in a list the same trailing punctuation. Either every item ends with a full stop,
-or none do.
+- One independent clause per sentence. A join on "and," "which," or "so" risks the grade limit.
+- Few commas per sentence. A sentence needing one more needs to split instead.
+- Introduce an abbreviation's full term first, in a plain sentence, outside any list.
+- Never join two independent clauses with a semicolon. Write two sentences.
+- Give every list item the same trailing punctuation: all full stops, or none.
 
 ## After drafting
-
-Run the real linter before considering a doc finished, not only before pushing:
 
 ```bash
 node_modules/.bin/textlint <path>
 ```
 
-A hard `error`-level finding at that point means the draft still needs a rewrite to the limits
-above.
+Run this before considering a doc finished, not only before pushing. A hard `error`-level finding
+names the exact configured limit it exceeded. Rewrite to that limit.
 
 ## What this does not cover
 
 `review-required` findings (`info`-level, from candidate rules like `passive-voice-candidate`) are
-expected in every doc in this repository. Semantic adjudication runs, or it does not, per
-`docs/diagnostic-policy.md`. Zero hard errors is the bar. Zero `info` findings is not.
+expected in every doc in this repository — see `docs/diagnostic-policy.md`. Zero hard errors is
+the bar. Zero `info` findings is not.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,6 @@ jobs:
 
       - name: Confirm shipped textlint configs actually resolve preset-ste-ai
         run: scripts/ci/check-textlint-configs-resolve.sh
+
+      - name: Confirm the pre-commit hook manifest is shaped correctly and still works
+        run: scripts/ci/check-pre-commit-hook-manifest.sh

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,6 @@
     Lint prose for Simplified-Technical-English-style vocabulary, sentence
     structure and terminology. Provisional rules; not ASD-STE100 certified.
     See docs/DISCLAIMER.md.
-  entry: npx --yes textlint-rule-preset-ste-ai lint --fail-on-review
+  entry: npx --yes textlint-rule-preset-ste-ai lint --fail-on-review --
   language: system
   types_or: [markdown, plain-text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: ste-ai
+  name: Simplified Technical English check
+  description: >-
+    Lint prose for Simplified-Technical-English-style vocabulary, sentence
+    structure and terminology. Provisional rules; not ASD-STE100 certified.
+    See docs/DISCLAIMER.md.
+  entry: npx --yes textlint-rule-preset-ste-ai lint --fail-on-review
+  language: system
+  types_or: [markdown, plain-text]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,44 @@ This file lists instructions for AI (artificial intelligence) agents in this rep
    - Replace or remove commands, paths, and claims that the change invalidates.
    - Also replace or remove any manually maintained, derivable data that the change invalidates.
 
+## Notice a problem, log it — never silently skip it
+
+Learned from a real incident. An agent was fixing an unrelated pull request (PR). It ran this
+project's own preset against `docs/configuration.md`. It found two genuine hard lint errors: a
+52-word sentence, graded far above the configured limit. Also an abbreviation used before it was
+introduced. The agent confirmed both predated the change in progress. It judged them out of
+scope. It moved on without recording them anywhere.
+
+The finding was real. It was verified. Then it simply vanished. It existed only inside a
+conversation nobody would read again. A defect an agent noticed, and chose not to log, is worse
+than one nobody noticed. It looks like the codebase was checked and passed.
+
+**Out of scope for the current change is never a reason to leave a verified problem unrecorded.**
+
+Work on one task can surface a confirmed problem outside that task's scope. A pre-existing test
+failure. A stale doc. A lint error unrelated to the current diff. A design gap. A security
+concern. File it before moving on:
+
+1. Confirm the problem is real and pre-existing.
+   - Check it against `git show HEAD:<path>` before attributing it elsewhere.
+   - A `git stash` also works, for a change not yet committed.
+2. Open a GitHub issue.
+   - Name the file and line.
+   - Quote the exact error or symptom.
+   - State how it was found.
+   - Give a reproduction command.
+   - Use the `bug` label, or the closest fit.
+3. Reference the new issue number from wherever the discovery happened.
+   - A PR comment works. A commit message works too.
+   - This leaves a trail back to the finding.
+4. Do not fix it inline as part of the unrelated change.
+   - An exception applies only when the fix is small and safe.
+   - The fix must also sit directly next to work already touching that exact file.
+   - This matches this project's own scope discipline against widening a change on a whim. See
+     `CLAUDE.md`.
+
+Silence is never acceptable here. "Not my task" is not a reason to leave a real finding unlogged.
+
 ## Delegation gotchas
 
 Learned from repeated multi-agent dispatch failures in this session. Read this before dispatching `isolation: "worktree"` agents in bulk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ This file lists instructions for AI (artificial intelligence) agents in this rep
    - Replace or remove commands, paths, and claims that the change invalidates.
    - Also replace or remove any manually maintained, derivable data that the change invalidates.
 
+Prose-style rules for this repository live in `.claude/skills/ste-ai-prose-style/SKILL.md`.
+
 ## Notice a problem, log it — never silently skip it
 
 Learned from a real incident. An agent was fixing an unrelated pull request (PR). It ran this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,6 @@ This file lists instructions for AI (artificial intelligence) agents in this rep
    - Update stale behavior descriptions.
    - Replace or remove commands, paths, and claims that the change invalidates.
    - Also replace or remove any manually maintained, derivable data that the change invalidates.
-4. Before writing or editing prose in this repository, load the `ste-ai-prose-style` skill.
 
 ## Notice a problem, log it — never silently skip it
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,13 @@ This file lists instructions for AI (artificial intelligence) agents in this rep
    - Update stale behavior descriptions.
    - Replace or remove commands, paths, and claims that the change invalidates.
    - Also replace or remove any manually maintained, derivable data that the change invalidates.
+4. Before writing or editing prose in this repository, load the `ste-ai-prose-style` skill.
+   - This repository lints its own documentation with its own preset.
+   - Every existing doc holds to zero hard errors from that preset.
+   - The skill holds the numeric limits (sentence grade level, comma count, and more) a compliant
+     first draft needs.
+   - Loading it before drafting avoids the repeated write-lint-rewrite cycle a draft written
+     without them produces.
 
 ## Notice a problem, log it — never silently skip it
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,6 @@ This file lists instructions for AI (artificial intelligence) agents in this rep
    - Replace or remove commands, paths, and claims that the change invalidates.
    - Also replace or remove any manually maintained, derivable data that the change invalidates.
 4. Before writing or editing prose in this repository, load the `ste-ai-prose-style` skill.
-   - This repository lints its own documentation with its own preset.
-   - Every existing doc holds to zero hard errors from that preset.
-   - The skill holds the numeric limits (sentence grade level, comma count, and more) a compliant
-     first draft needs.
-   - Loading it before drafting avoids the repeated write-lint-rewrite cycle a draft written
-     without them produces.
 
 ## Notice a problem, log it — never silently skip it
 

--- a/README.md
+++ b/README.md
@@ -89,23 +89,31 @@ are real today, not proposed:
   - `3` — any `error`-level run notice. See
     [`docs/configuration.md`](docs/configuration.md#protected-patterns-are-screened-before-they-run)
     for the full list: a protection mechanism failing, or a rule skipped for invalid options
+- This repository ships a [`.pre-commit-hooks.yaml`](.pre-commit-hooks.yaml) manifest at its root.
+  The Python `pre-commit` framework and `prek` can both point straight at this repository. Neither
+  needs a hand-copied `repo: local` block.
+
+Every path below needs the package installed locally first. See "Install" above. `npx` resolves the
+already-installed copy. Nothing here installs it for you.
 
 ```yaml
-# .pre-commit-config.yaml — works with prek too, same config format
+# .pre-commit-config.yaml — prek reads the same file format
 repos:
-  - repo: local
+  - repo: https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai
+    rev: <latest release tag> # see the repository's Releases page
     hooks:
       - id: ste-ai
-        name: Simplified Technical English check
-        entry: npx --yes ste-ai lint --fail-on-review
-        language: system
-        files: \.md$
 ```
 
 ```sh
 # .husky/pre-commit
-npx ste-ai lint docs/**/*.md --fail-on-review
+files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.txt')
+[ -z "$files" ] && exit 0
+npx --yes textlint-rule-preset-ste-ai lint --fail-on-review $files
 ```
+
+See [`docs/pre-commit-hooks.md`](docs/pre-commit-hooks.md) for both, including why the manifest
+uses `language: system` rather than `language: node`, and for troubleshooting.
 
 **2. An authoring agent consulting the vocabulary in-loop — proposed, not built**. The agent would
 check its own draft voluntarily, during composition, not just after the fact:
@@ -342,6 +350,7 @@ either one yourself.
 | [`docs/diagnostic-policy.md`](docs/diagnostic-policy.md)         | categories, outage policy, autofix policy                      |
 | [`docs/suppression.md`](docs/suppression.md)                     | inline directives, and what they record                        |
 | [`docs/configuration.md`](docs/configuration.md)                 | every option                                                   |
+| [`docs/pre-commit-hooks.md`](docs/pre-commit-hooks.md)           | wiring this into `pre-commit`, `prek`, or Husky                |
 | [`docs/rule-pack-import.md`](docs/rule-pack-import.md)           | supplying licensed material                                    |
 | [`docs/llama-cpp-setup.md`](docs/llama-cpp-setup.md)             | running the model service                                      |
 | [`docs/fixtures.md`](docs/fixtures.md)                           | the corpus and its provenance                                  |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ repos:
 files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.txt')
 [ -z "$files" ] && exit 0
 git diff --cached --name-only -z --diff-filter=ACMR -- '*.md' '*.txt' \
-  | xargs -0 npx --yes textlint-rule-preset-ste-ai lint --fail-on-review
+  | xargs -0 npx --yes textlint-rule-preset-ste-ai lint --fail-on-review --
 ```
 
 See [`docs/pre-commit-hooks.md`](docs/pre-commit-hooks.md) for both, including why the manifest

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ repos:
 # .husky/pre-commit
 files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.txt')
 [ -z "$files" ] && exit 0
-npx --yes textlint-rule-preset-ste-ai lint --fail-on-review $files
+git diff --cached --name-only -z --diff-filter=ACMR -- '*.md' '*.txt' \
+  | xargs -0 npx --yes textlint-rule-preset-ste-ai lint --fail-on-review
 ```
 
 See [`docs/pre-commit-hooks.md`](docs/pre-commit-hooks.md) for both, including why the manifest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,13 @@ They are read once from a shared file, resolved in this order (first hit wins):
 3. The same names in `process.cwd()`.
 4. Built-in defaults: bundled provisional pack, semantic analysis **off**.
 
+The CLI (`ste-ai lint`, with no `--config` flag) has no "textlint config base directory" of its
+own. It follows this same order starting from step 1, using `process.cwd()` for step 3. A bare
+`ste-ai lint` — run as a pre-commit or Husky hook, for instance — therefore applies the same
+`.ste-ai.json` a project's own `textlint --config .textlintrc.json` invocation already applies.
+The CLI's own `--config <path>` flag is a separate override. It takes precedence over all four
+steps above when given.
+
 `.ste-ai.json`:
 
 ```jsonc

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -82,13 +82,21 @@ shell script. It runs on every commit, unfiltered, unless the script filters it 
 # .husky/pre-commit
 files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.txt')
 [ -z "$files" ] && exit 0
-npx --yes textlint-rule-preset-ste-ai lint --fail-on-review $files
+git diff --cached --name-only -z --diff-filter=ACMR -- '*.md' '*.txt' \
+  | xargs -0 npx --yes textlint-rule-preset-ste-ai lint --fail-on-review
 ```
 
 `git diff --cached --name-only` lists staged files. `--diff-filter=ACMR` keeps only files that
 were added, copied, modified, or renamed. A staged deletion is never passed to a tool that expects
-the file to exist. `[ -z "$files" ]` skips the run entirely when nothing staged matches. A commit
-that touches only code is not slowed down.
+the file to exist. `[ -z "$files" ]` skips the run entirely when nothing staged matches, so a
+commit that touches only code is not slowed down.
+
+The `git diff` runs twice on purpose. The first, ordinary run only feeds that emptiness check. The
+second uses `-z`. Its output is separated by the null byte, not a newline, piped straight into
+`xargs -0`. A staged filename holding a space or a glob character then still reaches the linter as
+one argument. Storing that null-byte-separated output in a shell variable is not safe across `sh`
+implementations. `$(...)` can truncate at the first null byte. The file list is piped directly
+instead, rather than stored in `$files` a second time.
 
 Do not write `npx --yes textlint-rule-preset-ste-ai lint docs/**/*.md` instead.
 `.husky/pre-commit` runs under `sh`, not an interactive `bash` with `shopt -s globstar` set. Under

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -1,0 +1,126 @@
+# Pre-commit hooks
+
+This package ships a `.pre-commit-hooks.yaml` manifest at its repository root. The Python
+`pre-commit` framework and `prek` both consume that manifest directly. Husky has no manifest
+format. It runs a shell script instead. All three need the same one prerequisite.
+
+## Prerequisite: install the package locally
+
+Every path below assumes `textlint-rule-preset-ste-ai` is already a `devDependency` of the project
+being linted:
+
+```bash
+vp install --save-dev textlint textlint-rule-preset-ste-ai
+```
+
+None of these hook integrations install the package for you. `entry: npx --yes …` falls back to
+fetching it from the npm registry on demand. That means the first commit in a fresh clone pays a
+network fetch. A CI runner without registry access fails outright. Installing it as a real
+`devDependency` keeps every commit fast, offline, and locked to your lockfile. This is the same
+reason the CLI's deterministic rules never touch the network, extended to the hook's own
+installation.
+
+## Python `pre-commit` and `prek`
+
+```yaml
+# .pre-commit-config.yaml — prek reads the same file format
+repos:
+  - repo: https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai
+    rev: <latest release tag> # e.g. v1.2.3 — see the repository's Releases page
+    hooks:
+      - id: ste-ai
+```
+
+`rev` must point at a published release tag, not a branch. `pre-commit` resolves and pins `rev`
+once, at `pre-commit install` or first run. It never re-resolves the tag on its own. Run
+`pre-commit autoupdate` to move the pin forward later. See
+[`docs/publishing.md`](publishing.md) for how releases are tagged.
+
+This pulls the hook **manifest** from this repository over git. The manifest declares
+`language: system`, so `pre-commit` runs `entry` directly. It does not clone, build, or install
+this package from git to do that. The linter itself always comes from your own `node_modules`,
+resolved by `npx`, per the prerequisite above.
+
+### Why not `language: node`?
+
+`.pre-commit-hooks.yaml` deliberately avoids `language: node` with `additional_dependencies`. That
+is the pattern behind, for example, `pre-commit/mirrors-prettier`. Two things about this package
+rule it out:
+
+- `language: node` builds the hook's environment from this repository's own `git+file://` source.
+  That needs every `devDependency` installed (`vite-plus`, to run `vp pack`), then the build run,
+  inside `pre-commit`'s own managed node environment. That works with `prek`, which stages the
+  build with `npm pack` before installing. It does not work with the Python `pre-commit`
+  framework's own `npm install -g … --install-links` invocation. Verified: `dist/` never gets
+  built on that path. The hook fails with `Executable ste-ai not found`.
+- Adding `additional_dependencies: ["textlint-rule-preset-ste-ai@<version>"]` does not route
+  around that. `pre-commit`'s `language: node` still also installs this repository's own
+  `git+file://` source alongside it. The hook repository has both a `.git` directory and a
+  `package.json` at its root. Two installs of the identically named package then collide in the
+  same global `node_modules/textlint-rule-preset-ste-ai` directory. Verified: the install fails
+  with `ENOTEMPTY`.
+
+`language: system` sidesteps both failure modes. It executes `npx`, backed by your own
+`node_modules`. There is no environment left for `pre-commit` to build. A future version of this
+package could ship `.pre-commit-hooks.yaml` from a separate mirror repository instead. That mirror
+would carry its own placeholder `package.json`, the way `mirrors-prettier` does. `language: node`
+would become viable again then. It is not viable today.
+
+### Only lint staged files
+
+`pre-commit` already restricts `entry` to the files it detects as changed, or to every file on
+`--all-files` by request. `types_or: [markdown, plain-text]` in the manifest is what selects
+`.md` and `.txt` files for you. No extra configuration is needed for that. It is the default
+`pre-commit` behaviour for any hook.
+
+## Husky
+
+Husky has no hook manifest, and no built-in staged-file filtering. `.husky/pre-commit` is a plain
+shell script. It runs on every commit, unfiltered, unless the script filters it itself.
+
+```sh
+# .husky/pre-commit
+files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.txt')
+[ -z "$files" ] && exit 0
+npx --yes textlint-rule-preset-ste-ai lint --fail-on-review $files
+```
+
+`git diff --cached --name-only` lists staged files. `--diff-filter=ACMR` keeps only files that
+were added, copied, modified, or renamed. A staged deletion is never passed to a tool that expects
+the file to exist. `[ -z "$files" ]` skips the run entirely when nothing staged matches. A commit
+that touches only code is not slowed down.
+
+Do not write `npx --yes textlint-rule-preset-ste-ai lint docs/**/*.md` instead.
+`.husky/pre-commit` runs under `sh`, not an interactive `bash` with `shopt -s globstar` set. Under
+`sh`, `**` is not a recursive glob. It matches at most one directory level. `docs/**/*.md` then
+silently misses a file directly in `docs/`, while still catching one in `docs/sub/`. The
+staged-files form above never builds a glob at all, so this problem never comes up.
+
+## Both: the exit code contract
+
+Every integration above relies on the same [documented exit codes](configuration.md#cli):
+
+- `0` — clean
+- `1` — errors present (review-required counts too, with `--fail-on-review`)
+- `2` — a usage error
+- `3` — an infrastructure-level run notice
+
+A hook that drops `--fail-on-review` still blocks on `1`. It then blocks only for
+`error`-severity findings. See [`docs/diagnostic-policy.md`](diagnostic-policy.md) for what
+separates the two.
+
+## Troubleshooting
+
+**`Executable ste-ai not found` (Python `pre-commit` only).** The hook manifest resolved, but
+`npx` could not find or fetch the binary. Confirm `textlint-rule-preset-ste-ai` is listed in the
+target project's `package.json`, and that `node_modules/.bin/ste-ai` exists there. That is the
+prerequisite step above. The hook manifest cannot do it on your behalf.
+
+**A commit is far slower than expected, or fails offline.** `npx --yes` is falling through to a
+registry fetch. Either the prerequisite step was skipped, or `node_modules` is missing from this
+checkout. That happens on a fresh CI checkout, or a clean clone. Run the install step first.
+
+**A vendored or generated directory shows up in the findings.** `pre-commit` and Husky only see
+files git already tracks. A properly `.gitignore`d directory is never passed to the hook —
+`node_modules/`, or `dist/`. If one still shows up, it was tracked by git. Fix the `.gitignore`.
+Alternatively, add `exclude: ^path/to/dir/` to the hook entry in `.pre-commit-config.yaml`.

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -83,7 +83,7 @@ shell script. It runs on every commit, unfiltered, unless the script filters it 
 files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.txt')
 [ -z "$files" ] && exit 0
 git diff --cached --name-only -z --diff-filter=ACMR -- '*.md' '*.txt' \
-  | xargs -0 npx --yes textlint-rule-preset-ste-ai lint --fail-on-review
+  | xargs -0 npx --yes textlint-rule-preset-ste-ai lint --fail-on-review --
 ```
 
 `git diff --cached --name-only` lists staged files. `--diff-filter=ACMR` keeps only files that
@@ -98,11 +98,37 @@ one argument. Storing that null-byte-separated output in a shell variable is not
 implementations. `$(...)` can truncate at the first null byte. The file list is piped directly
 instead, rather than stored in `$files` a second time.
 
+The trailing `--` matters too, right before `xargs` hands `npx` its filenames. A tracked file can
+have a name that starts with a hyphen — `--notes.md`, unusual but legal. Without `--`, that name
+reaches the CLI's argument parser looking like an unknown flag. The CLI then exits `2`, and never
+lints it. `--` tells the parser that everything after it is a filename, never an option.
+`.pre-commit-hooks.yaml`'s own `entry` carries the same `--`, for the same reason.
+
 Do not write `npx --yes textlint-rule-preset-ste-ai lint docs/**/*.md` instead.
-`.husky/pre-commit` runs under `sh`, not an interactive `bash` with `shopt -s globstar` set. Under
-`sh`, `**` is not a recursive glob. It matches at most one directory level. `docs/**/*.md` then
-silently misses a file directly in `docs/`, while still catching one in `docs/sub/`. The
-staged-files form above never builds a glob at all, so this problem never comes up.
+`.husky/pre-commit` runs under `sh`. It is not an interactive `bash` with `shopt -s globstar` set.
+Under `sh`, `**` is not a recursive glob. It matches at most one directory level. `docs/**/*.md`
+then silently misses a file directly in `docs/`, while still catching one in `docs/sub/`. The
+staged-files form above never builds a glob at all. This problem never comes up there.
+
+### Partial staging (Husky only)
+
+The snippet above lints whatever is on disk at each staged path. It does not lint the staged
+content itself. Stage a clean fix to a file, then edit that same file further, without staging
+the new edit. The hook then lints your unstaged edit — not the clean version that would actually
+be committed. The reverse also happens. A real violation you staged can pass, if an unstaged edit
+on top of it happens to look clean on disk. Either way, what got checked is not what `git commit`
+would record.
+
+The Python `pre-commit` framework and `prek` do not have this problem. Verified directly: both
+stash unstaged changes to a patch file before running any hook. Both restore the patch afterwards.
+Every hook, including this one, then only ever sees staged content. Husky has no equivalent built
+in. This CLI has no way to read a file's staged content either. It only reads real paths off disk
+(`readFileSync`). Tracked as
+[issue #109](https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai/issues/109).
+
+A Husky user who needs this guarantee today has two options. Route through
+`.pre-commit-hooks.yaml` instead — `pre-commit` and `prek` both run fine under Husky, not only
+standalone. Or avoid partially staging a file this hook covers.
 
 ## Both: the exit code contract
 

--- a/scripts/ci/check-pre-commit-hook-manifest.sh
+++ b/scripts/ci/check-pre-commit-hook-manifest.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Confirm .pre-commit-hooks.yaml (docs/pre-commit-hooks.md) is present and shaped the way that
+# guide documents (id, `language: system`, an `entry:` naming this package and the `lint`
+# subcommand), and that the CLI flags in `entry` still exist and still flag a known violation. This
+# is the same failure mode check-textlint-configs-resolve.sh guards against for .textlintrc.json: a
+# shipped config that looks right but silently does nothing once a consumer points a tool at it.
+#
+# `language: system` means pre-commit and prek never build or install anything for this hook --
+# they just run `entry` verbatim, backed by whatever the consumer's own `node_modules` already has
+# installed (docs/pre-commit-hooks.md's prerequisite). There is therefore no environment for this
+# script to install either; it only needs the flags after `textlint-rule-preset-ste-ai` in `entry`
+# to still be valid CLI flags, which it checks by running this repository's own build with them.
+#
+# Usage: scripts/ci/check-pre-commit-hook-manifest.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+manifest=".pre-commit-hooks.yaml"
+
+if [ ! -f "$manifest" ]; then
+  echo "$manifest is missing." >&2
+  exit 2
+fi
+
+if [ ! -f dist/cli/main.js ]; then
+  echo "dist/cli/main.js is missing. Run 'vp pack' first." >&2
+  exit 2
+fi
+
+# The manifest must declare `language: system`: docs/pre-commit-hooks.md's whole rationale for not
+# using `language: node` is that this package cannot be reliably built as a pre-commit-managed node
+# environment (see that doc's "Why not language: node?"). A manifest edit that switches this back
+# would reintroduce that failure silently, so it is asserted here, not just described in prose.
+if ! grep -qE '^\s*language:\s*system\s*$' "$manifest"; then
+  echo "$manifest: expected 'language: system' (see docs/pre-commit-hooks.md)." >&2
+  exit 1
+fi
+
+if ! grep -qE '^\s*-?\s*id:\s*ste-ai\s*$' "$manifest"; then
+  echo "$manifest: expected hook id 'ste-ai'." >&2
+  exit 1
+fi
+
+entry_line="$(grep -E '^\s*entry:' "$manifest" | head -1)"
+if [ -z "$entry_line" ]; then
+  echo "$manifest: no 'entry:' line found." >&2
+  exit 1
+fi
+# Strip the `entry:` key, and any surrounding YAML quoting -- the value is a plain scalar today,
+# never block-scalar syntax, so this substring form is enough without a YAML parser.
+entry_cmd="${entry_line#*entry:}"
+entry_cmd="$(echo "$entry_cmd" | sed -E "s/^[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*\$//")"
+
+case "$entry_cmd" in
+  *"textlint-rule-preset-ste-ai lint"*) ;;
+  *)
+    echo "$manifest: entry '$entry_cmd' does not look like 'npx … textlint-rule-preset-ste-ai lint …'." >&2
+    exit 1
+    ;;
+esac
+
+# The trailing CLI flags (e.g. `--fail-on-review`) are what can drift -- a renamed or removed flag
+# would otherwise fail silently for hook users, since `entry` is opaque YAML nobody type-checks.
+# `npx --yes textlint-rule-preset-ste-ai …` itself is not re-exercised here: this repository links
+# the package to itself as a `file:.` devDependency for its own tests, and npm does not create a
+# `node_modules/.bin/ste-ai` symlink for that self-link (verified; every other script in
+# scripts/ci/ already routes around the same gap by calling `node dist/cli/main.js` directly, never
+# `node_modules/.bin/ste-ai`). A real consumer's install is a normal tarball install, not a
+# self-link, and does get the bin symlink -- see docs/pre-commit-hooks.md's own worked example, and
+# check-textlint-configs-resolve.sh, which already verifies the self-link itself resolves.
+cli_args="${entry_cmd#*textlint-rule-preset-ste-ai}"
+
+fixture="${RUNNER_TEMP:-/tmp}/ste-ai-pre-commit-hook-fixture.md"
+printf 'Utilise the the bracket.\n' > "$fixture"
+
+set +e
+# shellcheck disable=SC2086  # $cli_args is a fixed, repo-controlled flag list, not user input.
+output="$(node dist/cli/main.js $cli_args "$fixture" 2>&1)"
+status=$?
+set -e
+
+if [ "$status" -ne 1 ]; then
+  echo "$manifest: expected the hook's entry command to exit 1 for a known violation, got $status." >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if ! echo "$output" | grep -q "unapproved-vocabulary"; then
+  echo "$manifest: expected an unapproved-vocabulary finding from the hook's entry command." >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+# The check above alone cannot tell whether `--fail-on-review` is actually present in `entry`: a
+# hard `error`-level finding already forces exit 1 on its own, with or without that flag -- checked
+# by hand while writing this script, this exact fixture stayed green after deleting the flag from
+# `entry`. A passage that trips only a review-required candidate rule (nothing error-level) isolates
+# it: exit 0 without the flag, exit 1 with it, so a future edit that silently drops the flag from
+# `entry` fails this check instead of only reaching a hook user's commit later.
+review_fixture="${RUNNER_TEMP:-/tmp}/ste-ai-pre-commit-hook-review-fixture.md"
+printf 'The cover is removed by the technician.\n' > "$review_fixture"
+
+set +e
+# shellcheck disable=SC2086  # $cli_args is a fixed, repo-controlled flag list, not user input.
+review_output="$(node dist/cli/main.js $cli_args "$review_fixture" 2>&1)"
+review_status=$?
+set -e
+
+if [ "$review_status" -ne 1 ]; then
+  echo "$manifest: entry command exited $review_status for a review-required-only passage." >&2
+  echo "expected 1 -- entry must still include --fail-on-review (or equivalent)." >&2
+  echo "$review_output" >&2
+  exit 1
+fi
+
+echo "$manifest: language:system, id ste-ai, and its entry command resolved and ran correctly."
+rm -f "$fixture" "$review_fixture"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -9,6 +9,7 @@ import type { AnalysedDocument, Diagnostic, RunNotice, SuppressionRecord } from 
 import { deterministicRules } from '../deterministic/index.js';
 import { evaluatorDefinitions } from '../semantic/evaluators.js';
 import { packPermitsConformanceClaim, verifiedAuthority } from '../rule-pack/loader.js';
+import { loadSharedConfig } from '../textlint/shared-config.js';
 
 /**
  * `ste-ai` — a thin CLI over the programmatic API.
@@ -116,7 +117,15 @@ function buildConfig(args: Args): SteAiConfigInput {
         // this boundary, so a malformed `--config` file fails loudly with the same named-key
         // message as everywhere else, instead of a raw `ZodError`'s JSON issue dump.
         resolveConfig(JSON.parse(readFileSync(configPath, 'utf8')))
-      : {};
+      : // No `--config` given: fall back to the same shared-config discovery the textlint adapter
+        // uses (`STE_AI_CONFIG`, then `.ste-ai.json`/`.ste-ai.jsonc`/`ste-ai.config.json` in
+        // `process.cwd()`), documented in docs/configuration.md's "Shared configuration file"
+        // resolution order. Without this, `ste-ai lint` run bare — as a pre-commit or Husky hook
+        // does — silently applied only built-in defaults, ignoring a project's own approved terms
+        // or rule pack even though `textlint --config .textlintrc.json` in the same project
+        // respected them. `loadSharedConfig(undefined)` searches `process.cwd()` only, which is
+        // right here: the CLI has no "textlint config base directory" of its own to search first.
+        loadSharedConfig(undefined).config;
   const semanticEnabled = args.flags.get('semantic') === true;
   const endpoint = args.flags.get('endpoint');
   const model = args.flags.get('model');

--- a/test/architecture/module-boundaries.test.ts
+++ b/test/architecture/module-boundaries.test.ts
@@ -30,7 +30,13 @@ const ALLOWED: Record<string, readonly string[]> = {
   // Measurement tooling composes every layer by design: it must run the real rule set and the real
   // broker to produce numbers that mean anything. It is a leaf — nothing imports it.
   evaluation: ['core', 'rule-pack', 'deterministic', 'semantic', 'model-client', 'fixture-tools'],
-  cli: ['core', 'rule-pack', 'deterministic', 'semantic', 'analysis', 'model-client'],
+  // `cli` reuses `textlint`'s shared-config-file discovery (`findSharedConfigPath`,
+  // `loadSharedConfig`) so `ste-ai lint` run without `--config` applies the same
+  // `.ste-ai.json`/`STE_AI_CONFIG` resolution `textlint --config .textlintrc.json` already does in
+  // the same project -- see src/cli/main.ts's `buildConfig`. docs/architecture.md's "Shape" table
+  // already documents `cli → all of the above`; this brings the enforced allow-list in line with
+  // that, rather than widening what the module was already declared to permit.
+  cli: ['core', 'rule-pack', 'deterministic', 'semantic', 'analysis', 'model-client', 'textlint'],
 };
 
 interface ImportEdge {

--- a/test/integration/cli-output.test.ts
+++ b/test/integration/cli-output.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { z } from 'zod';
 import { main } from '../../src/cli/main.js';
 import { SteAiConfigError } from '../../src/core/config.js';
+import { clearSharedConfigCache } from '../../src/textlint/shared-config.js';
 
 /** The subset of `--json`'s real output shape this test itself inspects. */
 const jsonOutputSchema = z.object({
@@ -124,6 +125,37 @@ describe('ste-ai lint --config', () => {
     if (!(thrown instanceof SteAiConfigError)) throw thrown;
     expect(thrown.message).toContain('diagnostics.severity');
     expect(thrown.message).toContain('style-preference');
+  });
+});
+
+describe('ste-ai lint without --config', () => {
+  // Regression (`chatgpt-codex-connector`, P2, PR #107): `buildConfig` used to fall back to `{}`
+  // when `--config` was not given, so `ste-ai lint` invoked bare -- exactly how a pre-commit or
+  // Husky hook invokes it, per docs/pre-commit-hooks.md -- silently ran under built-in defaults
+  // only. A project's own `.ste-ai.json` (approved terms, rule pack, severities) was ignored, even
+  // though `textlint --config .textlintrc.json` in the same project respected it. `buildConfig` now
+  // falls back to the same shared-config discovery the textlint adapter uses
+  // (`loadSharedConfig(undefined)`, see docs/configuration.md's "Shared configuration file"
+  // resolution order), so both entry points apply the same policy.
+  const originalEnv = process.env['STE_AI_CONFIG'];
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['STE_AI_CONFIG'];
+    else process.env['STE_AI_CONFIG'] = originalEnv;
+    clearSharedConfigCache();
+  });
+
+  it('applies a shared-config file found via STE_AI_CONFIG, with no --config flag', async () => {
+    const dir = directory ?? tmpdir();
+    const configFile = join(dir, 'shared.json');
+    writeFileSync(configFile, JSON.stringify({ approvedTerms: ['Utilise'] }), 'utf8');
+    process.env['STE_AI_CONFIG'] = configFile;
+    clearSharedConfigCache();
+
+    const output = await lint('doc.md', 'Utilise the bracket.\n');
+
+    expect(output).toContain('no diagnostics');
+    expect(output).not.toContain('unapproved-vocabulary');
   });
 });
 


### PR DESCRIPTION
## Summary

- Ships `.pre-commit-hooks.yaml` at the repository root so the Python `pre-commit` framework and `prek` can point straight at this repo (`repo: https://github.com/Jamie-BitFlight/textlint-rule-preset-ste-ai`), instead of requiring a hand-copied `repo: local` block.
- Deliberately uses `language: system`, not `language: node`. Verified hands-on that `pre-commit`'s own `npm install -g --install-links` build of this package's git source never produces `dist/` (hook fails with `Executable ste-ai not found`), and that adding `additional_dependencies` to route around that collides two installs of the identically-named package in one `node_modules` directory (`ENOTEMPTY`). `language: system` sidesteps both: it just runs `entry` against whatever the consumer already installed locally, which is the existing documented prerequisite.
- Fixes the README's Husky recipe to lint only staged files (`git diff --cached`), replacing a `docs/**/*.md` glob that silently misses top-level files under `sh` (no `globstar`) — verified this recursion gap directly.
- Adds `docs/pre-commit-hooks.md`: both integrations, the `language: node` rationale, and troubleshooting.
- Adds `scripts/ci/check-pre-commit-hook-manifest.sh`, wired into `.github/workflows/ci.yml`, guarding the manifest's shape (`id`, `language: system`) and its `entry` flags (including `--fail-on-review`) against silent drift — mirrors the existing `check-textlint-configs-resolve.sh` approach for `.textlintrc.json`. Mutation-tested: confirmed it fails when `language` is flipped to `node`, when a flag is renamed, and when `--fail-on-review` is silently dropped.

## Test plan

- [x] `vp check` — format, lint, type check all pass
- [x] `vp test` — 654 tests pass (31 files)
- [x] `scripts/ci/check-pre-commit-hook-manifest.sh` passes, and was mutation-tested against three broken manifests (wrong `language`, dropped `--fail-on-review`, a bogus flag) to confirm each one is actually caught
- [x] `scripts/ci/check-textlint-configs-resolve.sh` and `scripts/ci/check-exit-codes.sh` still pass unchanged
- [x] End-to-end: built a real tarball of this package and verified `.pre-commit-hooks.yaml` against both the Python `pre-commit` framework and `prek`, with the package installed as a real local `devDependency` (not the self-link this repo uses for its own tests) — both correctly lint and block on findings
- [x] `node_modules/.bin/textlint README.md docs/pre-commit-hooks.md` — zero hard errors (only the same `review-required` infos every other doc in this repo carries with semantic adjudication off)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JMfUEmTsnN5X6PAmwimvhP)_