### PR TITLE
fix(analysis): unify the "adjudication did not run" message across both entry points

### DIFF
--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -39,7 +39,11 @@ import { readMarkdownUnitsSync } from '../reader/markdown-reader.js';
 import { readPlainTextUnitsSync } from '../reader/plain-text-reader.js';
 import type { TextUnit } from '../reader/types.js';
 import { resolveRulePack, verifiedAuthority } from '../rule-pack/loader.js';
-import { analyseSemantically } from '../semantic/analyse.js';
+import {
+  analyseSemantically,
+  semanticNotRunNoticeMessage,
+  undecidedCandidateReasonMessage,
+} from '../semantic/analyse.js';
 import { SemanticBroker, type SemanticBrokerDeps } from '../semantic/broker.js';
 import { resolveOverlappingFixes } from '../core/runner.js';
 
@@ -590,9 +594,7 @@ function undecidedCandidateDiagnostics(
         ruleStatus,
         category: 'review-required' as const,
         severity: config.diagnostics.severity['review-required'],
-        message:
-          'This passage needs semantic adjudication, which did not run, so it was not decided. ' +
-          `A reviewer must decide it. Reason: ${candidate.reason}`,
+        message: undecidedCandidateReasonMessage(candidate.reason),
         range: candidate.range,
         producedBy: 'deterministic' as const,
         candidateId: candidate.id,
@@ -606,9 +608,7 @@ function undecidedCandidateDiagnostics(
       {
         code: 'semantic-disabled',
         level: 'info',
-        message:
-          `${candidates.length} passage(s) needed semantic adjudication, which did not run. They ` +
-          'are reported as review-required. No compliance conclusion was drawn about them.',
+        message: semanticNotRunNoticeMessage(candidates.length),
         detail: { candidates: candidates.length },
       },
     ],

--- a/src/semantic/analyse.ts
+++ b/src/semantic/analyse.ts
@@ -31,6 +31,23 @@ export interface SemanticAnalysisResult {
 }
 
 /**
+ * Canonical wording for a candidate that needed semantic adjudication but never got it — whether
+ * because the broker declined it (`analyseSemantically` below) or because semantic adjudication was
+ * never attempted at all (`analyseTextDeterministic`'s `undecidedCandidateDiagnostics` in
+ * `../analysis/analyse.ts`). The two call sites used to maintain separate hand-written strings for
+ * this identical fact; they drifted apart (see `test/integration/deterministic-parity.test.ts`, which
+ * pins them staying equal).
+ */
+export function undecidedCandidateReasonMessage(reason: string): string {
+  return `Semantic adjudication did not run, so this candidate was not decided. A reviewer must decide it. Reason: ${reason}`;
+}
+
+/** Companion to {@link undecidedCandidateReasonMessage} for the run-notice summary line. */
+export function semanticNotRunNoticeMessage(count: number): string {
+  return `${count} passage(s) needed semantic adjudication, which is disabled. They are reported as review-required. No compliance conclusion was drawn about them.`;
+}
+
+/**
  * Turn candidates into diagnostics.
  *
  * Three invariants hold here:
@@ -73,8 +90,7 @@ export async function analyseSemantically(
           candidate,
           ruleStatus,
           policy,
-          'Semantic adjudication did not run, so this candidate was not decided. A reviewer must ' +
-            `decide it. Reason: ${candidate.reason}`,
+          undecidedCandidateReasonMessage(candidate.reason),
         );
         continue;
       }
@@ -187,9 +203,7 @@ export async function analyseSemantically(
     notices.push({
       code: 'semantic-disabled',
       level: 'info',
-      message:
-        `${disabledCount} passage(s) needed semantic adjudication, which is disabled. They are ` +
-        'reported as review-required. No compliance conclusion was drawn about them.',
+      message: semanticNotRunNoticeMessage(disabledCount),
       detail: { candidates: disabledCount },
     });
   }

--- a/test/integration/deterministic-parity.test.ts
+++ b/test/integration/deterministic-parity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { analyseText, analyseTextDeterministic } from '../../src/analysis/analyse.js';
+
+/**
+ * Regression: `ste-ai lint` (this repository's own CLI, run without `--semantic`) calls
+ * `analyseTextDeterministic`, which never touches a semantic broker at all. The real textlint plugin
+ * (`createSteTextlintRule` -> `getAnalysis` in `src/textlint/adapter.ts`) always calls `analyseText`
+ * instead -- even with `semantic.enabled: false` -- which routes every candidate through
+ * `SemanticBroker.adjudicate()`, which declines them with `failure.kind === 'disabled'`.
+ *
+ * Both paths report the identical fact -- "this candidate needed semantic adjudication, and it did
+ * not run" -- but each built its own hand-written message string for it, and the two had drifted:
+ * `analyseTextDeterministic` said "This passage needs semantic adjudication, which did not run, so
+ * it was not decided[...]"; the broker's disabled path said "Semantic adjudication did not run, so
+ * this candidate was not decided[...]". A comparison of `dist/cli/main.js lint` against the real
+ * `textlint --config .textlintrc.json` on the same file (`docs/implementation-report.md`) surfaced
+ * dozens of findings that looked unique to one side purely because of this wording split, though the
+ * same candidate was reported, undecided, on both.
+ *
+ * `undecidedCandidateReasonMessage`/`semanticNotRunNoticeMessage` in `src/semantic/analyse.ts` are now
+ * the single source for this text; this test proves the two entry points actually render identically
+ * for a real document, not just that the shared function works in isolation.
+ */
+describe('the deterministic-only CLI path and the semantic-disabled broker path agree', () => {
+  // Produces a `passive-voice-candidate` via `src/deterministic/rules/candidate-rules.ts` -- the
+  // same trigger `test/integration/candidate-payload-contract.test.ts` uses for this evaluator.
+  const text = 'The valve was closed by the technician.\n';
+
+  it('renders the same review-required message for the same undecided candidate', async () => {
+    const deterministic = analyseTextDeterministic(text, {});
+    const semanticDisabled = await analyseText(text, {});
+
+    const fromDeterministic = deterministic.diagnostics.find(
+      (d) => d.category === 'review-required',
+    );
+    const fromBroker = semanticDisabled.diagnostics.find((d) => d.category === 'review-required');
+
+    expect(fromDeterministic?.message).toBeDefined();
+    expect(fromBroker?.message).toBe(fromDeterministic?.message);
+  });
+
+  it('renders the same semantic-disabled run-notice summary for the same document', async () => {
+    const deterministic = analyseTextDeterministic(text, {});
+    const semanticDisabled = await analyseText(text, {});
+
+    const fromDeterministic = deterministic.notices.find((n) => n.code === 'semantic-disabled');
+    const fromBroker = semanticDisabled.notices.find((n) => n.code === 'semantic-disabled');
+
+    expect(fromDeterministic?.message).toBeDefined();
+    expect(fromBroker?.message).toBe(fromDeterministic?.message);
+  });
+});


### PR DESCRIPTION
## Summary

- `ste-ai lint` (no `--semantic`) calls `analyseTextDeterministic`, which never touches a semantic broker at all — undecided candidates get a review-required diagnostic built by its own hand-written message in `src/analysis/analyse.ts`.
- The real textlint plugin (`createSteTextlintRule` -> `getAnalysis` in `src/textlint/adapter.ts`) always calls `analyseText` instead, even with `semantic.enabled: false` — every candidate routes through `SemanticBroker.adjudicate()`, which declines them with `failure.kind === 'disabled'`, producing a review-required diagnostic via a *separate* hand-written message in `src/semantic/analyse.ts`.
- Both paths report the identical fact ("this candidate needed semantic adjudication, and it did not run") but the two literals had drifted apart in wording. A direct comparison of `node dist/cli/main.js lint docs/implementation-report.md --deterministic-only` against the real `textlint --config .textlintrc.json docs/implementation-report.md` on the same file surfaced dozens of findings that looked unique to one side — purely from this wording split, not from any actual difference in what was found.
- `undecidedCandidateReasonMessage` / `semanticNotRunNoticeMessage` in `src/semantic/analyse.ts` are now the single source for this text, imported and reused by `src/analysis/analyse.ts`'s deterministic-only path.

One remaining, intentional difference survives between the CLI and real textlint output for this same file: `abbreviation-introduction` flags one extra term ("CI") because `ste-ai lint` without `--config` discovers `.ste-ai.json`, not `.textlintrc.json` — this is documented, deliberate behaviour (see `docs/configuration.md`'s "shared configuration file" section and `buildConfig`'s doc comment in `src/cli/main.ts`), not part of this fix.

## Test plan

- [x] `test/integration/deterministic-parity.test.ts` (new) — drives a real trigger document through both `analyseTextDeterministic` and `analyseText` (semantic disabled) and asserts the review-required diagnostic message and the `semantic-disabled` run-notice message are byte-identical on both paths.
- [x] Proved the test actually catches the regression: reverted the source fix, confirmed both new tests fail with the two old drifted strings, then restored the fix.
- [x] `vp check` — format, lint, typecheck clean.
- [x] `vp test --run` — 793 tests pass.
- [x] `vp pack` — rebuild `dist/`, then re-ran `node dist/cli/main.js lint docs/implementation-report.md --deterministic-only --json` against `textlint --config .textlintrc.json --format json docs/implementation-report.md` and diffed the message sets — the only remaining difference is the already-documented `.ste-ai.json` vs `.textlintrc.json` abbreviation-list gap noted above.
- [x] `node scripts/ci/check-dogfood-lint.mjs` — 20 files, 1389 recorded errors, nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV1D6ZmPqrTCrgAGYrkHzd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV1D6ZmPqrTCrgAGYrkHzd)_