### PR TITLE
docs(textlint): drop hard-coded rule/cache counts from adapter comments

### DIFF
--- a/src/textlint/adapter.ts
+++ b/src/textlint/adapter.ts
@@ -126,8 +126,8 @@ function validRulesOf(raw: unknown): Record<string, Record<string, unknown>> {
 /**
  * Analyse the document once per (text, shared configuration) pair.
  *
- * Rules within one textlint run share the entry, so a 14-rule preset performs one analysis and, at
- * most, one round of semantic requests.
+ * Every enabled rule within one textlint run shares the entry, so a preset with many rules
+ * performs one analysis and, at most, one round of semantic requests, rather than one per rule.
  */
 export function getAnalysis(
   text: string,
@@ -167,16 +167,16 @@ export function getAnalysis(
   // Every enabled rule calls `getAnalysis` with its own `perRuleOptions` entry, most often `{}` --
   // no rule-specific options set beyond being enabled. Folding that entry's *key* into `mergedRules`
   // unconditionally, even when its value is empty, made `cacheKey` sensitive to which rule was
-  // calling regardless of whether the call actually carried anything new: a 14-rule preset produced
-  // up to 14 distinct cache entries for the same document, one per calling rule, because each call's
-  // `mergedRules` differed only by which rule's own (frequently empty) options object happened to be
-  // present as a key -- reproduced directly: instrumenting the cache with a trace showed 14 misses,
-  // 0 hits, for a single file under this repo's own preset. Skipping a genuinely empty entry restores
-  // the doc comment's own claim -- one shared cache entry per document, regardless of which of the
-  // 14 rules asks first -- without weakening the real fix this replaced (review found scoping a
-  // rule's *non-empty* own options into the merge, rather than sharing one unscoped config across
-  // every rule, was what closed a silently-dropped-notice defect; an empty entry never carried any of
-  // that information to begin with, so omitting it changes no rule's own effective options).
+  // calling regardless of whether the call actually carried anything new: each call's `mergedRules`
+  // differed only by which rule's own (frequently empty) options object happened to be present as a
+  // key, so a preset with many rules produced one distinct cache entry per calling rule instead of
+  // one shared entry per document -- reproduced directly by instrumenting the cache with a trace
+  // against this repo's own real preset. Skipping a genuinely empty entry restores the doc comment's
+  // own claim -- one shared cache entry per document, regardless of which rule asks first -- without
+  // weakening the real fix this replaced (review found scoping a rule's *non-empty* own options into
+  // the merge, rather than sharing one unscoped config across every rule, was what closed a
+  // silently-dropped-notice defect; an empty entry never carried any of that information to begin
+  // with, so omitting it changes no rule's own effective options).
   for (const [id, options] of perRuleOptions) {
     if (Object.keys(options).length === 0) continue;
     mergedRules[id] = { ...mergedRules[id], ...options };

--- a/test/integration/shared-config-merge.test.ts
+++ b/test/integration/shared-config-merge.test.ts
@@ -103,9 +103,9 @@ describe('getAnalysis merges a shared-config file with an inline shared option',
    * `cacheKey` hashes the whole merged config, so two rules that both carry empty options still
    * produced different cache entries purely because they were keyed under different rule ids, even
    * though neither call's `mergedRules` differed in any way that could change the analysis.
-   * Reproduced directly against this repo's own real preset (14 rules): instrumenting the cache with
-   * a trace showed 14 misses, 0 hits, for one document -- confirmed here at the `getAnalysis` level,
-   * not just observed as a slow corpus run.
+   * Reproduced directly against this repo's own real preset: instrumenting the cache with a trace
+   * showed a distinct cache miss per enabled rule and no hits, for one document -- confirmed here at
+   * the `getAnalysis` level, not just observed as a slow corpus run.
    */
   it('shares one cache entry across rules whose own options are empty', () => {
     const text = 'Utilise the bracket.\n';


### PR DESCRIPTION
## Summary

- Follow-up to #113 — a Codex review landed on it after merge, flagging that the new comment on `getAnalysis`'s merge loop hard-codes "14 rules / 14 misses / 0 hits", a derivable measurement with no live source, drifting the moment the preset gains or loses a rule. AGENTS.md bars this class of manually maintained fact.
- Reworded the flagged comment to describe the cache-key relationship without the numbers.
- Found and fixed the same issue in two adjacent places while already touching this file: the pre-existing `getAnalysis` doc comment ("a 14-rule preset performs one analysis") one paragraph above, and the matching comment in the new regression test.
- No behavior change — comment-only diff.

## Test plan

- [x] `vp check` — clean
- [x] `vp test --run` — 791 tests, all files pass
- [x] Grepped both changed files for `14 rule|14-rule|14 misses|14 distinct` — no remaining occurrences

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV1D6ZmPqrTCrgAGYrkHzd)_