### PR TITLE
fix(textlint): stop fragmenting the per-document analysis cache across rules

### DIFF
--- a/src/textlint/adapter.ts
+++ b/src/textlint/adapter.ts
@@ -161,16 +161,25 @@ export function getAnalysis(
   const fileRules = sharedFile.config.rules as Record<string, Record<string, unknown>>;
   const sharedRules = validRulesOf(shared?.rules);
   const mergedRules: Record<string, Record<string, unknown>> = {};
-  for (const id of new Set([
-    ...Object.keys(fileRules),
-    ...Object.keys(sharedRules),
-    ...perRuleOptions.keys(),
-  ])) {
-    mergedRules[id] = {
-      ...fileRules[id],
-      ...sharedRules[id],
-      ...perRuleOptions.get(id),
-    };
+  for (const id of new Set([...Object.keys(fileRules), ...Object.keys(sharedRules)])) {
+    mergedRules[id] = { ...fileRules[id], ...sharedRules[id] };
+  }
+  // Every enabled rule calls `getAnalysis` with its own `perRuleOptions` entry, most often `{}` --
+  // no rule-specific options set beyond being enabled. Folding that entry's *key* into `mergedRules`
+  // unconditionally, even when its value is empty, made `cacheKey` sensitive to which rule was
+  // calling regardless of whether the call actually carried anything new: a 14-rule preset produced
+  // up to 14 distinct cache entries for the same document, one per calling rule, because each call's
+  // `mergedRules` differed only by which rule's own (frequently empty) options object happened to be
+  // present as a key -- reproduced directly: instrumenting the cache with a trace showed 14 misses,
+  // 0 hits, for a single file under this repo's own preset. Skipping a genuinely empty entry restores
+  // the doc comment's own claim -- one shared cache entry per document, regardless of which of the
+  // 14 rules asks first -- without weakening the real fix this replaced (review found scoping a
+  // rule's *non-empty* own options into the merge, rather than sharing one unscoped config across
+  // every rule, was what closed a silently-dropped-notice defect; an empty entry never carried any of
+  // that information to begin with, so omitting it changes no rule's own effective options).
+  for (const [id, options] of perRuleOptions) {
+    if (Object.keys(options).length === 0) continue;
+    mergedRules[id] = { ...mergedRules[id], ...options };
   }
 
   const config: SteAiConfigInput = {

--- a/test/integration/shared-config-merge.test.ts
+++ b/test/integration/shared-config-merge.test.ts
@@ -94,4 +94,56 @@ describe('getAnalysis merges a shared-config file with an inline shared option',
     // The valid sibling entry must survive the malformed one, not be wiped out alongside it.
     expect(result.config.rules['no-contractions']?.['enabled']).toBe(false);
   });
+
+  /**
+   * Regression: `getAnalysis` is called once per enabled rule, each with only its own
+   * `perRuleOptions` entry (see this function's own doc comment on `reportedRunNoticesFor` in
+   * `adapter.ts`). An earlier version folded that entry's *key* into `mergedRules` unconditionally,
+   * even when its value was `{}` -- no rule-specific options beyond being enabled, the common case.
+   * `cacheKey` hashes the whole merged config, so two rules that both carry empty options still
+   * produced different cache entries purely because they were keyed under different rule ids, even
+   * though neither call's `mergedRules` differed in any way that could change the analysis.
+   * Reproduced directly against this repo's own real preset (14 rules): instrumenting the cache with
+   * a trace showed 14 misses, 0 hits, for one document -- confirmed here at the `getAnalysis` level,
+   * not just observed as a slow corpus run.
+   */
+  it('shares one cache entry across rules whose own options are empty', () => {
+    const text = 'Utilise the bracket.\n';
+    const promiseA = getAnalysis(
+      text,
+      undefined,
+      baseDir,
+      undefined,
+      new Map([['no-contractions', {}]]),
+    );
+    const promiseB = getAnalysis(
+      text,
+      undefined,
+      baseDir,
+      undefined,
+      new Map([['punctuation-constraints', {}]]),
+    );
+    expect(promiseA).toBe(promiseB);
+  });
+
+  /** The narrower fix must not reopen what it replaced: a rule with genuinely distinct own options
+   * still gets its own cache entry, not folded into the shared one. */
+  it('still gives a rule with genuinely distinct own options its own cache entry', () => {
+    const text = 'Utilise the bracket.\n';
+    const promiseA = getAnalysis(
+      text,
+      undefined,
+      baseDir,
+      undefined,
+      new Map([['no-contractions', {}]]),
+    );
+    const promiseB = getAnalysis(
+      text,
+      undefined,
+      baseDir,
+      undefined,
+      new Map([['abbreviation-introduction', { additionalWellKnown: ['FOO'] }]]),
+    );
+    expect(promiseA).not.toBe(promiseB);
+  });
 });


### PR DESCRIPTION
## Summary

- `getAnalysis` (`src/textlint/adapter.ts`) is called once per enabled rule, each with its own `perRuleOptions` entry — usually `{}` for a rule with no rule-specific config beyond being enabled. Folding that entry's *key* into `mergedRules` unconditionally, even when its value was empty, made `cacheKey` sensitive to which rule was calling regardless of whether the call carried anything new.
- Instrumented the cache with a trace against this repo's own 14-rule preset: **14 misses, 0 hits** for one document, before the fix.
- Fix: only merge a rule's own `perRuleOptions` entry into `mergedRules` when it's non-empty. After the fix, the same file traces to **2 misses, 12 hits** — the 13 rules with no rule-specific options now share one cache entry; the 1 rule that genuinely has its own options (`abbreviation-introduction`, via `.ste-ai.json`) still correctly gets its own.
- Verified safe: `config.rules[id] ?? {}` (`src/core/runner.ts:60`) already treats an absent entry the same as an empty one, and the `unknown-rule-id` check (`runner.ts:152`) only flags ids absent from the real rule registry — never a key this change removes, since every removed key is the calling rule's own real, registered id.

## Test plan

- [x] `vp check` — clean
- [x] `vp test --run` — 791 tests, all files pass
- [x] Two new tests in `test/integration/shared-config-merge.test.ts`:
  - `shares one cache entry across rules whose own options are empty` (reference-equal cache promises)
  - `still gives a rule with genuinely distinct own options its own cache entry` (proves the narrower prior fix — scoping a rule's *non-empty* own options into the merge — still holds)
- [x] Both proved via revert-and-fail: reverted the fix, confirmed the sharing test failed, restored it
- [x] Verified against the real corpus: `node scripts/ci/check-dogfood-lint.mjs` held at 20 files / 1389 errors before and after (zero regressions), full run completed in 1m9.6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV1D6ZmPqrTCrgAGYrkHzd)_