### PR TITLE
Sanitize untrusted rule-pack text, reject case-conflicting keys, narrow a provenance claim

### DIFF
--- a/docs/provisional-rules.md
+++ b/docs/provisional-rules.md
@@ -148,6 +148,11 @@ autofix gate also passes. The bundled pack marks just six entries safe: `utilise
 - The bundled list is deliberately small. It is not a controlled vocabulary and does not pretend to
   be one.
 
+**Configuration validation** A project's `additional` map is matched case-insensitively, the same
+way as the pack's own dictionary. Two keys that differ only by case, such as `Use` and `use`, would
+otherwise match the same span. The rule now rejects such a pair when they map to different
+alternatives. It reports `rule-options-invalid` and skips the rule. Every other rule still runs.
+
 ### preferred-terminology
 
 **Triggers** on the pack's `dictionary.preferred` mappings plus project `additional` entries.
@@ -156,6 +161,9 @@ autofix gate also passes. The bundled pack marks just six entries safe: `utilise
 
 **Known failure modes** Project `additional` entries never carry a fix, because the linter cannot
 know whether a project-specific swap is meaning-preserving.
+
+**Configuration validation** Same case-insensitive key-conflict check as `unapproved-vocabulary`
+above, applied to this rule's own `additional` map.
 
 ### no-contractions
 

--- a/src/core/default-pack.ts
+++ b/src/core/default-pack.ts
@@ -27,8 +27,14 @@ function deepFreeze<T>(value: T): T {
  *
  * No authorised ASD-STE100 material is available to this repository: the specification and its
  * dictionary are "a Copyright and a Trademark of ASD, Brussels, Belgium. All rights reserved."
- * (asd-ste100.org, retrieved 2026-07-26). Nothing here is copied, paraphrased or reconstructed
- * from that specification.
+ * (asd-ste100.org, retrieved 2026-07-26). No rule text, no dictionary entry and no rule numbering
+ * was copied, paraphrased or reconstructed from that specification.
+ *
+ * The numeric limits below (`limits`) are round working defaults chosen by the author, not values
+ * read from or reconstructed against the standard, which was never consulted. No claim is made
+ * about whether any of them coincides with a value the standard happens to use — that would be an
+ * assertion this repository has no evidence to support (#19). They are replaceable the same way as
+ * the rest of this pack, below.
  *
  * What this pack *is*: ordinary plain-English editing guidance of the kind published in many
  * public style guides — prefer the short common word, avoid contractions, keep sentences short,

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -37,7 +37,9 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  * The whitespace-shaped members of those categories — tab, newline, CR, vertical tab, form feed,
  * NEL (U+0085, a C1 control that is also a line break), and the two Unicode line/paragraph
  * separators — are normalised to an ordinary space rather than deleted outright, and normalised
- * *before* the rest of the category is stripped. This sanitizer runs on the actual replacement
+ * *after* the rest of the category (and bidi controls) are stripped outright, not before --
+ * see the ordering note on {@link stripUnsafeCharacters}'s whitespace-run comment below for
+ * why. This sanitizer runs on the actual replacement
  * text a fix writes into a document, not just display strings (`sanitizeQuotedValue`'s doc comment
  * on `note` is the display-only exception, not the rule) — so a legitimately schema-permitted pack
  * value like `sign\tin` or `do\nnot` deleting straight to `signin`/`donot` would silently glue two

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -59,6 +59,24 @@ export function stripUnsafeCharacters(text: string): string {
 }
 
 /**
+ * Whether `text` has at least one visible character, rather than only whitespace and/or Unicode
+ * format characters (`\p{Cf}`: ZWJ, ZWNJ, soft hyphen, ...).
+ *
+ * `stripUnsafeCharacters` intentionally leaves `\p{Cf}` alone — it can have a real, local effect
+ * on the word it sits inside (its own doc comment covers ZWJ joining an emoji sequence into one
+ * glyph, ZWNJ controlling Persian/Arabic letter-joining) — but a replacement made of *nothing but*
+ * such characters, with no visible base character for any of them to modify, renders as nothing.
+ * Confirmed as a real gap by Codex's review on this PR: a lone ZWJ survives both
+ * `stripUnsafeCharacters` and `.trim()` (neither strips nor counts as whitespace), so checking a
+ * sanitized replacement is merely non-blank after those two steps was not enough — a
+ * `safeSubstitution` fix built from it would still replace a visible word with something
+ * invisible.
+ */
+export function hasVisibleContent(text: string): boolean {
+  return /[^\p{Cf}\s]/u.test(text);
+}
+
+/**
  * As {@link stripUnsafeCharacters}, and also replaces a literal `"` with `'`.
  *
  * Use this only where the caller interpolates the result directly inside a double-quoted phrase in

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -2,21 +2,40 @@ import { proseWords } from '../core/document.js';
 import type { Sentence, SourceRange, TextBlock, Word } from '../core/types.js';
 
 /**
+ * Unicode bidirectional-control code points: the ones actually capable of reordering how
+ * surrounding text visually renders (the Trojan Source attack class), rather than every character
+ * Unicode classifies as "format" (`\p{Cf}`). Listed explicitly rather than derived from a broader
+ * property, because `\p{Cf}` also contains characters with a real, local effect on the word they
+ * sit inside — ZWJ (U+200D, joins emoji into one glyph), ZWNJ (U+200C, controls letter-joining in
+ * Persian/Arabic script), soft hyphen — none of which move *surrounding* text the way a bidi
+ * override does. `stripUnsafeCharacters` (below) used to strip the whole `\p{Cf}` category and, in
+ * doing so, mangled exactly that class of legitimate rule-pack replacement text (confirmed
+ * directly: stripping ZWJ from `👩‍🔧` produces `👩🔧`, a different emoji).
+ *
+ * ALM, LRM, RLM (U+061C, U+200E, U+200F): directional marks with no visible glyph of their own.
+ * LRE/RLE/PDF/LRO/RLO (U+202A–U+202E) and LRI/RLI/FSI/PDI (U+2066–U+2069): the embedding, override
+ * and isolate controls.
+ */
+const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
+
+/**
  * Remove characters that make a supplier-controlled string actively dangerous once it is
- * interpolated into rendered output (a diagnostic `message`, a fix `rationale`) — not merely
- * unusual-looking ones.
+ * interpolated into rendered output (a diagnostic `message`, a fix `rationale`) or written into a
+ * document (a fix's actual replacement text) — not merely unusual-looking ones.
  *
  * Rule-pack text fields such as `preferred.to`, `unapproved.alternatives` and `note` carry no
  * format constraint in `src/rule-pack/schema.ts`. Unlike `metadata.id` (`src/core/rule-pack-id.ts`),
  * free display text cannot be reduced to an allowed character set without breaking legitimate
  * non-English terms, so this strips categories of character rather than a fixed list — closing the
  * class the way the id allowlist does, instead of chasing individual characters. Removed:
- * `\p{Cc}`/`\p{Cf}` (C0/C1 controls, zero-width and bidirectional-override characters) and
- * `\p{Zl}`/`\p{Zp}` (line/paragraph separators), any of which can rewrite how surrounding terminal
- * or log output reads.
+ * `\p{Cc}` (C0/C1 controls), {@link BIDI_CONTROL_CHARS} (bidirectional overrides and embeddings),
+ * and `\p{Zl}`/`\p{Zp}` (line/paragraph separators) — every one of which can rewrite how
+ * surrounding terminal or log output reads, or reorder text around it. General Unicode format
+ * characters (`\p{Cf}`) outside that explicit list are left alone: a real word or replacement can
+ * legitimately need one.
  */
 export function stripUnsafeCharacters(text: string): string {
-  return text.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu, '');
+  return text.replace(/[\p{Cc}\p{Zl}\p{Zp}]/gu, '').replace(BIDI_CONTROL_CHARS, '');
 }
 
 /**

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -88,11 +88,12 @@ function codePointLength(term: string): number {
  * reports that whole bucket as {@link CaseConflictScan.unchecked} instead of exhaustively
  * confirming it.
  *
- * The check is quadratic per length bucket — measured directly at roughly 800ms for 2,000
- * pairwise-distinct same-length entries, the DoS-shaped cost Codex's review on this PR flagged
- * (`additional` is reachable from an untrusted pack's own `rules[].options`, per
+ * The check is quadratic per length bucket, which is the DoS-shaped cost Codex's review on this PR
+ * flagged (`additional` is reachable from an untrusted pack's own `rules[].options`, per
  * {@link reportCaseConflict}'s doc comment, so this is a real cost an untrusted pack can impose,
- * not only an operator's own mistake). Silently treating an oversized bucket as conflict-free was
+ * not only an operator's own mistake) — reproduce the shape with a same-length benchmark of a few
+ * thousand entries rather than trusting a one-off measurement committed here. Silently treating an
+ * oversized bucket as conflict-free was
  * tried first and rejected on review: a bucket this large could still contain a genuine conflict
  * (`Foo`/`foo` among 500 unrelated same-length keys, say), and reporting "no conflict" without
  * having checked is a false all-clear. Failing the rule instead, honestly naming the bucket as
@@ -106,23 +107,40 @@ const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
  *
  * {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH} alone bounds cost per bucket, but not in total: an
  * untrusted pack can keep every bucket at exactly that limit and supply arbitrarily many buckets
- * — confirmed directly by Codex's review on this PR, in its own review environment: 50 buckets of
- * 500 entries each (25,000 keys total, every one within the per-bucket limit) cost roughly 7.5s
- * across roughly 6.2 million regex comparisons. Once processing a bucket would push the running
- * total over this budget, that bucket (and every one after it) is reported as
+ * — Codex's review on this PR flagged exactly this shape (many buckets, each individually within
+ * the per-bucket limit). `test/unit/rules.test.ts`'s "bounds total cost across many buckets" test
+ * reproduces the adversarial shape and asserts a wall-clock ceiling directly, rather than this
+ * comment committing a one-off measurement that would drift from the real cost as the
+ * implementation or runtime changes. Once processing a bucket would push the running total over
+ * this budget, that bucket (and every one after it) is reported as
  * {@link CaseConflictScan.unchecked} instead of partially or fully processed — the same
  * fail-closed behaviour as one bucket over the per-length limit, just budgeted globally instead of
- * per length. 500,000 comparisons is comfortably under 200ms measured directly, room for several
- * buckets at the per-length cap or many more smaller ones.
+ * per length. The chosen value leaves room for several buckets at the per-length cap, or many more
+ * smaller ones, before the budget is spent.
  */
 const MAX_TOTAL_COMPARISONS = 500_000;
+
+/**
+ * One {@link CaseConflictScan.unchecked} group, naming both its keys and *why* they went
+ * unconfirmed — a bucket that individually exceeds {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH}
+ * is a different situation for a caller (and a reader of the resulting notice) than a
+ * comfortably-sized bucket that only lost out to {@link MAX_TOTAL_COMPARISONS} because earlier
+ * buckets already spent most of it — collapsing both into one shape would report the wrong
+ * constraint as the reason a rule got skipped.
+ */
+export interface UncheckedGroup {
+  /** The keys in this bucket, unconfirmed either way. */
+  readonly keys: string[];
+  /** Which limit stopped this bucket from being checked. */
+  readonly reason: 'bucket-too-large' | 'total-budget-exceeded';
+}
 
 /** {@link findCaseConflicts}'s result: confirmed conflicts, and buckets too large to confirm. */
 export interface CaseConflictScan {
   /** Groups confirmed, via the real matcher, to map to different values. */
   readonly conflicts: string[][];
-  /** Groups too large to check exhaustively (see {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH}); their case-conflict status was never determined. */
-  readonly unchecked: string[][];
+  /** Groups whose case-conflict status was never determined; see {@link UncheckedGroup.reason}. */
+  readonly unchecked: UncheckedGroup[];
 }
 
 /**
@@ -156,16 +174,16 @@ export function findCaseConflicts<T>(
   }
 
   const groups: [key: string, value: T][][] = [];
-  const unchecked: string[][] = [];
+  const unchecked: UncheckedGroup[] = [];
   let comparisonsSpent = 0;
   for (const bucket of byLength.values()) {
     if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) {
-      unchecked.push(bucket.map(([key]) => key));
+      unchecked.push({ keys: bucket.map(([key]) => key), reason: 'bucket-too-large' });
       continue;
     }
     const bucketCost = (bucket.length * (bucket.length - 1)) / 2;
     if (comparisonsSpent + bucketCost > MAX_TOTAL_COMPARISONS) {
-      unchecked.push(bucket.map(([key]) => key));
+      unchecked.push({ keys: bucket.map(([key]) => key), reason: 'total-budget-exceeded' });
       continue;
     }
     comparisonsSpent += bucketCost;
@@ -237,8 +255,15 @@ export function reportCaseConflict(
 }
 
 /**
- * Report one `findCaseConflicts` {@link CaseConflictScan.unchecked} group: too many keys of the
- * same length to confirm, one way or the other, whether any of them collide.
+ * Report one `findCaseConflicts` {@link CaseConflictScan.unchecked} group: keys that could not be
+ * confirmed, one way or the other, whether any of them collide.
+ *
+ * The message names which limit stopped the check ({@link UncheckedGroup.reason}) rather than
+ * always blaming this group's own length: a bucket well under
+ * {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH} can still end up unchecked if earlier buckets
+ * already spent most of {@link MAX_TOTAL_COMPARISONS}, and telling that caller "too many keys
+ * share this length" would misidentify the actual constraint and the actual fix (reduce keys
+ * overall, not just within this length).
  *
  * Names a sample rather than every key, both because the full list can be long and because each
  * key is display text (see {@link reportCaseConflict}'s doc comment on provenance) sanitized the
@@ -246,22 +271,25 @@ export function reportCaseConflict(
  */
 export function reportUncheckedGroup(
   ctx: IssueReporter,
-  group: readonly string[],
+  group: UncheckedGroup,
   noun: 'alternatives' | 'replacements',
 ): void {
-  const sample = group
+  const sample = group.keys
     .slice(0, 3)
     .map((key) => `"${sanitizeQuotedValue(key)}"`)
     .join(', ');
-  ctx.addIssue({
-    code: 'custom',
-    path: ['additional'],
-    message:
-      `${group.length} keys (for example ${sample}) are the same length once whitespace runs ` +
-      `are normalised — too many to exhaustively check for a case-insensitive collision over ` +
-      `their ${noun}. Reduce how many keys share this length, or split them across more than ` +
-      'one rule configuration.',
-  });
+  const message =
+    group.reason === 'bucket-too-large'
+      ? `${group.keys.length} keys (for example ${sample}) are the same length once whitespace ` +
+        `runs are normalised — too many to exhaustively check for a case-insensitive collision ` +
+        `over their ${noun}. Reduce how many keys share this length, or split them across more ` +
+        'than one rule configuration.'
+      : `${group.keys.length} keys (for example ${sample}) could not be checked for a ` +
+        `case-insensitive collision over their ${noun}: checking them would exceed the total ` +
+        `comparison budget shared across every key length in this "additional" map, even though ` +
+        'this group alone is well within the per-length limit. Reduce the total number of keys ' +
+        'across all lengths, or split them across more than one rule configuration.';
+  ctx.addIssue({ code: 'custom', path: ['additional'], message });
 }
 
 /** Escape regex metacharacters and collapse whitespace runs to a flexible `\s+`. */

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -67,6 +67,40 @@ export function findCaseConflicts<T>(
   return conflicts;
 }
 
+/**
+ * Minimal shape `ctx.addIssue` needs, matching zod v4's `$RefinementCtx` — kept structural so this
+ * helper does not depend on zod's internal types directly.
+ */
+export interface IssueReporter {
+  addIssue(issue: { code: 'custom'; path: PropertyKey[]; message: string }): void;
+}
+
+/**
+ * Report one `findCaseConflicts` group through a `superRefine` context, naming the conflicting
+ * keys.
+ *
+ * The keys themselves are supplier-controlled in the same sense `preferred.to`/`unapproved
+ * .alternatives` are (`options.additional` is user config, but `rule.optionsSchema.safeParse`
+ * also runs against `packSpec.options` — src/core/runner.ts's `rawOptions = { ...packSpec
+ * ?.options, ...stripControlKeys(userConfig) }` — and `rulePackRuleSpecSchema.options` is an
+ * unconstrained `z.record(z.string(), z.unknown())`, src/rule-pack/schema.ts). This message is
+ * rendered verbatim by the CLI and the textlint adapter's notice reporting, the same as
+ * `Diagnostic.message`, so the keys go through {@link sanitizeQuotedValue} before interpolation.
+ */
+export function reportCaseConflict(
+  ctx: IssueReporter,
+  group: readonly string[],
+  noun: 'alternatives' | 'replacements',
+): void {
+  ctx.addIssue({
+    code: 'custom',
+    path: ['additional'],
+    message:
+      `${group.map((key) => `"${sanitizeQuotedValue(key)}"`).join(' and ')} are case-equivalent ` +
+      `keys that resolve to the same source span but map to different ${noun}.`,
+  });
+}
+
 /** Build a whole-word, case-insensitive matcher for a term or multi-word phrase. */
 export function termPattern(term: string): RegExp {
   const escaped = term

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -46,7 +46,7 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  *
  * Matched and collapsed as a whole run, not one character at a time, and the run itself spans any
  * ordinary space characters immediately touching a control, not only the controls themselves --
- * two gaps in an earlier version, both confirmed directly by Codex's review on this PR:
+ * three gaps in an earlier version, all confirmed directly by Codex's review on this PR:
  *
  * - A conventional multi-character line break like `\r\n` is two of these controls back to
  *   back; replacing each independently produced `sign  in` (two spaces) for `sign\r\nin`
@@ -54,21 +54,28 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  * - Indentation around a line break (`sign \r\n in`) left the *adjacent* ordinary spaces
  *   untouched, since they are not themselves one of these controls, producing `sign   in`
  *   (three spaces) instead of one.
+ * - A run touching either end of the *whole replacement string* was still collapsed to a space
+ *   rather than dropped, even though there is no word on that side to separate from:
+ *   `stripUnsafeCharacters('\nfoo')` produced `' foo'`, a stray leading space that becomes a
+ *   double space once substituted next to the document's own existing separator.
  *
  * {@link WHITESPACE_RUN_TOUCHING_CONTROL} matches the broader run (controls and ordinary
- * spaces both); the replacer only collapses a matched run to one space when
- * {@link WHITESPACE_SHAPED_CONTROLS} actually finds a control character inside it, leaving a
- * run of *only* ordinary spaces -- legitimate, pack-authored text with no control character in
- * it at all -- untouched.
+ * spaces both); the replacer only touches a matched run that actually contains a control
+ * character (per {@link WHITESPACE_SHAPED_CONTROLS}), leaving a run of *only* ordinary spaces --
+ * legitimate, pack-authored text with no control character in it at all -- untouched. A
+ * control-bearing run touching either end of the whole string collapses to nothing; one that
+ * doesn't collapses to a single space.
  */
 const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]/u;
 const WHITESPACE_RUN_TOUCHING_CONTROL = /[ \t\n\v\f\r\u0085\u2028\u2029]+/gu;
 
 export function stripUnsafeCharacters(text: string): string {
   return text
-    .replace(WHITESPACE_RUN_TOUCHING_CONTROL, (run) =>
-      WHITESPACE_SHAPED_CONTROLS.test(run) ? ' ' : run,
-    )
+    .replace(WHITESPACE_RUN_TOUCHING_CONTROL, (run, offset) => {
+      if (!WHITESPACE_SHAPED_CONTROLS.test(run)) return run;
+      const atBoundary = offset === 0 || offset + run.length === text.length;
+      return atBoundary ? '' : ' ';
+    })
     .replace(/[\p{Cc}\p{Zl}\p{Zp}]/gu, '')
     .replace(BIDI_CONTROL_CHARS, '');
 }

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -35,27 +35,46 @@ export function sanitizeQuotedValue(text: string): string {
 }
 
 /**
- * Group the keys of a term map by case-insensitive equality and report every group whose members
- * do not all resolve to the same value.
+ * Group the keys of a term map by {@link sameTermSpan} and report every group whose members do not
+ * all resolve to the same value.
  *
  * `termPattern()` matches case-insensitively, so `Use` and `use` claim the same source span; the
  * first one in object key order silently wins and the other's mapping never applies. That is only
  * a real conflict when the two keys disagree about the replacement — `{ Use: ['employ'], use:
  * ['employ'] }` is redundant but not contradictory.
+ *
+ * Grouping is pairwise (`O(n²)`) rather than a single hash pass, because {@link sameTermSpan} is
+ * not reducible to a hashable key the way `String.prototype.toLowerCase()` is — Unicode case
+ * folding is an equivalence relation checked pairwise, not a function computing one canonical
+ * form per string. `additional` maps are operator- or pack-authored and small (tens of entries at
+ * most), so this cost is not a concern in practice.
  */
 export function findCaseConflicts<T>(
   entries: Readonly<Record<string, T>>,
   valuesEqual: (a: T, b: T) => boolean,
 ): string[][] {
-  const groups = new Map<string, [key: string, value: T][]>();
-  for (const [key, value] of Object.entries(entries)) {
-    const lower = key.toLowerCase();
-    const group = groups.get(lower);
-    if (group === undefined) groups.set(lower, [[key, value]]);
-    else group.push([key, value]);
+  const items = Object.entries(entries);
+  const consumed = new Set<number>();
+  const groups: [key: string, value: T][][] = [];
+  for (let i = 0; i < items.length; i++) {
+    if (consumed.has(i)) continue;
+    const current = items[i];
+    if (current === undefined) continue;
+    const group: [string, T][] = [current];
+    consumed.add(i);
+    for (let j = i + 1; j < items.length; j++) {
+      if (consumed.has(j)) continue;
+      const candidate = items[j];
+      if (candidate === undefined) continue;
+      if (sameTermSpan(current[0], candidate[0])) {
+        group.push(candidate);
+        consumed.add(j);
+      }
+    }
+    groups.push(group);
   }
   const conflicts: string[][] = [];
-  for (const group of groups.values()) {
+  for (const group of groups) {
     if (group.length < 2) continue;
     const first = group[0];
     if (first === undefined) continue;
@@ -101,13 +120,34 @@ export function reportCaseConflict(
   });
 }
 
-/** Build a whole-word, case-insensitive matcher for a term or multi-word phrase. */
-export function termPattern(term: string): RegExp {
-  const escaped = term
+/** Escape regex metacharacters and collapse whitespace runs to a flexible `\s+`. */
+function escapeForMatching(term: string): string {
+  return term
     .trim()
     .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     .replace(/\s+/g, '\\s+');
+}
+
+/** Build a whole-word, case-insensitive matcher for a term or multi-word phrase. */
+export function termPattern(term: string): RegExp {
+  const escaped = escapeForMatching(term);
   return new RegExp(`(?<![\\p{L}\\p{N}_])${escaped}(?![\\p{L}\\p{N}_])`, 'giu');
+}
+
+/**
+ * Whether `a` and `b` are the same term for `termPattern()`'s matching purposes — not merely
+ * `String.prototype.toLowerCase()`-equal.
+ *
+ * `/iu` implements full Unicode case folding, which is not the same relation `toLowerCase()`
+ * computes: `/s/iu` matches the Latin small letter long s (`ſ`, U+017F), but `'s'.toLowerCase()
+ * !== 'ſ'.toLowerCase()` — confirmed directly. A case-conflict check keyed on `toLowerCase()`
+ * would therefore miss a real collision between `additional` keys `s` and `ſ`, or their Greek and
+ * Turkish counterparts, leaving exactly the "object key order silently decides" ambiguity #125
+ * exists to reject. This asks the same regex engine `findTerm` actually uses, anchored to the
+ * whole string on both sides, rather than reimplementing its notion of "the same letter".
+ */
+export function sameTermSpan(a: string, b: string): boolean {
+  return new RegExp(`^${escapeForMatching(a)}$`, 'iu').test(b.trim());
 }
 
 export interface TermMatch {

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -35,16 +35,16 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  * legitimately need one.
  *
  * The whitespace-shaped members of those categories — tab, newline, CR, vertical tab, form feed,
- * and the two Unicode line/paragraph separators — are normalised to an ordinary space rather than
- * deleted outright, and normalised *before* the rest of the category is stripped. This sanitizer
- * runs on the actual replacement text a fix writes into a document, not just display strings
- * (`sanitizeQuotedValue`'s doc comment on `note` is the display-only exception, not the rule) — so
- * a legitimately schema-permitted pack value like `sign\tin` or `do\nnot` deleting straight to
- * `signin`/`donot` would silently glue two words together, corrupting the actual suggestion and
- * fix. Every other control character in these categories has no legitimate word-internal role, so
- * it is still deleted rather than replaced.
+ * NEL (U+0085, a C1 control that is also a line break), and the two Unicode line/paragraph
+ * separators — are normalised to an ordinary space rather than deleted outright, and normalised
+ * *before* the rest of the category is stripped. This sanitizer runs on the actual replacement
+ * text a fix writes into a document, not just display strings (`sanitizeQuotedValue`'s doc comment
+ * on `note` is the display-only exception, not the rule) — so a legitimately schema-permitted pack
+ * value like `sign\tin` or `do\nnot` deleting straight to `signin`/`donot` would silently glue two
+ * words together, corrupting the actual suggestion and fix. Every other control character in these
+ * categories has no legitimate word-internal role, so it is still deleted rather than replaced.
  */
-const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u2028\u2029]/gu;
+const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]/gu;
 
 export function stripUnsafeCharacters(text: string): string {
   return text
@@ -148,16 +148,26 @@ const MAX_TOTAL_COMPARISONS = 500_000;
  * individually very long, so the whole bucket's cost scales with `pairs × length`, not `pairs`
  * alone.
  *
- * The length used is each bucket's *raw*, un-whitespace-collapsed code-point count (tracked
- * alongside the bucket during grouping), not {@link codePointLength} — a follow-up round of the
- * same review found that `codePointLength` collapsing a long whitespace run to one unit made a key
- * built almost entirely of whitespace bucket as short, even though `escapeForMatching`/
- * {@link sameTermSpan} still scan every one of those whitespace characters on every comparison.
- * Charging the collapsed length would have let exactly that shape bypass this budget.
- * `test/unit/rules.test.ts`'s "bounds total cost by key length" and "...uncollapsed whitespace"
- * tests reproduce both shapes directly, rather than this comment committing a one-off measurement.
- * Once a bucket's own or the running weighted total would exceed this budget, it is reported as
- * {@link CaseConflictScan.unchecked} the same way as the other two limits.
+ * The length used is each bucket's *raw, untrimmed* code-point count (tracked alongside the bucket
+ * during grouping), not {@link codePointLength} — two follow-up rounds of the same review each
+ * found a different way the collapsed/trimmed length under-charges the real cost:
+ *
+ * - `codePointLength` collapses a long *internal* whitespace run to one unit, but
+ *   `escapeForMatching`/{@link sameTermSpan} still scan every one of those whitespace characters
+ *   on every comparison, so a key built almost entirely of internal whitespace bucketed (and
+ *   costed) as short.
+ * - Trimming *leading/trailing* whitespace before measuring hid the same problem in the other
+ *   direction: `escapeForMatching`'s own `.trim()` call, and `sameTermSpan`'s `b.trim()`, each cost
+ *   time proportional to the *untrimmed* length regardless of how much they strip, so a key with a
+ *   long leading or trailing run was still expensive to re-trim on every comparison even though the
+ *   trimmed result was short.
+ *
+ * Charging the collapsed or trimmed length would have let either shape bypass this budget.
+ * `test/unit/rules.test.ts`'s "bounds total cost by key length", "...uncollapsed whitespace", and
+ * "...untrimmed length" tests reproduce all three shapes directly, rather than this comment
+ * committing a one-off measurement. Once a bucket's own or the running weighted total would exceed
+ * this budget, it is reported as {@link CaseConflictScan.unchecked} the same way as the other two
+ * limits.
  */
 const MAX_TOTAL_COMPARISON_WORK = 25_000_000;
 
@@ -210,7 +220,7 @@ export function findCaseConflicts<T>(
   const byLength = new Map<number, { bucket: [key: string, value: T][]; maxRawLength: number }>();
   for (const item of items) {
     const length = codePointLength(item[0]);
-    const rawLength = Array.from(item[0].trim()).length;
+    const rawLength = Array.from(item[0]).length;
     const entry = byLength.get(length);
     if (entry === undefined) byLength.set(length, { bucket: [item], maxRawLength: rawLength });
     else {

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -100,6 +100,23 @@ function codePointLength(term: string): number {
  */
 const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
 
+/**
+ * Total pairwise `sameTermSpan` comparisons {@link findCaseConflicts} will attempt across every
+ * length bucket combined, not just within any one bucket.
+ *
+ * {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH} alone bounds cost per bucket, but not in total: an
+ * untrusted pack can keep every bucket at exactly that limit and supply arbitrarily many buckets
+ * — confirmed directly by Codex's review on this PR, in its own review environment: 50 buckets of
+ * 500 entries each (25,000 keys total, every one within the per-bucket limit) cost roughly 7.5s
+ * across roughly 6.2 million regex comparisons. Once processing a bucket would push the running
+ * total over this budget, that bucket (and every one after it) is reported as
+ * {@link CaseConflictScan.unchecked} instead of partially or fully processed — the same
+ * fail-closed behaviour as one bucket over the per-length limit, just budgeted globally instead of
+ * per length. 500,000 comparisons is comfortably under 200ms measured directly, room for several
+ * buckets at the per-length cap or many more smaller ones.
+ */
+const MAX_TOTAL_COMPARISONS = 500_000;
+
 /** {@link findCaseConflicts}'s result: confirmed conflicts, and buckets too large to confirm. */
 export interface CaseConflictScan {
   /** Groups confirmed, via the real matcher, to map to different values. */
@@ -140,11 +157,18 @@ export function findCaseConflicts<T>(
 
   const groups: [key: string, value: T][][] = [];
   const unchecked: string[][] = [];
+  let comparisonsSpent = 0;
   for (const bucket of byLength.values()) {
     if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) {
       unchecked.push(bucket.map(([key]) => key));
       continue;
     }
+    const bucketCost = (bucket.length * (bucket.length - 1)) / 2;
+    if (comparisonsSpent + bucketCost > MAX_TOTAL_COMPARISONS) {
+      unchecked.push(bucket.map(([key]) => key));
+      continue;
+    }
+    comparisonsSpent += bucketCost;
     const consumed = new Set<number>();
     for (let i = 0; i < bucket.length; i++) {
       if (consumed.has(i)) continue;

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -54,44 +54,85 @@ export function sanitizeQuotedValue(text: string): string {
 }
 
 /**
- * Group the keys of a term map by {@link sameTermSpan} and report every group whose members do not
- * all resolve to the same value.
+ * Fast-path canonical form for {@link findCaseConflicts}'s grouping: NFKC folds some
+ * compatibility variants `toLowerCase()` alone does not (confirmed directly: `'ſ'.normalize
+ * ('NFKC').toLowerCase() === 's'`, unifying the Latin long s with plain `s`), which is exactly
+ * the pair Codex's review on this PR flagged `toLowerCase()`-only grouping for missing.
+ */
+function canonicalKey(term: string): string {
+  return term.trim().normalize('NFKC').toLowerCase();
+}
+
+/**
+ * Above this many `additional` entries, {@link findCaseConflicts} skips the exhaustive pairwise
+ * merge below and returns {@link canonicalKey}'s grouping alone.
+ *
+ * That merge step exists only for a case-fold pair `canonicalKey` itself does not unify — Greek
+ * final sigma `ς`/`σ` is the standing example (confirmed directly: `'ς'.normalize('NFKC')
+ * .toLowerCase() !== 'σ'.toLowerCase()`, but `termPattern`'s `/iu` regex does treat them as the
+ * same letter). Finding every such pair exhaustively means testing every remaining group against
+ * every other, which is quadratic in the number of *distinct spellings* after canonicalisation —
+ * measured directly at roughly 800ms for 2,000 pairwise-distinct entries, the DoS-shaped cost
+ * Codex's review on this PR flagged in the pairwise-only version of this function. `additional`
+ * maps are operator- or pack-authored vocabulary lists; one this large is already unusual, so
+ * degrading to canonical-only grouping (which still catches every conflict this function shipped
+ * with before this pairwise refinement existed) is an acceptable trade against stalling a lint run.
+ */
+const EXHAUSTIVE_FOLD_MERGE_LIMIT = 500;
+
+/**
+ * Group the keys of a term map by case-fold equivalence and report every group whose members do
+ * not all resolve to the same value.
  *
  * `termPattern()` matches case-insensitively, so `Use` and `use` claim the same source span; the
  * first one in object key order silently wins and the other's mapping never applies. That is only
  * a real conflict when the two keys disagree about the replacement — `{ Use: ['employ'], use:
  * ['employ'] }` is redundant but not contradictory.
- *
- * Grouping is pairwise (`O(n²)`) rather than a single hash pass, because {@link sameTermSpan} is
- * not reducible to a hashable key the way `String.prototype.toLowerCase()` is — Unicode case
- * folding is an equivalence relation checked pairwise, not a function computing one canonical
- * form per string. `additional` maps are operator- or pack-authored and small (tens of entries at
- * most), so this cost is not a concern in practice.
  */
 export function findCaseConflicts<T>(
   entries: Readonly<Record<string, T>>,
   valuesEqual: (a: T, b: T) => boolean,
 ): string[][] {
   const items = Object.entries(entries);
-  const consumed = new Set<number>();
-  const groups: [key: string, value: T][][] = [];
-  for (let i = 0; i < items.length; i++) {
-    if (consumed.has(i)) continue;
-    const current = items[i];
-    if (current === undefined) continue;
-    const group: [string, T][] = [current];
-    consumed.add(i);
-    for (let j = i + 1; j < items.length; j++) {
-      if (consumed.has(j)) continue;
-      const candidate = items[j];
-      if (candidate === undefined) continue;
-      if (sameTermSpan(current[0], candidate[0])) {
-        group.push(candidate);
-        consumed.add(j);
-      }
-    }
-    groups.push(group);
+
+  // Fast path: O(n) grouping by canonical form, catching every plain-case and NFKC-decomposable
+  // pair (which covers everything `String.prototype.toLowerCase()` alone caught, plus more).
+  const byCanonical = new Map<string, [key: string, value: T][]>();
+  for (const item of items) {
+    const canonical = canonicalKey(item[0]);
+    const group = byCanonical.get(canonical);
+    if (group === undefined) byCanonical.set(canonical, [item]);
+    else group.push(item);
   }
+  let groups = [...byCanonical.values()];
+
+  // Precise path: merge any remaining groups `sameTermSpan` still considers equivalent, bounded
+  // so an unusually large map degrades to the fast path alone instead of stalling.
+  if (items.length <= EXHAUSTIVE_FOLD_MERGE_LIMIT) {
+    const merged: typeof groups = [];
+    const consumed = new Set<number>();
+    for (let i = 0; i < groups.length; i++) {
+      if (consumed.has(i)) continue;
+      let combined = groups[i];
+      if (combined === undefined) continue;
+      consumed.add(i);
+      for (let j = i + 1; j < groups.length; j++) {
+        if (consumed.has(j)) continue;
+        const candidate = groups[j];
+        const combinedFirst = combined[0];
+        if (candidate === undefined || combinedFirst === undefined) continue;
+        const candidateFirst = candidate[0];
+        if (candidateFirst === undefined) continue;
+        if (sameTermSpan(combinedFirst[0], candidateFirst[0])) {
+          combined = [...combined, ...candidate];
+          consumed.add(j);
+        }
+      }
+      merged.push(combined);
+    }
+    groups = merged;
+  }
+
   const conflicts: string[][] = [];
   for (const group of groups) {
     if (group.length < 2) continue;

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -263,6 +263,17 @@ export function findCaseConflicts<T>(
     // {@link CaseConflictScan.unchecked} rather than contributing a
     // partial, silently-incomplete scan.
     try {
+      // A key only has its own compile-safety exercised when it is used as `sameTermSpan`'s first
+      // argument (the side actually compiled into a pattern; the second is only `.trim()`'d and
+      // tested) — the pairwise loop below only calls it that way for a key still unconsumed when
+      // its own turn as `current` arrives. Confirmed directly: a bucket of exactly one such key
+      // never calls `sameTermSpan` at all, so `findCaseConflicts` reports it neither conflicting
+      // nor unchecked, passing validation without ever attempting to compile it. The same gap
+      // applies to any key a peer already claimed as its own `candidate` before its own turn as
+      // `current` arrived. Self-testing every key up front, before any pairwise work, exercises
+      // every key's own compile-safety exactly once regardless of the role it plays below.
+      for (const [key] of bucket) sameTermSpan(key, key);
+
       const bucketGroups: [key: string, value: T][][] = [];
       const consumed = new Set<number>();
       for (let i = 0; i < bucket.length; i++) {

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -44,16 +44,31 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  * words together, corrupting the actual suggestion and fix. Every other control character in these
  * categories has no legitimate word-internal role, so it is still deleted rather than replaced.
  *
- * Matched as a run (`+`), not one character at a time: a conventional multi-character line break
- * like `\r\n` is two of these controls back to back, and replacing each independently produces
- * `sign  in` (two spaces) for `sign\r\nin` instead of one — confirmed as a real gap by Codex's
- * review on this PR. A whole contiguous run collapses to a single replacement space.
+ * Matched and collapsed as a whole run, not one character at a time, and the run itself spans any
+ * ordinary space characters immediately touching a control, not only the controls themselves --
+ * two gaps in an earlier version, both confirmed directly by Codex's review on this PR:
+ *
+ * - A conventional multi-character line break like `\r\n` is two of these controls back to
+ *   back; replacing each independently produced `sign  in` (two spaces) for `sign\r\nin`
+ *   instead of one.
+ * - Indentation around a line break (`sign \r\n in`) left the *adjacent* ordinary spaces
+ *   untouched, since they are not themselves one of these controls, producing `sign   in`
+ *   (three spaces) instead of one.
+ *
+ * {@link WHITESPACE_RUN_TOUCHING_CONTROL} matches the broader run (controls and ordinary
+ * spaces both); the replacer only collapses a matched run to one space when
+ * {@link WHITESPACE_SHAPED_CONTROLS} actually finds a control character inside it, leaving a
+ * run of *only* ordinary spaces -- legitimate, pack-authored text with no control character in
+ * it at all -- untouched.
  */
-const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]+/gu;
+const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]/u;
+const WHITESPACE_RUN_TOUCHING_CONTROL = /[ \t\n\v\f\r\u0085\u2028\u2029]+/gu;
 
 export function stripUnsafeCharacters(text: string): string {
   return text
-    .replace(WHITESPACE_SHAPED_CONTROLS, ' ')
+    .replace(WHITESPACE_RUN_TOUCHING_CONTROL, (run) =>
+      WHITESPACE_SHAPED_CONTROLS.test(run) ? ' ' : run,
+    )
     .replace(/[\p{Cc}\p{Zl}\p{Zp}]/gu, '')
     .replace(BIDI_CONTROL_CHARS, '');
 }

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -130,12 +130,19 @@ const MAX_TOTAL_COMPARISONS = 500_000;
  * {@link MAX_TOTAL_COMPARISONS} treats every `sameTermSpan` comparison as equal-cost, but a regex
  * match's cost scales with the length of the strings it matches — Codex's review on this PR found
  * that a bucket comfortably within the pair-count budget can still be expensive if its keys are
- * individually very long: every key sharing one length bucket, so the whole bucket's cost scales
- * with `pairs × length`, not `pairs` alone. `test/unit/rules.test.ts`'s "bounds total cost by key
- * length" test reproduces the shape (few hundred same-bucket keys, each long) directly, rather
- * than this comment committing a one-off measurement. Once a bucket's own or the running weighted
- * total would exceed this budget, it is reported as {@link CaseConflictScan.unchecked} the same
- * way as the other two limits.
+ * individually very long, so the whole bucket's cost scales with `pairs × length`, not `pairs`
+ * alone.
+ *
+ * The length used is each bucket's *raw*, un-whitespace-collapsed code-point count (tracked
+ * alongside the bucket during grouping), not {@link codePointLength} — a follow-up round of the
+ * same review found that `codePointLength` collapsing a long whitespace run to one unit made a key
+ * built almost entirely of whitespace bucket as short, even though `escapeForMatching`/
+ * {@link sameTermSpan} still scan every one of those whitespace characters on every comparison.
+ * Charging the collapsed length would have let exactly that shape bypass this budget.
+ * `test/unit/rules.test.ts`'s "bounds total cost by key length" and "...uncollapsed whitespace"
+ * tests reproduce both shapes directly, rather than this comment committing a one-off measurement.
+ * Once a bucket's own or the running weighted total would exceed this budget, it is reported as
+ * {@link CaseConflictScan.unchecked} the same way as the other two limits.
  */
 const MAX_TOTAL_COMPARISON_WORK = 25_000_000;
 
@@ -185,25 +192,29 @@ export function findCaseConflicts<T>(
 ): CaseConflictScan {
   const items = Object.entries(entries);
 
-  const byLength = new Map<number, [key: string, value: T][]>();
+  const byLength = new Map<number, { bucket: [key: string, value: T][]; maxRawLength: number }>();
   for (const item of items) {
     const length = codePointLength(item[0]);
-    const bucket = byLength.get(length);
-    if (bucket === undefined) byLength.set(length, [item]);
-    else bucket.push(item);
+    const rawLength = Array.from(item[0].trim()).length;
+    const entry = byLength.get(length);
+    if (entry === undefined) byLength.set(length, { bucket: [item], maxRawLength: rawLength });
+    else {
+      entry.bucket.push(item);
+      if (rawLength > entry.maxRawLength) entry.maxRawLength = rawLength;
+    }
   }
 
   const groups: [key: string, value: T][][] = [];
   const unchecked: UncheckedGroup[] = [];
   let comparisonsSpent = 0;
   let workSpent = 0;
-  for (const [length, bucket] of byLength.entries()) {
+  for (const { bucket, maxRawLength } of byLength.values()) {
     if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) {
       unchecked.push({ keys: bucket.map(([key]) => key), reason: 'bucket-too-large' });
       continue;
     }
     const bucketCost = (bucket.length * (bucket.length - 1)) / 2;
-    const bucketWork = bucketCost * length;
+    const bucketWork = bucketCost * maxRawLength;
     if (
       comparisonsSpent + bucketCost > MAX_TOTAL_COMPARISONS ||
       workSpent + bucketWork > MAX_TOTAL_COMPARISON_WORK

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -43,8 +43,13 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  * value like `sign\tin` or `do\nnot` deleting straight to `signin`/`donot` would silently glue two
  * words together, corrupting the actual suggestion and fix. Every other control character in these
  * categories has no legitimate word-internal role, so it is still deleted rather than replaced.
+ *
+ * Matched as a run (`+`), not one character at a time: a conventional multi-character line break
+ * like `\r\n` is two of these controls back to back, and replacing each independently produces
+ * `sign  in` (two spaces) for `sign\r\nin` instead of one — confirmed as a real gap by Codex's
+ * review on this PR. A whole contiguous run collapses to a single replacement space.
  */
-const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]/gu;
+const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]+/gu;
 
 export function stripUnsafeCharacters(text: string): string {
   return text

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -46,7 +46,7 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  *
  * Matched and collapsed as a whole run, not one character at a time, and the run itself spans any
  * ordinary space characters immediately touching a control, not only the controls themselves --
- * three gaps in an earlier version, all confirmed directly by Codex's review on this PR:
+ * four gaps in an earlier version, all confirmed directly by Codex's review on this PR:
  *
  * - A conventional multi-character line break like `\r\n` is two of these controls back to
  *   back; replacing each independently produced `sign  in` (two spaces) for `sign\r\nin`
@@ -58,6 +58,17 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  *   rather than dropped, even though there is no word on that side to separate from:
  *   `stripUnsafeCharacters('\nfoo')` produced `' foo'`, a stray leading space that becomes a
  *   double space once substituted next to the document's own existing separator.
+ * - The boundary check above ran against the *original* string, before the other two
+ *   `.replace()` steps below had removed anything else that was going to disappear entirely --
+ *   `stripUnsafeCharacters('\b\nfoo')` (backspace, then newline) saw the newline run at
+ *   offset 1, not touching either end of the *original* string, so it collapsed to a space
+ *   rather than nothing; only afterwards did the next step delete the backspace, leaving that
+ *   space stranded at the true start of the final string, the identical bug in a different
+ *   guise. This is why the two entirely-deleting steps now run *before* the whitespace-run
+ *   step below, and why that step's boundary check reads the *live* string each `.replace()`
+ *   callback receives as its third argument, not this function's original `text` parameter:
+ *   by the time it runs, every character that is going to vanish already has, so "touches the
+ *   boundary" means the same thing here as it will in the final result.
  *
  * {@link WHITESPACE_RUN_TOUCHING_CONTROL} matches the broader run (controls and ordinary
  * spaces both); the replacer only touches a matched run that actually contains a control
@@ -69,15 +80,24 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
 const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u0085\u2028\u2029]/u;
 const WHITESPACE_RUN_TOUCHING_CONTROL = /[ \t\n\v\f\r\u0085\u2028\u2029]+/gu;
 
+/**
+ * `\p{Cc}` characters that are not {@link WHITESPACE_SHAPED_CONTROLS} -- the ones with no
+ * word-internal role at all, stripped outright rather than normalised to a space. Excluded via
+ * a negative lookahead rather than a character-class subtraction, which JS regex does not
+ * support directly.
+ */
+const NON_WHITESPACE_CC = /(?![\t\n\v\f\r\u0085])[\p{Cc}]/gu;
+
 export function stripUnsafeCharacters(text: string): string {
   return text
-    .replace(WHITESPACE_RUN_TOUCHING_CONTROL, (run, offset) => {
+    .replace(BIDI_CONTROL_CHARS, '')
+    .replace(NON_WHITESPACE_CC, '')
+    .replace(WHITESPACE_RUN_TOUCHING_CONTROL, (run, offset, liveText) => {
       if (!WHITESPACE_SHAPED_CONTROLS.test(run)) return run;
-      const atBoundary = offset === 0 || offset + run.length === text.length;
+      const atBoundary = offset === 0 || offset + run.length === liveText.length;
       return atBoundary ? '' : ' ';
     })
-    .replace(/[\p{Cc}\p{Zl}\p{Zp}]/gu, '')
-    .replace(BIDI_CONTROL_CHARS, '');
+    .replace(/[\p{Zl}\p{Zp}]/gu, '');
 }
 
 /**

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -117,16 +117,36 @@ const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
  * fail-closed behaviour as one bucket over the per-length limit, just budgeted globally instead of
  * per length. The chosen value leaves room for several buckets at the per-length cap, or many more
  * smaller ones, before the budget is spent.
+ *
+ * This counts comparisons, not the work each one costs — see {@link MAX_TOTAL_COMPARISON_WORK} for
+ * the budget that closes that gap.
  */
 const MAX_TOTAL_COMPARISONS = 500_000;
+
+/**
+ * Total `pairs × key-length` work {@link findCaseConflicts} will attempt across every length
+ * bucket combined, alongside (not instead of) {@link MAX_TOTAL_COMPARISONS}.
+ *
+ * {@link MAX_TOTAL_COMPARISONS} treats every `sameTermSpan` comparison as equal-cost, but a regex
+ * match's cost scales with the length of the strings it matches — Codex's review on this PR found
+ * that a bucket comfortably within the pair-count budget can still be expensive if its keys are
+ * individually very long: every key sharing one length bucket, so the whole bucket's cost scales
+ * with `pairs × length`, not `pairs` alone. `test/unit/rules.test.ts`'s "bounds total cost by key
+ * length" test reproduces the shape (few hundred same-bucket keys, each long) directly, rather
+ * than this comment committing a one-off measurement. Once a bucket's own or the running weighted
+ * total would exceed this budget, it is reported as {@link CaseConflictScan.unchecked} the same
+ * way as the other two limits.
+ */
+const MAX_TOTAL_COMPARISON_WORK = 25_000_000;
 
 /**
  * One {@link CaseConflictScan.unchecked} group, naming both its keys and *why* they went
  * unconfirmed — a bucket that individually exceeds {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH}
  * is a different situation for a caller (and a reader of the resulting notice) than a
- * comfortably-sized bucket that only lost out to {@link MAX_TOTAL_COMPARISONS} because earlier
- * buckets already spent most of it — collapsing both into one shape would report the wrong
- * constraint as the reason a rule got skipped.
+ * comfortably-sized bucket that only lost out to the total {@link MAX_TOTAL_COMPARISONS} or
+ * {@link MAX_TOTAL_COMPARISON_WORK} budget because earlier buckets already spent most of it —
+ * collapsing both into one shape would report the wrong constraint as the reason a rule got
+ * skipped.
  */
 export interface UncheckedGroup {
   /** The keys in this bucket, unconfirmed either way. */
@@ -176,17 +196,23 @@ export function findCaseConflicts<T>(
   const groups: [key: string, value: T][][] = [];
   const unchecked: UncheckedGroup[] = [];
   let comparisonsSpent = 0;
-  for (const bucket of byLength.values()) {
+  let workSpent = 0;
+  for (const [length, bucket] of byLength.entries()) {
     if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) {
       unchecked.push({ keys: bucket.map(([key]) => key), reason: 'bucket-too-large' });
       continue;
     }
     const bucketCost = (bucket.length * (bucket.length - 1)) / 2;
-    if (comparisonsSpent + bucketCost > MAX_TOTAL_COMPARISONS) {
+    const bucketWork = bucketCost * length;
+    if (
+      comparisonsSpent + bucketCost > MAX_TOTAL_COMPARISONS ||
+      workSpent + bucketWork > MAX_TOTAL_COMPARISON_WORK
+    ) {
       unchecked.push({ keys: bucket.map(([key]) => key), reason: 'total-budget-exceeded' });
       continue;
     }
     comparisonsSpent += bucketCost;
+    workSpent += bucketWork;
     const consumed = new Set<number>();
     for (let i = 0; i < bucket.length; i++) {
       if (consumed.has(i)) continue;
@@ -261,9 +287,9 @@ export function reportCaseConflict(
  * The message names which limit stopped the check ({@link UncheckedGroup.reason}) rather than
  * always blaming this group's own length: a bucket well under
  * {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH} can still end up unchecked if earlier buckets
- * already spent most of {@link MAX_TOTAL_COMPARISONS}, and telling that caller "too many keys
- * share this length" would misidentify the actual constraint and the actual fix (reduce keys
- * overall, not just within this length).
+ * already spent most of {@link MAX_TOTAL_COMPARISONS} or {@link MAX_TOTAL_COMPARISON_WORK}, and
+ * telling that caller "too many keys share this length" would misidentify the actual constraint
+ * and the actual fix (reduce keys overall, or their length, not just how many share this length).
  *
  * Names a sample rather than every key, both because the full list can be long and because each
  * key is display text (see {@link reportCaseConflict}'s doc comment on provenance) sanitized the
@@ -287,8 +313,8 @@ export function reportUncheckedGroup(
       : `${group.keys.length} keys (for example ${sample}) could not be checked for a ` +
         `case-insensitive collision over their ${noun}: checking them would exceed the total ` +
         `comparison budget shared across every key length in this "additional" map, even though ` +
-        'this group alone is well within the per-length limit. Reduce the total number of keys ' +
-        'across all lengths, or split them across more than one rule configuration.';
+        'this group alone is well within the per-length limit. Reduce the total number of keys, ' +
+        'their length, or split them across more than one rule configuration.';
   ctx.addIssue({ code: 'custom', path: ['additional'], message });
 }
 

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -85,15 +85,28 @@ function codePointLength(term: string): number {
 
 /**
  * Above this many entries sharing the same {@link codePointLength}, {@link findCaseConflicts}
- * skips the exhaustive pairwise check for that length and treats none of them as conflicting.
+ * reports that whole bucket as {@link CaseConflictScan.unchecked} instead of exhaustively
+ * confirming it.
  *
  * The check is quadratic per length bucket — measured directly at roughly 800ms for 2,000
- * pairwise-distinct same-length entries, the DoS-shaped cost Codex's review on this PR flagged.
- * `additional` maps are operator- or pack-authored vocabulary lists; a single length bucket this
- * large is already unusual, so skipping it (rather than guessing at a conflict with an
- * unconfirmed heuristic) is an acceptable trade against stalling a lint run.
+ * pairwise-distinct same-length entries, the DoS-shaped cost Codex's review on this PR flagged
+ * (`additional` is reachable from an untrusted pack's own `rules[].options`, per
+ * {@link reportCaseConflict}'s doc comment, so this is a real cost an untrusted pack can impose,
+ * not only an operator's own mistake). Silently treating an oversized bucket as conflict-free was
+ * tried first and rejected on review: a bucket this large could still contain a genuine conflict
+ * (`Foo`/`foo` among 500 unrelated same-length keys, say), and reporting "no conflict" without
+ * having checked is a false all-clear. Failing the rule instead, honestly naming the bucket as
+ * unverified, is the safer default — {@link reportUncheckedGroup} is the caller-side half of this.
  */
 const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
+
+/** {@link findCaseConflicts}'s result: confirmed conflicts, and buckets too large to confirm. */
+export interface CaseConflictScan {
+  /** Groups confirmed, via the real matcher, to map to different values. */
+  readonly conflicts: string[][];
+  /** Groups too large to check exhaustively (see {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH}); their case-conflict status was never determined. */
+  readonly unchecked: string[][];
+}
 
 /**
  * Group the keys of a term map by case-fold equivalence and report every group whose members do
@@ -104,8 +117,8 @@ const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
  * a real conflict when the two keys disagree about the replacement — `{ Use: ['employ'], use:
  * ['employ'] }` is redundant but not contradictory.
  *
- * Every reported group is confirmed with {@link sameTermSpan} — the actual matcher — rather than
- * a cheaper canonicalisation, because a canonicalisation broad enough to catch every case
+ * Every reported conflict is confirmed with {@link sameTermSpan} — the actual matcher — rather
+ * than a cheaper canonicalisation, because a canonicalisation broad enough to catch every case
  * `sameTermSpan` recognises (Greek final sigma, the Latin long s) is also broad enough to falsely
  * merge keys the matcher treats as distinct (ASCII/fullwidth Latin letters); see
  * {@link codePointLength}'s doc comment for both confirmed examples. {@link codePointLength}
@@ -114,7 +127,7 @@ const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
 export function findCaseConflicts<T>(
   entries: Readonly<Record<string, T>>,
   valuesEqual: (a: T, b: T) => boolean,
-): string[][] {
+): CaseConflictScan {
   const items = Object.entries(entries);
 
   const byLength = new Map<number, [key: string, value: T][]>();
@@ -126,8 +139,12 @@ export function findCaseConflicts<T>(
   }
 
   const groups: [key: string, value: T][][] = [];
+  const unchecked: string[][] = [];
   for (const bucket of byLength.values()) {
-    if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) continue;
+    if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) {
+      unchecked.push(bucket.map(([key]) => key));
+      continue;
+    }
     const consumed = new Set<number>();
     for (let i = 0; i < bucket.length; i++) {
       if (consumed.has(i)) continue;
@@ -158,7 +175,7 @@ export function findCaseConflicts<T>(
       conflicts.push(group.map(([key]) => key));
     }
   }
-  return conflicts;
+  return { conflicts, unchecked };
 }
 
 /**
@@ -192,6 +209,34 @@ export function reportCaseConflict(
     message:
       `${group.map((key) => `"${sanitizeQuotedValue(key)}"`).join(' and ')} are case-equivalent ` +
       `keys that resolve to the same source span but map to different ${noun}.`,
+  });
+}
+
+/**
+ * Report one `findCaseConflicts` {@link CaseConflictScan.unchecked} group: too many keys of the
+ * same length to confirm, one way or the other, whether any of them collide.
+ *
+ * Names a sample rather than every key, both because the full list can be long and because each
+ * key is display text (see {@link reportCaseConflict}'s doc comment on provenance) sanitized the
+ * same way.
+ */
+export function reportUncheckedGroup(
+  ctx: IssueReporter,
+  group: readonly string[],
+  noun: 'alternatives' | 'replacements',
+): void {
+  const sample = group
+    .slice(0, 3)
+    .map((key) => `"${sanitizeQuotedValue(key)}"`)
+    .join(', ');
+  ctx.addIssue({
+    code: 'custom',
+    path: ['additional'],
+    message:
+      `${group.length} keys (for example ${sample}) are the same length once whitespace runs ` +
+      `are normalised — too many to exhaustively check for a case-insensitive collision over ` +
+      `their ${noun}. Reduce how many keys share this length, or split them across more than ` +
+      'one rule configuration.',
   });
 }
 

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -1,6 +1,72 @@
 import { proseWords } from '../core/document.js';
 import type { Sentence, SourceRange, TextBlock, Word } from '../core/types.js';
 
+/**
+ * Remove characters that make a supplier-controlled string actively dangerous once it is
+ * interpolated into rendered output (a diagnostic `message`, a fix `rationale`) — not merely
+ * unusual-looking ones.
+ *
+ * Rule-pack text fields such as `preferred.to`, `unapproved.alternatives` and `note` carry no
+ * format constraint in `src/rule-pack/schema.ts`. Unlike `metadata.id` (`src/core/rule-pack-id.ts`),
+ * free display text cannot be reduced to an allowed character set without breaking legitimate
+ * non-English terms, so this strips categories of character rather than a fixed list — closing the
+ * class the way the id allowlist does, instead of chasing individual characters. Removed:
+ * `\p{Cc}`/`\p{Cf}` (C0/C1 controls, zero-width and bidirectional-override characters) and
+ * `\p{Zl}`/`\p{Zp}` (line/paragraph separators), any of which can rewrite how surrounding terminal
+ * or log output reads.
+ */
+export function stripUnsafeCharacters(text: string): string {
+  return text.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu, '');
+}
+
+/**
+ * As {@link stripUnsafeCharacters}, and also replaces a literal `"` with `'`.
+ *
+ * Use this only where the caller interpolates the result directly inside a double-quoted phrase in
+ * the message template itself (`` `Use "${...}" instead of…` ``) — an embedded `"` would otherwise
+ * let fabricated pack text visually escape that quoting. Free-standing text that the template does
+ * not wrap in its own quotes (a `note` appended after the quoted phrase) should use
+ * {@link stripUnsafeCharacters} instead: that text's own internal quoting (`Ambiguous: "it is" or
+ * "it has".`) is legitimate authored prose, not an escape attempt, and rewriting it changes
+ * correct, trusted message text for no safety benefit.
+ */
+export function sanitizeQuotedValue(text: string): string {
+  return stripUnsafeCharacters(text).replace(/"/g, "'");
+}
+
+/**
+ * Group the keys of a term map by case-insensitive equality and report every group whose members
+ * do not all resolve to the same value.
+ *
+ * `termPattern()` matches case-insensitively, so `Use` and `use` claim the same source span; the
+ * first one in object key order silently wins and the other's mapping never applies. That is only
+ * a real conflict when the two keys disagree about the replacement — `{ Use: ['employ'], use:
+ * ['employ'] }` is redundant but not contradictory.
+ */
+export function findCaseConflicts<T>(
+  entries: Readonly<Record<string, T>>,
+  valuesEqual: (a: T, b: T) => boolean,
+): string[][] {
+  const groups = new Map<string, [key: string, value: T][]>();
+  for (const [key, value] of Object.entries(entries)) {
+    const lower = key.toLowerCase();
+    const group = groups.get(lower);
+    if (group === undefined) groups.set(lower, [[key, value]]);
+    else group.push([key, value]);
+  }
+  const conflicts: string[][] = [];
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const first = group[0];
+    if (first === undefined) continue;
+    const [, firstValue] = first;
+    if (group.some(([, value]) => !valuesEqual(value, firstValue))) {
+      conflicts.push(group.map(([key]) => key));
+    }
+  }
+  return conflicts;
+}
+
 /** Build a whole-word, case-insensitive matcher for a term or multi-word phrase. */
 export function termPattern(term: string): RegExp {
   const escaped = term

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -33,9 +33,24 @@ const BIDI_CONTROL_CHARS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/gu;
  * surrounding terminal or log output reads, or reorder text around it. General Unicode format
  * characters (`\p{Cf}`) outside that explicit list are left alone: a real word or replacement can
  * legitimately need one.
+ *
+ * The whitespace-shaped members of those categories — tab, newline, CR, vertical tab, form feed,
+ * and the two Unicode line/paragraph separators — are normalised to an ordinary space rather than
+ * deleted outright, and normalised *before* the rest of the category is stripped. This sanitizer
+ * runs on the actual replacement text a fix writes into a document, not just display strings
+ * (`sanitizeQuotedValue`'s doc comment on `note` is the display-only exception, not the rule) — so
+ * a legitimately schema-permitted pack value like `sign\tin` or `do\nnot` deleting straight to
+ * `signin`/`donot` would silently glue two words together, corrupting the actual suggestion and
+ * fix. Every other control character in these categories has no legitimate word-internal role, so
+ * it is still deleted rather than replaced.
  */
+const WHITESPACE_SHAPED_CONTROLS = /[\t\n\v\f\r\u2028\u2029]/gu;
+
 export function stripUnsafeCharacters(text: string): string {
-  return text.replace(/[\p{Cc}\p{Zl}\p{Zp}]/gu, '').replace(BIDI_CONTROL_CHARS, '');
+  return text
+    .replace(WHITESPACE_SHAPED_CONTROLS, ' ')
+    .replace(/[\p{Cc}\p{Zl}\p{Zp}]/gu, '')
+    .replace(BIDI_CONTROL_CHARS, '');
 }
 
 /**

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -168,6 +168,12 @@ const MAX_TOTAL_COMPARISONS = 500_000;
  * committing a one-off measurement. Once a bucket's own or the running weighted total would exceed
  * this budget, it is reported as {@link CaseConflictScan.unchecked} the same way as the other two
  * limits.
+ *
+ * A later round of the same review found this budget itself had a gap: it only weighed the
+ * pairwise scan's cost, not the fixed per-key self-test cost `findCaseConflicts` runs before that
+ * scan (see its own comment on `selfTestWork`) — a bucket too small to cost anything pairwise
+ * (a singleton, say) still paid that self-test cost with nothing here to bound it across many such
+ * buckets. `selfTestWork` is now included in what this budget tracks.
  */
 const MAX_TOTAL_COMPARISON_WORK = 25_000_000;
 
@@ -240,7 +246,16 @@ export function findCaseConflicts<T>(
       continue;
     }
     const bucketCost = (bucket.length * (bucket.length - 1)) / 2;
-    const bucketWork = bucketCost * maxRawLength;
+    // Two self-tests per key (`sameTermSpan` and `termPattern`, below), each proportional to the
+    // bucket's raw length — this is the per-key work the pairwise `bucketWork` term does not
+    // cover. Without it, a bucket costs nothing by this budget's own accounting whenever
+    // `bucket.length` is small (a singleton bucket has `bucketCost === 0` regardless of its key's
+    // length), so a pack supplying many singleton buckets of long keys — never colliding, so
+    // never bucketed together, so never contributing pairwise cost — would still impose unbounded
+    // self-test work with nothing here to stop it. Confirmed as a real gap by Codex's review on
+    // this PR.
+    const selfTestWork = 2 * bucket.length * maxRawLength;
+    const bucketWork = bucketCost * maxRawLength + selfTestWork;
     if (
       comparisonsSpent + bucketCost > MAX_TOTAL_COMPARISONS ||
       workSpent + bucketWork > MAX_TOTAL_COMPARISON_WORK
@@ -448,12 +463,28 @@ export interface TermMatch {
  *
  * Matching runs against `sentence.masked`, so a term can never match inside protected content.
  * Returned ranges are absolute offsets into the source document.
+ *
+ * `termPattern(term)`'s compiled `RegExp` only fully compiles on first execution (confirmed
+ * directly: construction alone never throws, no matter how long or pathologically-shaped `term`
+ * is — the failure surfaces lazily, inside `matchAll` here), and the size at which that lazy
+ * compile fails is sensitive to how much call stack is already in use at the point of execution —
+ * confirmed directly, the same term and the same pattern shape can succeed at a shallow stack
+ * depth and fail deeper in a real call chain. `findCaseConflicts`'s own self-test of this same
+ * shape, at schema-validation time, cannot rule this out for every later call from a different
+ * point in the call stack at document-analysis time — this is `findTerm`'s own, independent
+ * guard, not a duplicate of that one. A term this pathological is never going to usefully match
+ * real prose anyway, so treating the failure as "no match in this sentence" costs nothing a
+ * legitimate rule pack or config would ever need.
  */
 export function findTerm(sentence: Sentence, term: string): TermMatch[] {
   const out: TermMatch[] = [];
-  for (const m of sentence.masked.matchAll(termPattern(term))) {
-    const start = sentence.range.start + m.index;
-    out.push({ range: { start, end: start + m[0].length }, text: m[0] });
+  try {
+    for (const m of sentence.masked.matchAll(termPattern(term))) {
+      const start = sentence.range.start + m.index;
+      out.push({ range: { start, end: start + m[0].length }, text: m[0] });
+    }
+  } catch {
+    return [];
   }
   return out;
 }

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -54,31 +54,40 @@ export function sanitizeQuotedValue(text: string): string {
 }
 
 /**
- * Fast-path canonical form for {@link findCaseConflicts}'s grouping: NFKC folds some
- * compatibility variants `toLowerCase()` alone does not (confirmed directly: `'ſ'.normalize
- * ('NFKC').toLowerCase() === 's'`, unifying the Latin long s with plain `s`), which is exactly
- * the pair Codex's review on this PR flagged `toLowerCase()`-only grouping for missing.
+ * Code-point count of a term, after the same `trim()` {@link sameTermSpan} applies before
+ * comparing.
+ *
+ * Used only as a *necessary* pre-filter for {@link findCaseConflicts}, never as a verdict on its
+ * own: JS's `/iu` regex canonicalisation is confirmed directly to be one-code-point-to-one
+ * (`new RegExp('^ß$', 'iu').test('ss')` is `false` — unlike full Unicode case folding, which
+ * would expand `ß` to `ss`), so two strings `termPattern` actually treats as the same span always
+ * have equal code-point length. The converse does not hold — equal length never implies
+ * equivalence (ASCII `A` and fullwidth `Ａ` are both length 1, and are visually/case-fold-similar
+ * enough that an NFKC-based canonicalisation this function used to rely on falsely merged them,
+ * confirmed directly: `'Ａ'.normalize('NFKC').toLowerCase() === 'a'` while
+ * `/^A$/iu.test('Ａ')` is `false`) — so a length match is only ever a candidate to confirm with
+ * {@link sameTermSpan}, never a substitute for it.
+ *
+ * `Array.from` over a string iterates *code points*, not user-perceived grapheme clusters (an
+ * `Intl.Segmenter` count), which is exactly what this needs: the invariant above is that simple
+ * case folding preserves code-point count, not grapheme count, so grapheme-based counting would
+ * not be the same invariant.
  */
-function canonicalKey(term: string): string {
-  return term.trim().normalize('NFKC').toLowerCase();
+function codePointLength(term: string): number {
+  return Array.from(term.trim()).length;
 }
 
 /**
- * Above this many `additional` entries, {@link findCaseConflicts} skips the exhaustive pairwise
- * merge below and returns {@link canonicalKey}'s grouping alone.
+ * Above this many entries sharing the same {@link codePointLength}, {@link findCaseConflicts}
+ * skips the exhaustive pairwise check for that length and treats none of them as conflicting.
  *
- * That merge step exists only for a case-fold pair `canonicalKey` itself does not unify — Greek
- * final sigma `ς`/`σ` is the standing example (confirmed directly: `'ς'.normalize('NFKC')
- * .toLowerCase() !== 'σ'.toLowerCase()`, but `termPattern`'s `/iu` regex does treat them as the
- * same letter). Finding every such pair exhaustively means testing every remaining group against
- * every other, which is quadratic in the number of *distinct spellings* after canonicalisation —
- * measured directly at roughly 800ms for 2,000 pairwise-distinct entries, the DoS-shaped cost
- * Codex's review on this PR flagged in the pairwise-only version of this function. `additional`
- * maps are operator- or pack-authored vocabulary lists; one this large is already unusual, so
- * degrading to canonical-only grouping (which still catches every conflict this function shipped
- * with before this pairwise refinement existed) is an acceptable trade against stalling a lint run.
+ * The check is quadratic per length bucket — measured directly at roughly 800ms for 2,000
+ * pairwise-distinct same-length entries, the DoS-shaped cost Codex's review on this PR flagged.
+ * `additional` maps are operator- or pack-authored vocabulary lists; a single length bucket this
+ * large is already unusual, so skipping it (rather than guessing at a conflict with an
+ * unconfirmed heuristic) is an acceptable trade against stalling a lint run.
  */
-const EXHAUSTIVE_FOLD_MERGE_LIMIT = 500;
+const EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH = 500;
 
 /**
  * Group the keys of a term map by case-fold equivalence and report every group whose members do
@@ -88,6 +97,13 @@ const EXHAUSTIVE_FOLD_MERGE_LIMIT = 500;
  * first one in object key order silently wins and the other's mapping never applies. That is only
  * a real conflict when the two keys disagree about the replacement — `{ Use: ['employ'], use:
  * ['employ'] }` is redundant but not contradictory.
+ *
+ * Every reported group is confirmed with {@link sameTermSpan} — the actual matcher — rather than
+ * a cheaper canonicalisation, because a canonicalisation broad enough to catch every case
+ * `sameTermSpan` recognises (Greek final sigma, the Latin long s) is also broad enough to falsely
+ * merge keys the matcher treats as distinct (ASCII/fullwidth Latin letters); see
+ * {@link codePointLength}'s doc comment for both confirmed examples. {@link codePointLength}
+ * narrows the candidates checked, as a size (not a correctness) optimisation.
  */
 export function findCaseConflicts<T>(
   entries: Readonly<Record<string, T>>,
@@ -95,42 +111,35 @@ export function findCaseConflicts<T>(
 ): string[][] {
   const items = Object.entries(entries);
 
-  // Fast path: O(n) grouping by canonical form, catching every plain-case and NFKC-decomposable
-  // pair (which covers everything `String.prototype.toLowerCase()` alone caught, plus more).
-  const byCanonical = new Map<string, [key: string, value: T][]>();
+  const byLength = new Map<number, [key: string, value: T][]>();
   for (const item of items) {
-    const canonical = canonicalKey(item[0]);
-    const group = byCanonical.get(canonical);
-    if (group === undefined) byCanonical.set(canonical, [item]);
-    else group.push(item);
+    const length = codePointLength(item[0]);
+    const bucket = byLength.get(length);
+    if (bucket === undefined) byLength.set(length, [item]);
+    else bucket.push(item);
   }
-  let groups = [...byCanonical.values()];
 
-  // Precise path: merge any remaining groups `sameTermSpan` still considers equivalent, bounded
-  // so an unusually large map degrades to the fast path alone instead of stalling.
-  if (items.length <= EXHAUSTIVE_FOLD_MERGE_LIMIT) {
-    const merged: typeof groups = [];
+  const groups: [key: string, value: T][][] = [];
+  for (const bucket of byLength.values()) {
+    if (bucket.length > EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH) continue;
     const consumed = new Set<number>();
-    for (let i = 0; i < groups.length; i++) {
+    for (let i = 0; i < bucket.length; i++) {
       if (consumed.has(i)) continue;
-      let combined = groups[i];
-      if (combined === undefined) continue;
+      const current = bucket[i];
+      if (current === undefined) continue;
+      const group: [string, T][] = [current];
       consumed.add(i);
-      for (let j = i + 1; j < groups.length; j++) {
+      for (let j = i + 1; j < bucket.length; j++) {
         if (consumed.has(j)) continue;
-        const candidate = groups[j];
-        const combinedFirst = combined[0];
-        if (candidate === undefined || combinedFirst === undefined) continue;
-        const candidateFirst = candidate[0];
-        if (candidateFirst === undefined) continue;
-        if (sameTermSpan(combinedFirst[0], candidateFirst[0])) {
-          combined = [...combined, ...candidate];
+        const candidate = bucket[j];
+        if (candidate === undefined) continue;
+        if (sameTermSpan(current[0], candidate[0])) {
+          group.push(candidate);
           consumed.add(j);
         }
       }
-      merged.push(combined);
+      groups.push(group);
     }
-    groups = merged;
   }
 
   const conflicts: string[][] = [];

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -59,21 +59,24 @@ export function stripUnsafeCharacters(text: string): string {
 }
 
 /**
- * Whether `text` has at least one visible character, rather than only whitespace and/or Unicode
- * format characters (`\p{Cf}`: ZWJ, ZWNJ, soft hyphen, ...).
+ * Whether `text` has at least one visible character, rather than only whitespace and/or code
+ * points Unicode itself designates as invisible by default.
  *
- * `stripUnsafeCharacters` intentionally leaves `\p{Cf}` alone — it can have a real, local effect
- * on the word it sits inside (its own doc comment covers ZWJ joining an emoji sequence into one
- * glyph, ZWNJ controlling Persian/Arabic letter-joining) — but a replacement made of *nothing but*
- * such characters, with no visible base character for any of them to modify, renders as nothing.
- * Confirmed as a real gap by Codex's review on this PR: a lone ZWJ survives both
- * `stripUnsafeCharacters` and `.trim()` (neither strips nor counts as whitespace), so checking a
- * sanitized replacement is merely non-blank after those two steps was not enough — a
- * `safeSubstitution` fix built from it would still replace a visible word with something
- * invisible.
+ * `stripUnsafeCharacters` intentionally leaves `\p{Cf}` (ZWJ, ZWNJ, soft hyphen, ...) alone — it
+ * can have a real, local effect on the word it sits inside (its own doc comment covers ZWJ joining
+ * an emoji sequence into one glyph, ZWNJ controlling Persian/Arabic letter-joining) — but a
+ * replacement made of *nothing but* such characters, with no visible base character for any of
+ * them to modify, renders as nothing. This first shipped checking only `\p{Cf}`, and a follow-up
+ * round of the same review found that an equally invisible-on-its-own character can sit outside
+ * that category — confirmed directly, a variation selector (U+FE0F) is general category `Mn`, not
+ * `Cf`, and a combining grapheme joiner (U+034F) likewise, so a `\p{Cf}` exclusion alone let either
+ * slip through as "visible." Rather than continue enumerating categories one finding at a time,
+ * this uses Unicode's own `Default_Ignorable_Code_Point` property, defined for exactly this
+ * purpose (a code point with no visible glyph by default) and confirmed directly to already cover
+ * every case above, ZWJ and the emoji-sequence exception included.
  */
 export function hasVisibleContent(text: string): boolean {
-  return /[^\p{Cf}\s]/u.test(text);
+  return /[^\p{Default_Ignorable_Code_Point}\s]/u.test(text);
 }
 
 /**

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -54,27 +54,33 @@ export function sanitizeQuotedValue(text: string): string {
 }
 
 /**
- * Code-point count of a term, after the same `trim()` {@link sameTermSpan} applies before
- * comparing.
+ * Code-point count of a term, treating each internal whitespace run as a single unit, matching
+ * how {@link escapeForMatching}/{@link sameTermSpan} actually treat whitespace.
  *
  * Used only as a *necessary* pre-filter for {@link findCaseConflicts}, never as a verdict on its
  * own: JS's `/iu` regex canonicalisation is confirmed directly to be one-code-point-to-one
  * (`new RegExp('^ß$', 'iu').test('ss')` is `false` — unlike full Unicode case folding, which
  * would expand `ß` to `ss`), so two strings `termPattern` actually treats as the same span always
- * have equal code-point length. The converse does not hold — equal length never implies
- * equivalence (ASCII `A` and fullwidth `Ａ` are both length 1, and are visually/case-fold-similar
- * enough that an NFKC-based canonicalisation this function used to rely on falsely merged them,
- * confirmed directly: `'Ａ'.normalize('NFKC').toLowerCase() === 'a'` while
- * `/^A$/iu.test('Ａ')` is `false`) — so a length match is only ever a candidate to confirm with
- * {@link sameTermSpan}, never a substitute for it.
+ * have equal code-point length — *once whitespace is normalised the same way the matcher itself
+ * normalises it*. `escapeForMatching` turns every whitespace run into a flexible `\s+` (matching
+ * one or more characters, of any length, on either side), so `"foo bar"` and `"foo  bar"` are
+ * `sameTermSpan`-equivalent despite differing raw code-point counts — confirmed directly, and a
+ * real miss in an earlier version of this pre-filter, which bucketed by raw length and so never
+ * even tested that pair against each other. Collapsing every whitespace run to one code point
+ * before counting restores the invariant.
+ *
+ * A length match is still only ever a candidate to confirm with {@link sameTermSpan}, never a
+ * substitute for it — equal length does not imply equivalence (ASCII `A` and fullwidth `Ａ` are
+ * both length 1, and are visually/case-fold-similar enough that an NFKC-based canonicalisation
+ * this function used to rely on falsely merged them, confirmed directly: `'Ａ'.normalize('NFKC')
+ * .toLowerCase() === 'a'` while `/^A$/iu.test('Ａ')` is `false`).
  *
  * `Array.from` over a string iterates *code points*, not user-perceived grapheme clusters (an
- * `Intl.Segmenter` count), which is exactly what this needs: the invariant above is that simple
- * case folding preserves code-point count, not grapheme count, so grapheme-based counting would
- * not be the same invariant.
+ * `Intl.Segmenter` count), which is exactly what this needs: the invariant above is about
+ * code-point count, not grapheme count.
  */
 function codePointLength(term: string): number {
-  return Array.from(term.trim()).length;
+  return Array.from(term.trim().replace(/\s+/g, ' ')).length;
 }
 
 /**

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -272,7 +272,21 @@ export function findCaseConflicts<T>(
       // applies to any key a peer already claimed as its own `candidate` before its own turn as
       // `current` arrived. Self-testing every key up front, before any pairwise work, exercises
       // every key's own compile-safety exactly once regardless of the role it plays below.
-      for (const [key] of bucket) sameTermSpan(key, key);
+      //
+      // `sameTermSpan`'s anchored `^...$` pattern is not a reliable proxy for `termPattern`'s own
+      // lookaround-boundary shape (the one `findTerm` actually uses to match this key against real
+      // document text): confirmed directly, a `RegExp` object survives construction no matter how
+      // long the pattern is — the compile step that can throw `SyntaxError` for an oversized or
+      // pathologically-shaped pattern happens lazily, on first execution (`.test()`/`.exec()`/
+      // `.matchAll()`), not at `new RegExp(...)` time — and the two shapes hit that lazy-compile
+      // failure at different sizes for the same content. Self-testing `sameTermSpan` alone missed
+      // exactly this: a key that `sameTermSpan` accepted still failed once actually exercised
+      // through `termPattern`. Both shapes are self-tested here, each executed (not merely
+      // constructed) so the lazy compile step is actually forced.
+      for (const [key] of bucket) {
+        sameTermSpan(key, key);
+        termPattern(key).test(key);
+      }
 
       const bucketGroups: [key: string, value: T][][] = [];
       const consumed = new Set<number>();

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -176,15 +176,16 @@ const MAX_TOTAL_COMPARISON_WORK = 25_000_000;
  * unconfirmed — a bucket that individually exceeds {@link EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH}
  * is a different situation for a caller (and a reader of the resulting notice) than a
  * comfortably-sized bucket that only lost out to the total {@link MAX_TOTAL_COMPARISONS} or
- * {@link MAX_TOTAL_COMPARISON_WORK} budget because earlier buckets already spent most of it —
- * collapsing both into one shape would report the wrong constraint as the reason a rule got
- * skipped.
+ * {@link MAX_TOTAL_COMPARISON_WORK} budget because earlier buckets already spent most of it, or a
+ * bucket whose keys were too long for the underlying regex engine to compare at all (`'comparison-
+ * failed'`; see the `try`/`catch` in {@link findCaseConflicts}) — collapsing all three into one
+ * shape would report the wrong constraint as the reason a rule got skipped.
  */
 export interface UncheckedGroup {
   /** The keys in this bucket, unconfirmed either way. */
   readonly keys: string[];
   /** Which limit stopped this bucket from being checked. */
-  readonly reason: 'bucket-too-large' | 'total-budget-exceeded';
+  readonly reason: 'bucket-too-large' | 'total-budget-exceeded' | 'comparison-failed';
 }
 
 /** {@link findCaseConflicts}'s result: confirmed conflicts, and buckets too large to confirm. */
@@ -249,23 +250,41 @@ export function findCaseConflicts<T>(
     }
     comparisonsSpent += bucketCost;
     workSpent += bucketWork;
-    const consumed = new Set<number>();
-    for (let i = 0; i < bucket.length; i++) {
-      if (consumed.has(i)) continue;
-      const current = bucket[i];
-      if (current === undefined) continue;
-      const group: [string, T][] = [current];
-      consumed.add(i);
-      for (let j = i + 1; j < bucket.length; j++) {
-        if (consumed.has(j)) continue;
-        const candidate = bucket[j];
-        if (candidate === undefined) continue;
-        if (sameTermSpan(current[0], candidate[0])) {
-          group.push(candidate);
-          consumed.add(j);
+    // `sameTermSpan` compiles a `RegExp` from each key, and the underlying engine refuses to
+    // compile one past its own internal size limit — a version-specific threshold this comment
+    // does not pin a number to; `test/unit/rules.test.ts`'s "degrades to unchecked instead of
+    // crashing" test reproduces the failure directly on whatever engine runs it. Neither
+    // `MAX_TOTAL_COMPARISONS` nor `MAX_TOTAL_COMPARISON_WORK` catches this: a bucket of just two
+    // such keys costs one comparison, comfortably under both budgets. Uncaught, that exception
+    // would escape this whole function, then the `superRefine` callback calling it, then
+    // `safeParse` itself, crashing the run instead of the schema-validation failure this rule is
+    // supposed to degrade to. Buffer this bucket's groups locally and only merge them in on
+    // success, so a bucket that fails partway through reports honestly as
+    // {@link CaseConflictScan.unchecked} rather than contributing a
+    // partial, silently-incomplete scan.
+    try {
+      const bucketGroups: [key: string, value: T][][] = [];
+      const consumed = new Set<number>();
+      for (let i = 0; i < bucket.length; i++) {
+        if (consumed.has(i)) continue;
+        const current = bucket[i];
+        if (current === undefined) continue;
+        const group: [string, T][] = [current];
+        consumed.add(i);
+        for (let j = i + 1; j < bucket.length; j++) {
+          if (consumed.has(j)) continue;
+          const candidate = bucket[j];
+          if (candidate === undefined) continue;
+          if (sameTermSpan(current[0], candidate[0])) {
+            group.push(candidate);
+            consumed.add(j);
+          }
         }
+        bucketGroups.push(group);
       }
-      groups.push(group);
+      groups.push(...bucketGroups);
+    } catch {
+      unchecked.push({ keys: bucket.map(([key]) => key), reason: 'comparison-failed' });
     }
   }
 
@@ -340,17 +359,27 @@ export function reportUncheckedGroup(
     .slice(0, 3)
     .map((key) => `"${sanitizeQuotedValue(key)}"`)
     .join(', ');
-  const message =
-    group.reason === 'bucket-too-large'
-      ? `${group.keys.length} keys (for example ${sample}) are the same length once whitespace ` +
-        `runs are normalised — too many to exhaustively check for a case-insensitive collision ` +
-        `over their ${noun}. Reduce how many keys share this length, or split them across more ` +
-        'than one rule configuration.'
-      : `${group.keys.length} keys (for example ${sample}) could not be checked for a ` +
-        `case-insensitive collision over their ${noun}: checking them would exceed the total ` +
-        `comparison budget shared across every key length in this "additional" map, even though ` +
-        'this group alone is well within the per-length limit. Reduce the total number of keys, ' +
-        'their length, or split them across more than one rule configuration.';
+  let message: string;
+  if (group.reason === 'bucket-too-large') {
+    message =
+      `${group.keys.length} keys (for example ${sample}) are the same length once whitespace ` +
+      `runs are normalised — too many to exhaustively check for a case-insensitive collision ` +
+      `over their ${noun}. Reduce how many keys share this length, or split them across more ` +
+      'than one rule configuration.';
+  } else if (group.reason === 'total-budget-exceeded') {
+    message =
+      `${group.keys.length} keys (for example ${sample}) could not be checked for a ` +
+      `case-insensitive collision over their ${noun}: checking them would exceed the total ` +
+      `comparison budget shared across every key length in this "additional" map, even though ` +
+      'this group alone is well within the per-length limit. Reduce the total number of keys, ' +
+      'their length, or split them across more than one rule configuration.';
+  } else {
+    message =
+      `${group.keys.length} keys (for example ${sample}) could not be checked for a ` +
+      `case-insensitive collision over their ${noun}: at least one of them is too long for the ` +
+      'underlying matcher to compare. Shorten these keys, or split them across more than one ' +
+      'rule configuration.';
+  }
   ctx.addIssue({ code: 'custom', path: ['additional'], message });
 }
 

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -11,6 +11,7 @@ import {
   excerpt,
   findCaseConflicts,
   findTerm,
+  hasVisibleContent,
   matchCapitalisation,
   reportCaseConflict,
   reportUncheckedGroup,
@@ -118,16 +119,18 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
             // sent to the model. Stripping the source once, rather than at each render site, means
             // none of those sinks can be missed by a future addition to this list.
             // Filtered, not just mapped: a pack-supplied alternative made entirely of characters
-            // `stripUnsafeCharacters` strips (control characters, bidi overrides) sanitizes to an
-            // empty string. Keeping it here would offer an empty-string suggestion and, worse,
-            // build a fix that deletes the matched term outright -- `checkFixSafety`'s numeric/
-            // negation/modal/ordering checks do not catch a blank replacement for an ordinary word,
-            // so it would reach `--fix` unchallenged. Treating a blank result the same as "no
+            // `stripUnsafeCharacters` strips (control characters, bidi overrides), or entirely of
+            // characters it intentionally leaves alone but which are invisible on their own (ZWJ,
+            // ZWNJ, soft hyphen -- see `hasVisibleContent`'s doc comment), sanitizes to something
+            // with no visible content. Keeping it here would offer that as a suggestion and, worse,
+            // build a fix that replaces the matched term with nothing a reader can see --
+            // `checkFixSafety`'s numeric/negation/modal/ordering checks do not catch this for an
+            // ordinary word, so it would reach `--fix` unchallenged. Treating this the same as "no
             // alternative supplied" is the same fallback already below for an empty `alternatives`
             // array.
             const alternatives = entry.alternatives
               .map(stripUnsafeCharacters)
-              .filter((alternative) => alternative.trim() !== '');
+              .filter((alternative) => hasVisibleContent(alternative));
             const safeTerm = stripUnsafeCharacters(entry.term);
             const suggestion = alternatives[0];
             let fix: TextFix | undefined;
@@ -261,11 +264,12 @@ export const preferredTerminologyRule: DeterministicRule<z.output<typeof preferr
             // rationale below.
             const safeFrom = stripUnsafeCharacters(entry.from);
             const safeTo = stripUnsafeCharacters(entry.to);
-            // A pack-supplied `to` made entirely of characters `stripUnsafeCharacters` strips
-            // sanitizes to an empty string; `checkFixSafety` does not catch a blank replacement for
-            // an ordinary word, so an unguarded fix would delete the matched term outright and
-            // `--fix` would apply it unchallenged.
-            const hasReplacement = safeTo.trim() !== '';
+            // A pack-supplied `to` with no visible content once sanitized -- whether every
+            // character was stripped outright, or what remains is only invisible format characters
+            // like a lone ZWJ (see `hasVisibleContent`'s doc comment) -- would build a fix that
+            // replaces the matched term with nothing a reader can see; `checkFixSafety` does not
+            // catch this for an ordinary word, so an unguarded fix would reach `--fix` unchallenged.
+            const hasReplacement = hasVisibleContent(safeTo);
             const replacement = hasReplacement
               ? matchCapitalisation(match.text, safeTo)
               : undefined;
@@ -350,10 +354,13 @@ export const noContractionsRule: DeterministicRule<z.output<typeof contractionOp
             // than what the pack actually declared.
             const safeFrom = stripUnsafeCharacters(entry.from);
             const safeTo = stripUnsafeCharacters(entry.to);
-            // A pack-supplied expansion made entirely of characters `stripUnsafeCharacters` strips
-            // sanitizes to an empty string; `checkFixSafety` does not catch a blank replacement for
-            // an ordinary word, so an unguarded fix would delete the matched contraction outright.
-            const hasReplacement = safeTo.trim() !== '';
+            // A pack-supplied expansion with no visible content once sanitized -- whether every
+            // character was stripped outright, or what remains is only invisible format characters
+            // like a lone ZWJ (see `hasVisibleContent`'s doc comment) -- would build a fix that
+            // replaces the matched contraction with nothing a reader can see; `checkFixSafety` does
+            // not catch this for an ordinary word, so an unguarded fix would reach `--fix`
+            // unchallenged.
+            const hasReplacement = hasVisibleContent(safeTo);
             const replacement = hasReplacement
               ? matchCapitalisation(match.text, safeTo)
               : undefined;

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -38,10 +38,16 @@ const unapprovedOptionsSchema = z
     // `additional` keys are matched case-insensitively (`findTerm` → `termPattern`), so `Use` and
     // `use` claim the same span; JSON key order would otherwise decide which alternatives list
     // applies. Reject only when the conflicting keys actually disagree (#125).
-    const scan = findCaseConflicts(
-      options.additional,
-      (a, b) => JSON.stringify(a) === JSON.stringify(b),
+    //
+    // Checked against `allow`-filtered entries, matching `run()`'s own `allow.has(entry.term
+    // .toLowerCase())` filter (below): an operator can name-and-disable both sides of a conflict
+    // via `allow` (`{ additional: { Use: [...], use: [...] }, allow: ['use'] }`), at which point
+    // neither key ever reaches `findTerm` and there is no runtime ambiguity left to reject.
+    const allow = new Set(options.allow.map((term) => term.toLowerCase()));
+    const effective = Object.fromEntries(
+      Object.entries(options.additional).filter(([term]) => !allow.has(term.toLowerCase())),
     );
+    const scan = findCaseConflicts(effective, (a, b) => JSON.stringify(a) === JSON.stringify(b));
     for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'alternatives');
     for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'alternatives');
   });
@@ -174,8 +180,13 @@ const preferredOptionsSchema = z
     allow: z.array(z.string()).default([]),
   })
   .superRefine((options, ctx) => {
-    // Same case-insensitive span-matching conflict as `unapproved-vocabulary` above (#125).
-    const scan = findCaseConflicts(options.additional, (a, b) => a === b);
+    // Same case-insensitive span-matching conflict, and the same allow-filtering before checking
+    // it, as `unapproved-vocabulary` above (#125) -- see that schema's `superRefine` doc comment.
+    const allow = new Set(options.allow.map((term) => term.toLowerCase()));
+    const effective = Object.fromEntries(
+      Object.entries(options.additional).filter(([term]) => !allow.has(term.toLowerCase())),
+    );
+    const scan = findCaseConflicts(effective, (a, b) => a === b);
     for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'replacements');
     for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'replacements');
   });

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -12,6 +12,7 @@ import {
   findCaseConflicts,
   findTerm,
   matchCapitalisation,
+  reportCaseConflict,
   sanitizeQuotedValue,
   stripUnsafeCharacters,
 } from '../helpers.js';
@@ -40,13 +41,7 @@ const unapprovedOptionsSchema = z
       options.additional,
       (a, b) => JSON.stringify(a) === JSON.stringify(b),
     )) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['additional'],
-        message:
-          `${group.map((key) => `"${key}"`).join(' and ')} are case-equivalent keys that ` +
-          'resolve to the same source span but map to different alternatives.',
-      });
+      reportCaseConflict(ctx, group, 'alternatives');
     }
   });
 
@@ -96,7 +91,17 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
               continue;
             claimed.push(match.range);
 
-            const alternatives = entry.alternatives;
+            // Stripped once, here: `entry.alternatives` is supplier-controlled (the pack's
+            // `unapprovedTermSchema.alternatives`, or a project's own `additional` entry) and
+            // feeds every use below -- the displayed message, the fix `rationale`, the actual
+            // `fix.text` a caller applies to the document, the `Diagnostic.suggestions` array
+            // (`src/textlint/adapter.ts` builds its own rendered copy from this, but an editor's
+            // "apply fix" path writes this array's own value straight into the file too), `meta`
+            // (serialised verbatim by `steai lint --json`), and the semantic-adjudication payload
+            // sent to the model. Stripping the source once, rather than at each render site, means
+            // none of those sinks can be missed by a future addition to this list.
+            const alternatives = entry.alternatives.map(stripUnsafeCharacters);
+            const safeTerm = stripUnsafeCharacters(entry.term);
             const suggestion = alternatives[0];
             let fix: TextFix | undefined;
             if (entry.safeSubstitution && suggestion !== undefined) {
@@ -104,7 +109,7 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
                 range: match.range,
                 text: matchCapitalisation(match.text, suggestion),
                 rationale:
-                  `Rule pack marks "${sanitizeQuotedValue(entry.term)}" → ` +
+                  `Rule pack marks "${sanitizeQuotedValue(safeTerm)}" → ` +
                   `"${sanitizeQuotedValue(suggestion)}" as meaning-preserving.`,
                 safety: 'deterministic-meaning-preserving',
               };
@@ -124,9 +129,9 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
                 suggestions: alternatives,
                 ...(fix === undefined ? {} : { fix }),
                 meta: {
-                  term: entry.term,
+                  term: safeTerm,
                   safeSubstitution: entry.safeSubstitution,
-                  ...(entry.note === undefined ? {} : { note: entry.note }),
+                  ...(entry.note === undefined ? {} : { note: stripUnsafeCharacters(entry.note) }),
                 },
               }),
             );
@@ -170,13 +175,7 @@ const preferredOptionsSchema = z
   .superRefine((options, ctx) => {
     // Same case-insensitive span-matching conflict as `unapproved-vocabulary` above (#125).
     for (const group of findCaseConflicts(options.additional, (a, b) => a === b)) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['additional'],
-        message:
-          `${group.map((key) => `"${key}"`).join(' and ')} are case-equivalent keys that ` +
-          'resolve to the same source span but map to different replacements.',
-      });
+      reportCaseConflict(ctx, group, 'replacements');
     }
   });
 
@@ -220,29 +219,35 @@ export const preferredTerminologyRule: DeterministicRule<z.output<typeof preferr
             if (claimed.some((c) => match.range.start < c.end && c.start < match.range.end))
               continue;
             claimed.push(match.range);
-            const replacement = matchCapitalisation(match.text, entry.to);
+            // Stripped once: `entry.to`/`entry.from` are supplier-controlled and feed the fix
+            // text actually written to the document, `Diagnostic.suggestions`, and `meta`
+            // (serialised verbatim by `steai lint --json`), not only the rendered message and
+            // rationale below.
+            const safeFrom = stripUnsafeCharacters(entry.from);
+            const safeTo = stripUnsafeCharacters(entry.to);
+            const replacement = matchCapitalisation(match.text, safeTo);
             const fix: TextFix | undefined = entry.safeSubstitution
               ? {
                   range: match.range,
                   text: replacement,
                   rationale:
-                    `Rule pack marks "${sanitizeQuotedValue(entry.from)}" → ` +
-                    `"${sanitizeQuotedValue(entry.to)}" as a spelling choice.`,
+                    `Rule pack marks "${sanitizeQuotedValue(safeFrom)}" → ` +
+                    `"${sanitizeQuotedValue(safeTo)}" as a spelling choice.`,
                   safety: 'deterministic-meaning-preserving',
                 }
               : undefined;
             diagnostics.push(
               buildDiagnostic(preferredMeta, policy, {
                 category: 'deterministic-violation',
-                message: `Use "${sanitizeQuotedValue(entry.to)}" instead of "${match.text}".`,
+                message: `Use "${sanitizeQuotedValue(safeTo)}" instead of "${match.text}".`,
                 range: match.range,
                 evidence: excerpt(sentence.raw),
                 suggestions: [replacement],
                 ...(fix === undefined ? {} : { fix }),
                 meta: {
-                  from: entry.from,
-                  to: entry.to,
-                  ...(entry.note === undefined ? {} : { note: entry.note }),
+                  from: safeFrom,
+                  to: safeTo,
+                  ...(entry.note === undefined ? {} : { note: stripUnsafeCharacters(entry.note) }),
                 },
               }),
             );
@@ -289,14 +294,22 @@ export const noContractionsRule: DeterministicRule<z.output<typeof contractionOp
         // Match both the straight apostrophe and U+2019.
         for (const variant of variantsOf(entry.from)) {
           for (const match of findTerm(sentence, variant)) {
-            const replacement = matchCapitalisation(match.text, entry.to);
+            // Stripped once: `entry.from`/`entry.to` are pack-supplied (`pack.contractions`) and
+            // feed the fix text actually written to the document and `meta` (serialised verbatim
+            // by `steai lint --json`), not only the rendered message and rationale. Matching above
+            // still uses the raw `entry.from` -- stripping would not change a legitimate
+            // contraction's apostrophe, but there is no reason to match against anything other
+            // than what the pack actually declared.
+            const safeFrom = stripUnsafeCharacters(entry.from);
+            const safeTo = stripUnsafeCharacters(entry.to);
+            const replacement = matchCapitalisation(match.text, safeTo);
             const fix: TextFix | undefined = entry.safeSubstitution
               ? {
                   range: match.range,
                   text: replacement,
                   rationale:
-                    `"${sanitizeQuotedValue(entry.from)}" expands unambiguously to ` +
-                    `"${sanitizeQuotedValue(entry.to)}".`,
+                    `"${sanitizeQuotedValue(safeFrom)}" expands unambiguously to ` +
+                    `"${sanitizeQuotedValue(safeTo)}".`,
                   safety: 'deterministic-meaning-preserving',
                 }
               : undefined;
@@ -313,7 +326,7 @@ export const noContractionsRule: DeterministicRule<z.output<typeof contractionOp
                 evidence: excerpt(sentence.raw),
                 suggestions: [replacement],
                 ...(fix === undefined ? {} : { fix }),
-                meta: { contraction: entry.from, ambiguous: !entry.safeSubstitution },
+                meta: { contraction: safeFrom, ambiguous: !entry.safeSubstitution },
               }),
             );
           }

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -7,23 +7,48 @@ import type {
   RuleMetadata,
   TextFix,
 } from '../../core/types.js';
-import { excerpt, findTerm, matchCapitalisation } from '../helpers.js';
+import {
+  excerpt,
+  findCaseConflicts,
+  findTerm,
+  matchCapitalisation,
+  sanitizeQuotedValue,
+  stripUnsafeCharacters,
+} from '../helpers.js';
 
 // ---------------------------------------------------------------------------
 // unapproved-vocabulary
 // ---------------------------------------------------------------------------
 
-const unapprovedOptionsSchema = z.object({
-  /** Additional terms to treat as unapproved: `{ "leverage": ["use"] }`. */
-  additional: z.record(z.string(), z.array(z.string())).default({}),
-  /** Terms from the pack to ignore in this project. */
-  allow: z.array(z.string()).default([]),
-  /**
-   * Ask the semantic subsystem whether a flagged word is used in a sense the pack permits.
-   * Off by default so the rule stays purely deterministic unless the operator opts in.
-   */
-  adjudicateSense: z.boolean().default(false),
-});
+const unapprovedOptionsSchema = z
+  .object({
+    /** Additional terms to treat as unapproved: `{ "leverage": ["use"] }`. */
+    additional: z.record(z.string(), z.array(z.string())).default({}),
+    /** Terms from the pack to ignore in this project. */
+    allow: z.array(z.string()).default([]),
+    /**
+     * Ask the semantic subsystem whether a flagged word is used in a sense the pack permits.
+     * Off by default so the rule stays purely deterministic unless the operator opts in.
+     */
+    adjudicateSense: z.boolean().default(false),
+  })
+  .superRefine((options, ctx) => {
+    // `additional` keys are matched case-insensitively (`findTerm` → `termPattern`), so `Use` and
+    // `use` claim the same span; JSON key order would otherwise decide which alternatives list
+    // applies. Reject only when the conflicting keys actually disagree (#125).
+    for (const group of findCaseConflicts(
+      options.additional,
+      (a, b) => JSON.stringify(a) === JSON.stringify(b),
+    )) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['additional'],
+        message:
+          `${group.map((key) => `"${key}"`).join(' and ')} are case-equivalent keys that ` +
+          'resolve to the same source span but map to different alternatives.',
+      });
+    }
+  });
 
 const unapprovedMeta: RuleMetadata = {
   id: 'unapproved-vocabulary',
@@ -78,14 +103,16 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
               fix = {
                 range: match.range,
                 text: matchCapitalisation(match.text, suggestion),
-                rationale: `Rule pack marks "${entry.term}" → "${suggestion}" as meaning-preserving.`,
+                rationale:
+                  `Rule pack marks "${sanitizeQuotedValue(entry.term)}" → ` +
+                  `"${sanitizeQuotedValue(suggestion)}" as meaning-preserving.`,
                 safety: 'deterministic-meaning-preserving',
               };
             }
 
             const alternativeText =
               alternatives.length > 0
-                ? ` Use ${alternatives.map((a) => `"${a}"`).join(' or ')}.`
+                ? ` Use ${alternatives.map((a) => `"${sanitizeQuotedValue(a)}"`).join(' or ')}.`
                 : ' The rule pack supplies no approved alternative; rewrite the sentence.';
 
             diagnostics.push(
@@ -134,11 +161,24 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
 // preferred-terminology
 // ---------------------------------------------------------------------------
 
-const preferredOptionsSchema = z.object({
-  /** Extra mappings: `{ "log in": "sign in" }`. Never fixed automatically. */
-  additional: z.record(z.string(), z.string()).default({}),
-  allow: z.array(z.string()).default([]),
-});
+const preferredOptionsSchema = z
+  .object({
+    /** Extra mappings: `{ "log in": "sign in" }`. Never fixed automatically. */
+    additional: z.record(z.string(), z.string()).default({}),
+    allow: z.array(z.string()).default([]),
+  })
+  .superRefine((options, ctx) => {
+    // Same case-insensitive span-matching conflict as `unapproved-vocabulary` above (#125).
+    for (const group of findCaseConflicts(options.additional, (a, b) => a === b)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['additional'],
+        message:
+          `${group.map((key) => `"${key}"`).join(' and ')} are case-equivalent keys that ` +
+          'resolve to the same source span but map to different replacements.',
+      });
+    }
+  });
 
 const preferredMeta: RuleMetadata = {
   id: 'preferred-terminology',
@@ -185,14 +225,16 @@ export const preferredTerminologyRule: DeterministicRule<z.output<typeof preferr
               ? {
                   range: match.range,
                   text: replacement,
-                  rationale: `Rule pack marks "${entry.from}" → "${entry.to}" as a spelling choice.`,
+                  rationale:
+                    `Rule pack marks "${sanitizeQuotedValue(entry.from)}" → ` +
+                    `"${sanitizeQuotedValue(entry.to)}" as a spelling choice.`,
                   safety: 'deterministic-meaning-preserving',
                 }
               : undefined;
             diagnostics.push(
               buildDiagnostic(preferredMeta, policy, {
                 category: 'deterministic-violation',
-                message: `Use "${entry.to}" instead of "${match.text}".`,
+                message: `Use "${sanitizeQuotedValue(entry.to)}" instead of "${match.text}".`,
                 range: match.range,
                 evidence: excerpt(sentence.raw),
                 suggestions: [replacement],
@@ -252,7 +294,9 @@ export const noContractionsRule: DeterministicRule<z.output<typeof contractionOp
               ? {
                   range: match.range,
                   text: replacement,
-                  rationale: `"${entry.from}" expands unambiguously to "${entry.to}".`,
+                  rationale:
+                    `"${sanitizeQuotedValue(entry.from)}" expands unambiguously to ` +
+                    `"${sanitizeQuotedValue(entry.to)}".`,
                   safety: 'deterministic-meaning-preserving',
                 }
               : undefined;
@@ -260,8 +304,11 @@ export const noContractionsRule: DeterministicRule<z.output<typeof contractionOp
               buildDiagnostic(contractionMeta, policy, {
                 category: 'deterministic-violation',
                 message:
-                  `Do not use the contraction "${match.text}". Write "${replacement}".` +
-                  (entry.safeSubstitution ? '' : ` ${entry.note ?? 'Confirm the intended sense.'}`),
+                  `Do not use the contraction "${match.text}". ` +
+                  `Write "${sanitizeQuotedValue(replacement)}".` +
+                  (entry.safeSubstitution
+                    ? ''
+                    : ` ${entry.note === undefined ? 'Confirm the intended sense.' : stripUnsafeCharacters(entry.note)}`),
                 range: match.range,
                 evidence: excerpt(sentence.raw),
                 suggestions: [replacement],

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -13,6 +13,7 @@ import {
   findTerm,
   matchCapitalisation,
   reportCaseConflict,
+  reportUncheckedGroup,
   sanitizeQuotedValue,
   stripUnsafeCharacters,
 } from '../helpers.js';
@@ -37,12 +38,12 @@ const unapprovedOptionsSchema = z
     // `additional` keys are matched case-insensitively (`findTerm` → `termPattern`), so `Use` and
     // `use` claim the same span; JSON key order would otherwise decide which alternatives list
     // applies. Reject only when the conflicting keys actually disagree (#125).
-    for (const group of findCaseConflicts(
+    const scan = findCaseConflicts(
       options.additional,
       (a, b) => JSON.stringify(a) === JSON.stringify(b),
-    )) {
-      reportCaseConflict(ctx, group, 'alternatives');
-    }
+    );
+    for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'alternatives');
+    for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'alternatives');
   });
 
 const unapprovedMeta: RuleMetadata = {
@@ -174,9 +175,9 @@ const preferredOptionsSchema = z
   })
   .superRefine((options, ctx) => {
     // Same case-insensitive span-matching conflict as `unapproved-vocabulary` above (#125).
-    for (const group of findCaseConflicts(options.additional, (a, b) => a === b)) {
-      reportCaseConflict(ctx, group, 'replacements');
-    }
+    const scan = findCaseConflicts(options.additional, (a, b) => a === b);
+    for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'replacements');
+    for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'replacements');
   });
 
 const preferredMeta: RuleMetadata = {

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -47,7 +47,17 @@ const unapprovedOptionsSchema = z
     const effective = Object.fromEntries(
       Object.entries(options.additional).filter(([term]) => !allow.has(term.toLowerCase())),
     );
-    const scan = findCaseConflicts(effective, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+    // Compared after the same `stripUnsafeCharacters` the raw alternatives get before they ever
+    // reach a diagnostic or fix (below) — two keys whose raw alternatives differ only in a control
+    // character that sanitizes away (`"sign\tin"` vs `"sign in"`, say) produce the identical
+    // effective replacement and have no real conflict, even though the raw arrays themselves
+    // differ. Comparing the raw values rejected exactly that non-conflict.
+    const scan = findCaseConflicts(
+      effective,
+      (a, b) =>
+        JSON.stringify(a.map(stripUnsafeCharacters)) ===
+        JSON.stringify(b.map(stripUnsafeCharacters)),
+    );
     for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'alternatives');
     for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'alternatives');
   });
@@ -180,13 +190,17 @@ const preferredOptionsSchema = z
     allow: z.array(z.string()).default([]),
   })
   .superRefine((options, ctx) => {
-    // Same case-insensitive span-matching conflict, and the same allow-filtering before checking
-    // it, as `unapproved-vocabulary` above (#125) -- see that schema's `superRefine` doc comment.
+    // Same case-insensitive span-matching conflict, the same allow-filtering, and the same
+    // sanitized-value comparison before checking it, as `unapproved-vocabulary` above (#125) --
+    // see that schema's `superRefine` doc comment for both.
     const allow = new Set(options.allow.map((term) => term.toLowerCase()));
     const effective = Object.fromEntries(
       Object.entries(options.additional).filter(([term]) => !allow.has(term.toLowerCase())),
     );
-    const scan = findCaseConflicts(effective, (a, b) => a === b);
+    const scan = findCaseConflicts(
+      effective,
+      (a, b) => stripUnsafeCharacters(a) === stripUnsafeCharacters(b),
+    );
     for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'replacements');
     for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'replacements');
   });

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -117,7 +117,17 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
             // (serialised verbatim by `steai lint --json`), and the semantic-adjudication payload
             // sent to the model. Stripping the source once, rather than at each render site, means
             // none of those sinks can be missed by a future addition to this list.
-            const alternatives = entry.alternatives.map(stripUnsafeCharacters);
+            // Filtered, not just mapped: a pack-supplied alternative made entirely of characters
+            // `stripUnsafeCharacters` strips (control characters, bidi overrides) sanitizes to an
+            // empty string. Keeping it here would offer an empty-string suggestion and, worse,
+            // build a fix that deletes the matched term outright -- `checkFixSafety`'s numeric/
+            // negation/modal/ordering checks do not catch a blank replacement for an ordinary word,
+            // so it would reach `--fix` unchallenged. Treating a blank result the same as "no
+            // alternative supplied" is the same fallback already below for an empty `alternatives`
+            // array.
+            const alternatives = entry.alternatives
+              .map(stripUnsafeCharacters)
+              .filter((alternative) => alternative.trim() !== '');
             const safeTerm = stripUnsafeCharacters(entry.term);
             const suggestion = alternatives[0];
             let fix: TextFix | undefined;
@@ -251,24 +261,36 @@ export const preferredTerminologyRule: DeterministicRule<z.output<typeof preferr
             // rationale below.
             const safeFrom = stripUnsafeCharacters(entry.from);
             const safeTo = stripUnsafeCharacters(entry.to);
-            const replacement = matchCapitalisation(match.text, safeTo);
-            const fix: TextFix | undefined = entry.safeSubstitution
-              ? {
-                  range: match.range,
-                  text: replacement,
-                  rationale:
-                    `Rule pack marks "${sanitizeQuotedValue(safeFrom)}" → ` +
-                    `"${sanitizeQuotedValue(safeTo)}" as a spelling choice.`,
-                  safety: 'deterministic-meaning-preserving',
-                }
+            // A pack-supplied `to` made entirely of characters `stripUnsafeCharacters` strips
+            // sanitizes to an empty string; `checkFixSafety` does not catch a blank replacement for
+            // an ordinary word, so an unguarded fix would delete the matched term outright and
+            // `--fix` would apply it unchallenged.
+            const hasReplacement = safeTo.trim() !== '';
+            const replacement = hasReplacement
+              ? matchCapitalisation(match.text, safeTo)
               : undefined;
+            const fix: TextFix | undefined =
+              entry.safeSubstitution && replacement !== undefined
+                ? {
+                    range: match.range,
+                    text: replacement,
+                    rationale:
+                      `Rule pack marks "${sanitizeQuotedValue(safeFrom)}" → ` +
+                      `"${sanitizeQuotedValue(safeTo)}" as a spelling choice.`,
+                    safety: 'deterministic-meaning-preserving',
+                  }
+                : undefined;
+            const message = hasReplacement
+              ? `Use "${sanitizeQuotedValue(safeTo)}" instead of "${match.text}".`
+              : `"${match.text}" should not be used here, but the rule pack's replacement is ` +
+                'blank once sanitized.';
             diagnostics.push(
               buildDiagnostic(preferredMeta, policy, {
                 category: 'deterministic-violation',
-                message: `Use "${sanitizeQuotedValue(safeTo)}" instead of "${match.text}".`,
+                message,
                 range: match.range,
                 evidence: excerpt(sentence.raw),
-                suggestions: [replacement],
+                suggestions: replacement === undefined ? [] : [replacement],
                 ...(fix === undefined ? {} : { fix }),
                 meta: {
                   from: safeFrom,
@@ -328,29 +350,39 @@ export const noContractionsRule: DeterministicRule<z.output<typeof contractionOp
             // than what the pack actually declared.
             const safeFrom = stripUnsafeCharacters(entry.from);
             const safeTo = stripUnsafeCharacters(entry.to);
-            const replacement = matchCapitalisation(match.text, safeTo);
-            const fix: TextFix | undefined = entry.safeSubstitution
-              ? {
-                  range: match.range,
-                  text: replacement,
-                  rationale:
-                    `"${sanitizeQuotedValue(safeFrom)}" expands unambiguously to ` +
-                    `"${sanitizeQuotedValue(safeTo)}".`,
-                  safety: 'deterministic-meaning-preserving',
-                }
+            // A pack-supplied expansion made entirely of characters `stripUnsafeCharacters` strips
+            // sanitizes to an empty string; `checkFixSafety` does not catch a blank replacement for
+            // an ordinary word, so an unguarded fix would delete the matched contraction outright.
+            const hasReplacement = safeTo.trim() !== '';
+            const replacement = hasReplacement
+              ? matchCapitalisation(match.text, safeTo)
               : undefined;
+            const fix: TextFix | undefined =
+              entry.safeSubstitution && replacement !== undefined
+                ? {
+                    range: match.range,
+                    text: replacement,
+                    rationale:
+                      `"${sanitizeQuotedValue(safeFrom)}" expands unambiguously to ` +
+                      `"${sanitizeQuotedValue(safeTo)}".`,
+                    safety: 'deterministic-meaning-preserving',
+                  }
+                : undefined;
+            const expansionText =
+              replacement === undefined
+                ? 'the rule pack supplies no usable expansion.'
+                : `Write "${sanitizeQuotedValue(replacement)}".`;
             diagnostics.push(
               buildDiagnostic(contractionMeta, policy, {
                 category: 'deterministic-violation',
                 message:
-                  `Do not use the contraction "${match.text}". ` +
-                  `Write "${sanitizeQuotedValue(replacement)}".` +
+                  `Do not use the contraction "${match.text}". ${expansionText}` +
                   (entry.safeSubstitution
                     ? ''
                     : ` ${entry.note === undefined ? 'Confirm the intended sense.' : stripUnsafeCharacters(entry.note)}`),
                 range: match.range,
                 evidence: excerpt(sentence.raw),
-                suggestions: [replacement],
+                suggestions: replacement === undefined ? [] : [replacement],
                 ...(fix === undefined ? {} : { fix }),
                 meta: { contraction: safeFrom, ambiguous: !entry.safeSubstitution },
               }),

--- a/src/deterministic/rules/vocabulary.ts
+++ b/src/deterministic/rules/vocabulary.ts
@@ -23,6 +23,17 @@ import {
 // unapproved-vocabulary
 // ---------------------------------------------------------------------------
 
+/**
+ * An `alternatives` array's effective value for case-conflict comparison purposes: each entry
+ * sanitized, then any entry with no visible content dropped entirely. Order is preserved and still
+ * distinguishes two otherwise-equal-looking arrays, matching `unapprovedVocabularyRule.run()`'s own
+ * use of `alternatives[0]` as the fix candidate (below) — this is the same two-step transform, not
+ * a looser one.
+ */
+function effectiveAlternatives(alternatives: readonly string[]): string[] {
+  return alternatives.map(stripUnsafeCharacters).filter(hasVisibleContent);
+}
+
 const unapprovedOptionsSchema = z
   .object({
     /** Additional terms to treat as unapproved: `{ "leverage": ["use"] }`. */
@@ -48,16 +59,19 @@ const unapprovedOptionsSchema = z
     const effective = Object.fromEntries(
       Object.entries(options.additional).filter(([term]) => !allow.has(term.toLowerCase())),
     );
-    // Compared after the same `stripUnsafeCharacters` the raw alternatives get before they ever
-    // reach a diagnostic or fix (below) — two keys whose raw alternatives differ only in a control
-    // character that sanitizes away (`"sign\tin"` vs `"sign in"`, say) produce the identical
-    // effective replacement and have no real conflict, even though the raw arrays themselves
-    // differ. Comparing the raw values rejected exactly that non-conflict.
+    // Compared after the same two-step transform the raw alternatives get before they ever reach
+    // a diagnostic or fix (below): `stripUnsafeCharacters`, then dropping any entry that sanitizes
+    // to no visible content (`hasVisibleContent`). A follow-up round of the same review found that
+    // comparing only the first step wasn't enough -- `Use` mapped to a single ZWJ (U+200D) and
+    // `use` mapped to an empty array sanitize to different-looking raw arrays (`["‍"]` vs
+    // `[]`), but the second step drops the invisible-only entry from both, so at the runtime the
+    // rule actually reaches (below), both keys resolve to the identical empty alternatives list.
+    // Comparing after only the first step rejected that non-conflict the same way comparing raw
+    // values did before.
     const scan = findCaseConflicts(
       effective,
       (a, b) =>
-        JSON.stringify(a.map(stripUnsafeCharacters)) ===
-        JSON.stringify(b.map(stripUnsafeCharacters)),
+        JSON.stringify(effectiveAlternatives(a)) === JSON.stringify(effectiveAlternatives(b)),
     );
     for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'alternatives');
     for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'alternatives');
@@ -196,6 +210,18 @@ export const unapprovedVocabularyRule: DeterministicRule<z.output<typeof unappro
 // preferred-terminology
 // ---------------------------------------------------------------------------
 
+/**
+ * A `to` value's effective replacement for case-conflict comparison purposes: the sanitized value
+ * itself, or a canonical empty string when that sanitized value has no visible content. Two
+ * replacements that each sanitize to no visible content compare equal here even if their raw,
+ * invisible-only content differs, since `preferredTerminologyRule`'s own `hasReplacement` check
+ * (below) treats both identically as "no usable replacement" at runtime.
+ */
+function effectiveReplacement(to: string): string {
+  const safe = stripUnsafeCharacters(to);
+  return hasVisibleContent(safe) ? safe : '';
+}
+
 const preferredOptionsSchema = z
   .object({
     /** Extra mappings: `{ "log in": "sign in" }`. Never fixed automatically. */
@@ -204,7 +230,7 @@ const preferredOptionsSchema = z
   })
   .superRefine((options, ctx) => {
     // Same case-insensitive span-matching conflict, the same allow-filtering, and the same
-    // sanitized-value comparison before checking it, as `unapproved-vocabulary` above (#125) --
+    // effective-value comparison before checking it, as `unapproved-vocabulary` above (#125) --
     // see that schema's `superRefine` doc comment for both.
     const allow = new Set(options.allow.map((term) => term.toLowerCase()));
     const effective = Object.fromEntries(
@@ -212,7 +238,7 @@ const preferredOptionsSchema = z
     );
     const scan = findCaseConflicts(
       effective,
-      (a, b) => stripUnsafeCharacters(a) === stripUnsafeCharacters(b),
+      (a, b) => effectiveReplacement(a) === effectiveReplacement(b),
     );
     for (const group of scan.conflicts) reportCaseConflict(ctx, group, 'replacements');
     for (const group of scan.unchecked) reportUncheckedGroup(ctx, group, 'replacements');

--- a/src/textlint/adapter.ts
+++ b/src/textlint/adapter.ts
@@ -8,6 +8,7 @@ import type {
 import { analyseText, type AnalysisResult } from '../analysis/analyse.js';
 import type { SteAiConfigInput } from '../core/config.js';
 import type { Diagnostic } from '../core/types.js';
+import { sanitizeQuotedValue } from '../deterministic/helpers.js';
 import { deterministicRules, findDeterministicRule } from '../deterministic/index.js';
 import { tryConfigFingerprint } from './config-fingerprint.js';
 import { loadSharedConfig } from './shared-config.js';
@@ -354,9 +355,18 @@ export function createSteTextlintRule(
           if (diagnostic.suggestions !== undefined && diagnostic.suggestions.length > 0) {
             // Suggestions are advisory: an editor may offer them, but `textlint --fix` applies
             // only `details.fix`, which the autofix gate has already approved.
+            //
+            // `replacement` can be supplier-controlled, schema-unconstrained rule-pack text (a
+            // vocabulary rule's `entry.alternatives`/`entry.to`, from `src/deterministic/rules/
+            // vocabulary.ts`) -- the same untrusted-text class #123 sanitizes for `Diagnostic
+            // .message` and fix `rationale`. `message` below wraps it in the template's own
+            // literal quotes, so it needs `sanitizeQuotedValue` for display. `fix` must keep the
+            // raw `replacement`: it is the actual text `fixer.replaceTextRange` inserts into the
+            // document, and sanitizing it would silently change what an editor's "apply fix"
+            // action writes to the file.
             details.suggestions = diagnostic.suggestions.slice(0, 3).map((replacement, index) => ({
               id: `${ruleId}-${start}-${index}`,
-              message: `Replace with "${replacement}"`,
+              message: `Replace with "${sanitizeQuotedValue(replacement)}"`,
               fix: fixer.replaceTextRange([start, end], replacement),
             }));
           }

--- a/test/e2e/textlint-run.test.ts
+++ b/test/e2e/textlint-run.test.ts
@@ -305,6 +305,31 @@ describe('textlint lint run', () => {
     const message = result.messages[0] as { suggestions?: { message: string }[] } | undefined;
     expect(message?.suggestions?.[0]?.message).toContain('start');
   });
+
+  it('sanitizes a rule-pack-controlled alternative in the rendered suggestion message (#123)', async () => {
+    // `diagnostic.suggestions` (`src/deterministic/rules/vocabulary.ts`) can carry
+    // schema-unconstrained pack/project text. `src/textlint/adapter.ts` wraps each one in its own
+    // literal double quotes to build `details.suggestions[].message` -- the review that found this
+    // gap traced it through `mustGetRule`/`kernel.lintText` to confirm it is genuinely rendered,
+    // not just an internal field. The control character below must not survive into that message,
+    // and an embedded `"` must not let the forged text visually escape the quoting.
+    const forged = 'apply"; forged citation\u0008';
+    const result = await kernel.lintText('Leverage the API.\n', {
+      ...options([]),
+      rules: [
+        {
+          ruleId: 'unapproved-vocabulary',
+          rule: mustGetRule('unapproved-vocabulary'),
+          options: { additional: { leverage: [forged] } },
+        },
+      ],
+    });
+
+    const message = result.messages[0] as { suggestions?: { message: string }[] } | undefined;
+    const suggestionMessage = message?.suggestions?.[0]?.message;
+    expect(suggestionMessage).not.toContain('\u0008');
+    expect(suggestionMessage?.match(/"/g)).toHaveLength(2);
+  });
 });
 
 describe('textlint fix run', () => {

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1195,6 +1195,32 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.fix?.text).toBe('foo');
   });
 
+  it('drops a control-derived boundary run even when another doomed character sits between it and the edge (Codex review)', () => {
+    // The boundary check above ran against the original string, before a separate .replace() step
+    // had removed characters that were also going to disappear entirely -- a backspace ahead of a
+    // newline (`\bfoo`, `\b` then `\n` then `foo`) put the newline run at offset 1, not touching
+    // either end of the *original* string, so it collapsed to a space rather than nothing. Only
+    // afterwards did the next step delete the backspace, leaving that space stranded at the true
+    // start of the final string -- the same bug in a different guise. The boundary check now reads
+    // the live string after the entirely-deleting steps have already run, so this collapses
+    // correctly regardless of what used to sit between the control run and the true edge.
+    const backspace = String.fromCharCode(0x08);
+    const lf = String.fromCharCode(0x0a);
+    const replacement = `${backspace}${lf}foo`;
+    const result = analyse('Use the widget here.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: replacement, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('foo');
+  });
+
   it('does not offer or apply a fix that sanitizes to a blank replacement (unapproved-vocabulary, Codex review)', () => {
     // A pack-supplied alternative made entirely of control characters sanitizes to an empty
     // string. checkFixSafety's numeric/negation/modal/ordering checks do not catch a blank

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1208,4 +1208,26 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.suggestions).toEqual([]);
     expect(diagnostic?.message).toContain('blank once sanitized');
   });
+
+  it('does not offer or apply a fix made only of a variation selector (Codex review)', () => {
+    // hasVisibleContent's first version excluded only \p{Cf} and whitespace, but a variation
+    // selector (U+FE0F) is general category Mn, not Cf, and is equally invisible on its own --
+    // confirmed as a real gap by review. A replacement of only U+FE0F passed the \p{Cf}-based
+    // check and still built a fix replacing the matched word with something invisible.
+    const vs16 = String.fromCodePoint(0xfe0f);
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: vs16, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix).toBeUndefined();
+    expect(diagnostic?.suggestions).toEqual([]);
+    expect(diagnostic?.message).toContain('blank once sanitized');
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -963,6 +963,17 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.message?.match(/"/g)).toHaveLength(4);
     expect(diagnostic?.fix?.rationale).not.toContain(CONTROL_CHAR);
     expect(diagnostic?.fix?.rationale).not.toContain(BIDI_OVERRIDE);
+    // `entry.to` is stripped once, at the source, before it becomes `fix.text` or `suggestions` --
+    // not just before it is interpolated into `message`/`rationale`. `fix.text` is the value
+    // `textlint --fix` (or an editor's "apply fix") writes straight into the document, so a
+    // control character or bidi override reaching it would corrupt the file being linted, not
+    // just a rendered message. A literal `"` is not stripped here (unlike in the quoted message),
+    // since this is the real replacement text, not display text wrapped in a template's quotes.
+    expect(diagnostic?.fix?.text).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.fix?.text).not.toContain(BIDI_OVERRIDE);
+    expect(diagnostic?.fix?.text).toContain('"');
+    expect(diagnostic?.suggestions?.[0]).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.suggestions?.[0]).not.toContain(BIDI_OVERRIDE);
   });
 
   it("sanitizes unapproved-vocabulary's alternatives before they reach the message", () => {
@@ -980,13 +991,19 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.message).not.toContain(CONTROL_CHAR);
     expect(diagnostic?.message).not.toContain(BIDI_OVERRIDE);
     expect(diagnostic?.fix?.rationale).not.toContain(CONTROL_CHAR);
-    // `Diagnostic.suggestions` itself stays raw at this (core) layer: it is the value the
-    // textlint adapter's autofix path substitutes into the document verbatim, not display text.
-    // `src/textlint/adapter.ts` sanitizes its own copy only when it renders a suggestion as a
-    // message (`Replace with "..."`) -- see the e2e coverage in
-    // `test/e2e/textlint-run.test.ts`'s "sanitizes a rule-pack-controlled alternative in the
-    // rendered suggestion message" case, which exercises that render path directly.
-    expect(diagnostic?.suggestions).toEqual([FORGED]);
+    // `entry.alternatives` is stripped once, at the source (`unapprovedVocabularyRule` in
+    // `src/deterministic/rules/vocabulary.ts`), before it becomes `Diagnostic.suggestions` or
+    // `fix.text` -- not just before it reaches `message`/`rationale`. `fix.text` is what
+    // `textlint --fix` (or an editor's "apply fix") writes straight into the document, and
+    // `suggestions` is what `src/textlint/adapter.ts` uses for its own suggestion `fix` too, so
+    // both need the control character and bidi override gone, not only the rendered copies. The
+    // literal `"` survives here (unlike in `message`, which wraps the value in its own quotes):
+    // this is real replacement text, not a display string.
+    expect(diagnostic?.suggestions?.[0]).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.suggestions?.[0]).not.toContain(BIDI_OVERRIDE);
+    expect(diagnostic?.suggestions?.[0]).toContain('"');
+    expect(diagnostic?.fix?.text).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.fix?.text).not.toContain(BIDI_OVERRIDE);
   });
 
   it('sanitizes a project-configured (non-pack) additional entry the same way', () => {
@@ -1001,5 +1018,32 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     const diagnostic = result.diagnostics.find((d) => d.ruleId === 'unapproved-vocabulary');
     expect(diagnostic?.message).not.toContain(CONTROL_CHAR);
     expect(diagnostic?.message).not.toContain(BIDI_OVERRIDE);
+  });
+
+  it("sanitizes meta fields, which the CLI's --json output serialises verbatim", () => {
+    // `Diagnostic.message`/`fix.rationale` are what a human reads on a terminal, but `steai lint
+    // --json` writes the whole `Diagnostic` object -- `meta` included -- straight to stdout via
+    // `JSON.stringify`. `JSON.stringify` escapes the C0 controls covered by the JSON spec's own
+    // short escapes (`\b`, `\n`, ...), but a bidi-override character (`‮`) is not one of
+    // those and passes through raw, so `meta` needs the same stripping as the rendered fields.
+    const result = analyse('Use the gadget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'gadget', to: FORGED, safeSubstitution: false, note: FORGED }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    const meta = diagnostic?.meta ?? {};
+    for (const value of Object.values(meta)) {
+      if (typeof value !== 'string') continue;
+      expect(value).not.toContain(CONTROL_CHAR);
+      expect(value).not.toContain(BIDI_OVERRIDE);
+    }
+    expect(meta['to']).toBeDefined();
+    expect(meta['note']).toBeDefined();
   });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1069,4 +1069,26 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.fix?.text).toBe(manTechnologist);
     expect(diagnostic?.fix?.text).toContain(zwj);
   });
+
+  it('normalises a tab/newline-like control to a space instead of deleting it (Codex review)', () => {
+    // stripUnsafeCharacters deleted every \p{Cc} character outright, tab and newline included --
+    // but the schema permits those in a pack's replacement text, and this sanitizer runs on the
+    // actual text a fix writes into the document, not only display strings. Deleting rather than
+    // normalising a word-separating control glued the words on either side together
+    // (`sign\tin` -> `signin`); normalising to an ordinary space instead preserves the boundary.
+    const tab = String.fromCharCode(0x09);
+    const replacement = `sign${tab}in`;
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: replacement, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('sign in');
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -933,3 +933,68 @@ describe('rule pack: limits, contractions, path resolution, and the autofix gate
     });
   });
 });
+
+describe('rule pack: untrusted text reaching a rendered message is neutralised (#123)', () => {
+  // A control character or an embedded double-quote in supplier-controlled text can rewrite how a
+  // terminal reads surrounding output, or make fabricated text look like it has escaped the
+  // message's own quoting -- the same class of finding PR #116 fixed for `meta.sourceRef`, but
+  // here on `message`, the field actually rendered by `src/textlint/adapter.ts`'s `formatMessage`
+  // and the CLI's human-output branch. Escape sequences, not literal glyphs: BACKSPACE stands in
+  // for a control character, RIGHT-TO-LEFT OVERRIDE for a bidi override.
+  const CONTROL_CHAR = '\u0008';
+  const BIDI_OVERRIDE = '\u202e';
+  const FORGED = 'widget"; forged citation' + CONTROL_CHAR + BIDI_OVERRIDE;
+
+  it('sanitizes preferred-terminology\'s "to" before it reaches the message and fix rationale', () => {
+    const result = analyse('Use the gadget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'gadget', to: FORGED, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.message).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.message).not.toContain(BIDI_OVERRIDE);
+    // The message wraps the value in its own double quotes; an embedded quote must not survive.
+    expect(diagnostic?.message?.match(/"/g)).toHaveLength(4);
+    expect(diagnostic?.fix?.rationale).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.fix?.rationale).not.toContain(BIDI_OVERRIDE);
+  });
+
+  it("sanitizes unapproved-vocabulary's alternatives before they reach the message", () => {
+    const result = analyse('Utilise the bracket.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [{ term: 'utilise', alternatives: [FORGED], safeSubstitution: true }],
+          preferred: [],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'unapproved-vocabulary');
+    expect(diagnostic?.message).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.message).not.toContain(BIDI_OVERRIDE);
+    expect(diagnostic?.fix?.rationale).not.toContain(CONTROL_CHAR);
+    // The raw alternative is unaffected outside rendered text: it is still a real suggestion.
+    expect(diagnostic?.suggestions).toEqual([FORGED]);
+  });
+
+  it('sanitizes a project-configured (non-pack) additional entry the same way', () => {
+    // `options.additional` is operator-supplied, not pack-supplied, but it feeds the identical
+    // interpolation site -- the sanitizer must not be conditioned on where the string came from.
+    const result = analyseTextDeterministic('Leverage the API.\n', {
+      config: {
+        rules: { 'unapproved-vocabulary': { additional: { leverage: [FORGED] } } },
+      },
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'unapproved-vocabulary');
+    expect(diagnostic?.message).not.toContain(CONTROL_CHAR);
+    expect(diagnostic?.message).not.toContain(BIDI_OVERRIDE);
+  });
+});

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -980,7 +980,12 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.message).not.toContain(CONTROL_CHAR);
     expect(diagnostic?.message).not.toContain(BIDI_OVERRIDE);
     expect(diagnostic?.fix?.rationale).not.toContain(CONTROL_CHAR);
-    // The raw alternative is unaffected outside rendered text: it is still a real suggestion.
+    // `Diagnostic.suggestions` itself stays raw at this (core) layer: it is the value the
+    // textlint adapter's autofix path substitutes into the document verbatim, not display text.
+    // `src/textlint/adapter.ts` sanitizes its own copy only when it renders a suggestion as a
+    // message (`Replace with "..."`) -- see the e2e coverage in
+    // `test/e2e/textlint-run.test.ts`'s "sanitizes a rule-pack-controlled alternative in the
+    // rendered suggestion message" case, which exercises that render path directly.
     expect(diagnostic?.suggestions).toEqual([FORGED]);
   });
 

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1091,4 +1091,24 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
     expect(diagnostic?.fix?.text).toBe('sign in');
   });
+
+  it('normalises NEL (U+0085) to a space too, not just ASCII whitespace controls (Codex review)', () => {
+    // The first version of the tab/newline fix above listed only the ASCII C0 whitespace controls
+    // and missed NEL (U+0085), a C1 control that is also a legitimate line break -- so a
+    // schema-permitted replacement containing it still deleted straight through a word boundary.
+    const nel = String.fromCharCode(0x85);
+    const replacement = `sign${nel}in`;
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: replacement, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('sign in');
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1185,4 +1185,27 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.suggestions).toEqual([]);
     expect(diagnostic?.message).toContain('no usable expansion');
   });
+
+  it('does not offer or apply a fix made only of invisible format characters (Codex review)', () => {
+    // A replacement made entirely of a lone ZWJ survives both stripUnsafeCharacters (which
+    // intentionally leaves \p{Cf} alone -- it can have a real, local effect on the word it sits
+    // inside) and .trim() (which only strips whitespace) -- so checking merely that the sanitized
+    // value is non-blank was not enough: a ZWJ-only replacement would still build a fix that
+    // replaces the matched word with something invisible.
+    const zwj = String.fromCharCode(0x200d);
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: zwj, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix).toBeUndefined();
+    expect(diagnostic?.suggestions).toEqual([]);
+    expect(diagnostic?.message).toContain('blank once sanitized');
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1111,4 +1111,26 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
     expect(diagnostic?.fix?.text).toBe('sign in');
   });
+
+  it('collapses a CRLF line break to one space, not two (Codex review)', () => {
+    // stripUnsafeCharacters replaced each whitespace-shaped control independently, so a
+    // conventional multi-character line break -- CR followed by LF -- produced two replacement
+    // spaces instead of one: `sign\r\nin` became `sign  in`, not `sign in`. A whole contiguous run
+    // of these controls now collapses to a single space.
+    const cr = String.fromCharCode(0x0d);
+    const lf = String.fromCharCode(0x0a);
+    const replacement = `sign${cr}${lf}in`;
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: replacement, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('sign in');
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1046,4 +1046,27 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(meta['to']).toBeDefined();
     expect(meta['note']).toBeDefined();
   });
+
+  it('preserves a legitimate zero-width joiner in replacement text (Codex review)', () => {
+    // `stripUnsafeCharacters` originally removed the entire Unicode "format" category (`\p{Cf}`),
+    // which also contains characters with a real, local effect on the word they sit inside, not
+    // just bidi overrides. ZWJ (U+200D) is the clearest case: it is what makes a multi-codepoint
+    // emoji sequence render as one glyph. Stripping it from a rule pack's real replacement text
+    // would corrupt exactly the text `safeSubstitution: true` promises is meaning-preserving.
+    const zwj = String.fromCharCode(0x200d);
+    const manTechnologist = `\u{1F468}${zwj}\u{1F4BB}`; // U+1F468 U+200D U+1F4BB
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: manTechnologist, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe(manTechnologist);
+    expect(diagnostic?.fix?.text).toContain(zwj);
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1133,4 +1133,56 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
     expect(diagnostic?.fix?.text).toBe('sign in');
   });
+
+  it('does not offer or apply a fix that sanitizes to a blank replacement (unapproved-vocabulary, Codex review)', () => {
+    // A pack-supplied alternative made entirely of control characters sanitizes to an empty
+    // string. checkFixSafety's numeric/negation/modal/ordering checks do not catch a blank
+    // replacement for an ordinary word, so an unguarded fix would delete the matched term outright
+    // and `--fix` would apply it unchallenged.
+    const blank = String.fromCharCode(0x08);
+    const result = analyse('Utilise the bracket.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [{ term: 'utilise', alternatives: [blank], safeSubstitution: true }],
+          preferred: [],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'unapproved-vocabulary');
+    expect(diagnostic?.fix).toBeUndefined();
+    expect(diagnostic?.suggestions).toEqual([]);
+    expect(diagnostic?.message).toContain('no approved alternative');
+  });
+
+  it('does not offer or apply a fix that sanitizes to a blank replacement (preferred-terminology, Codex review)', () => {
+    const blank = String.fromCharCode(0x08);
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: blank, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix).toBeUndefined();
+    expect(diagnostic?.suggestions).toEqual([]);
+    expect(diagnostic?.message).toContain('blank once sanitized');
+  });
+
+  it('does not offer or apply a fix that sanitizes to a blank replacement (no-contractions, Codex review)', () => {
+    const blank = String.fromCharCode(0x08);
+    const result = analyse("Don't touch the busbar.\n", {
+      rulePack: pack({ contractions: [{ from: "don't", to: blank, safeSubstitution: true }] }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'no-contractions');
+    expect(diagnostic?.fix).toBeUndefined();
+    expect(diagnostic?.suggestions).toEqual([]);
+    expect(diagnostic?.message).toContain('no usable expansion');
+  });
 });

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1134,6 +1134,46 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.fix?.text).toBe('sign in');
   });
 
+  it('collapses ordinary spaces touching a line break too, not only the controls (Codex review)', () => {
+    // The CRLF fix above collapsed a run of controls to one space but left ordinary spaces
+    // immediately touching that run untouched, since they are not themselves one of the listed
+    // controls -- indentation around a line break (`sign \r\n in`) produced `sign   in` (three
+    // spaces) instead of one.
+    const cr = String.fromCharCode(0x0d);
+    const lf = String.fromCharCode(0x0a);
+    const replacement = `sign ${cr}${lf} in`;
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: replacement, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('sign in');
+  });
+
+  it('leaves a plain double space with no control character untouched (Codex review)', () => {
+    // The broader whitespace-run match added above must only collapse a run that actually
+    // contains a control character -- a run of nothing but ordinary spaces, with no control
+    // involved at all, is legitimate pack-authored text and stays as the pack wrote it.
+    const result = analyse('Use the widget.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: 'sign  in', safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('sign  in');
+  });
+
   it('does not offer or apply a fix that sanitizes to a blank replacement (unapproved-vocabulary, Codex review)', () => {
     // A pack-supplied alternative made entirely of control characters sanitizes to an empty
     // string. checkFixSafety's numeric/negation/modal/ordering checks do not catch a blank

--- a/test/integration/rule-pack.test.ts
+++ b/test/integration/rule-pack.test.ts
@@ -1174,6 +1174,27 @@ describe('rule pack: untrusted text reaching a rendered message is neutralised (
     expect(diagnostic?.fix?.text).toBe('sign  in');
   });
 
+  it('drops a control-derived run at the replacement boundary instead of leaving a stray space (Codex review)', () => {
+    // A control-bearing run touching either end of the whole replacement string was still
+    // collapsed to a space, not dropped, even though there is no word on that side to separate
+    // from: `stripUnsafeCharacters('\nfoo')` produced `' foo'`, a stray leading space that turns
+    // into a double space once substituted next to the document's own existing separator.
+    const lf = String.fromCharCode(0x0a);
+    const replacement = `${lf}foo`;
+    const result = analyse('Use the widget here.\n', {
+      rulePack: pack({
+        dictionary: {
+          approved: [],
+          unapproved: [],
+          preferred: [{ from: 'widget', to: replacement, safeSubstitution: true }],
+        },
+      }),
+    });
+
+    const diagnostic = result.diagnostics.find((d) => d.ruleId === 'preferred-terminology');
+    expect(diagnostic?.fix?.text).toBe('foo');
+  });
+
   it('does not offer or apply a fix that sanitizes to a blank replacement (unapproved-vocabulary, Codex review)', () => {
     // A pack-supplied alternative made entirely of control characters sanitizes to an empty
     // string. checkFixSafety's numeric/negation/modal/ordering checks do not catch a blank

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -289,6 +289,42 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(result.diagnostics.some((d) => d.ruleId === 'unapproved-vocabulary')).toBe(true);
   });
 
+  it('does not reject a conflict whose keys are both disabled via allow (Codex review)', () => {
+    // `run()` filters `additional` entries through `allow` (case-insensitively) before matching,
+    // so `{ additional: { Use: [...], use: [...] }, allow: ['use'] }` has no runtime ambiguity at
+    // all: neither key ever reaches `findTerm`. Validating the unfiltered map rejected this
+    // perfectly valid configuration on a conflict that can never actually occur.
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': {
+          additional: { Use: ['employ'], use: ['apply'] },
+          allow: ['use'],
+        },
+      },
+    });
+
+    expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
+  });
+
+  it('still rejects a conflict when allow disables only one of the two keys', () => {
+    // Filtering must be case-insensitive and per-key, not "any entry present in allow clears the
+    // whole map": disabling `Use` alone leaves `use` on its own, so there is no conflict left
+    // either -- this proves the filter narrows to the *other* remaining key correctly, not that it
+    // happens to clear everything whenever `allow` is non-empty.
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': {
+          additional: { Use: ['employ'], use: ['apply'], leverage: ['employ'] },
+          allow: ['leverage'],
+        },
+      },
+    });
+
+    const notice = result.notices.find((n) => n.code === 'rule-options-invalid');
+    expect(notice?.message).toContain('"Use"');
+    expect(notice?.message).toContain('"use"');
+  });
+
   it('rejects conflicting case-equivalent keys in preferred-terminology, both key orders', () => {
     const orderA = runRaw({
       rules: {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -226,6 +226,89 @@ describe('preferred-terminology', () => {
   });
 });
 
+/** Runs a fixed trivial document, exposing notices that the `run()` helper above discards. */
+function runRaw(config: SteAiConfigInput) {
+  const resolved = resolveConfig(config);
+  const doc = analyseDocument({ id: 't', format: 'markdown', text: 'Use the tool.\n' });
+  return runDeterministicRules({
+    doc,
+    rules: deterministicRules,
+    config: resolved,
+    pack: provisionalRulePack,
+  });
+}
+
+/**
+ * `additional` keys are matched case-insensitively (`termPattern()` in `src/deterministic/
+ * helpers.ts`), so `Use` and `use` claim the same span. Before #125's fix, JSON key order silently
+ * decided which alternatives list applied.
+ */
+describe('case-equivalent "additional" keys are rejected, not silently order-dependent (#125)', () => {
+  it('rejects conflicting case-equivalent keys in unapproved-vocabulary, both key orders', () => {
+    const orderA = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { Use: ['employ'], use: ['apply'] } },
+      },
+    });
+    const orderB = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { use: ['apply'], Use: ['employ'] } },
+      },
+    });
+
+    for (const result of [orderA, orderB]) {
+      expect(result.diagnostics.some((d) => d.ruleId === 'unapproved-vocabulary')).toBe(false);
+      const notice = result.notices.find((n) => n.code === 'rule-options-invalid');
+      expect(notice?.detail).toEqual({ ruleId: 'unapproved-vocabulary' });
+      expect(notice?.message).toContain('"Use"');
+      expect(notice?.message).toContain('"use"');
+    }
+  });
+
+  it('accepts case-equivalent keys that resolve to the same alternatives', () => {
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { Use: ['employ'], use: ['employ'] } },
+      },
+    });
+
+    expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
+    expect(result.diagnostics.some((d) => d.ruleId === 'unapproved-vocabulary')).toBe(true);
+  });
+
+  it('rejects conflicting case-equivalent keys in preferred-terminology, both key orders', () => {
+    const orderA = runRaw({
+      rules: {
+        'preferred-terminology': { additional: { Use: 'employ', use: 'apply' } },
+      },
+    });
+    const orderB = runRaw({
+      rules: {
+        'preferred-terminology': { additional: { use: 'apply', Use: 'employ' } },
+      },
+    });
+
+    for (const result of [orderA, orderB]) {
+      expect(result.diagnostics.some((d) => d.ruleId === 'preferred-terminology')).toBe(false);
+      const notice = result.notices.find((n) => n.code === 'rule-options-invalid');
+      expect(notice?.detail).toEqual({ ruleId: 'preferred-terminology' });
+    }
+  });
+
+  it('does not reject unrelated rules when one rule’s additional map conflicts', () => {
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { Use: ['employ'], use: ['apply'] } },
+      },
+    });
+
+    // The malformed rule is skipped; every other rule still ran (mirrors the `unknown-rule-id`
+    // degrade-not-fail contract in `test/unit/config-strictness.test.ts`).
+    expect(result.notices.filter((n) => n.level === 'error')).toHaveLength(1);
+    expect(result.diagnostics.some((d) => d.ruleId === 'no-contractions')).toBe(false);
+  });
+});
+
 describe('no-contractions', () => {
   const id = 'no-contractions';
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -471,11 +471,31 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     // the per-bucket limit (500) and the total pair-count budget (500,000) can still be expensive
     // if its keys are individually very long. 500 keys of 201 code points each: 124,750 pairs,
     // under every count-based limit, but 124,750 * 201 code points of matching work exceeds
-    // MAX_TOTAL_COMPARISON_WORK -- confirmed directly, before this bound existed, to take multiple
-    // seconds for keys an order of magnitude longer than this.
+    // MAX_TOTAL_COMPARISON_WORK, so this reproduces the shape the budget exists to reject rather
+    // than asserting a specific measured duration that would drift from the real cost over time.
     const additional: Record<string, string[]> = {};
     for (let i = 0; i < 500; i++) {
       const key = `${String(i).padStart(3, '0')}${'x'.repeat(198)}`;
+      additional[key] = [`v${i}`];
+    }
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]?.reason).toBe('total-budget-exceeded');
+    expect(scan.unchecked[0]?.keys).toHaveLength(500);
+  });
+
+  it('charges the work budget for uncollapsed whitespace, not the bucketed length (Codex review)', () => {
+    // codePointLength collapses a whitespace run to one unit for bucketing, matching how
+    // sameTermSpan's \s+ actually treats it -- but escapeForMatching/sameTermSpan still scan every
+    // raw whitespace character on each comparison, so a key built mostly of whitespace bucketed as
+    // short. Charging the work budget off that collapsed length let this shape slip under it: 500
+    // keys of a letter, three digits, three thousand spaces, and "x" all bucket at the same short
+    // collapsed length (6), but the raw length actually scanned per comparison is over 3,000.
+    const additional: Record<string, string[]> = {};
+    for (let i = 0; i < 500; i++) {
+      const key = `${String.fromCharCode(65 + (i % 26))}${String(i).padStart(3, '0')}${' '.repeat(3000)}x`;
       additional[key] = [`v${i}`];
     }
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -542,6 +542,26 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(scan.unchecked[0]?.keys).toHaveLength(500);
   });
 
+  it('charges the work budget for untrimmed leading/trailing whitespace too (Codex review)', () => {
+    // The raw-length fix above measured Array.from(item[0].trim()).length -- trimming before
+    // counting hid exactly the whitespace that costs time: escapeForMatching's own .trim() call,
+    // and sameTermSpan's b.trim(), each scan the full untrimmed string regardless of how much they
+    // end up stripping. 500 distinct three-character keys each followed by 3,000 trailing spaces
+    // all bucket at the same short trimmed length (3), so a length charge that also trims hides
+    // the real per-comparison re-trim cost the same way the internal-whitespace case did above.
+    const additional: Record<string, string[]> = {};
+    for (let i = 0; i < 500; i++) {
+      const key = `${String(i).padStart(3, '0')}${' '.repeat(3000)}`;
+      additional[key] = [`v${i}`];
+    }
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]?.reason).toBe('total-budget-exceeded');
+    expect(scan.unchecked[0]?.keys).toHaveLength(500);
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -4,6 +4,7 @@ import { analyseDocument } from '../../src/core/document.js';
 import { runDeterministicRules } from '../../src/core/runner.js';
 import type { Diagnostic, DocumentFormat } from '../../src/core/types.js';
 import { deterministicRules } from '../../src/deterministic/index.js';
+import { findCaseConflicts } from '../../src/deterministic/helpers.js';
 import { provisionalRulePack } from '../../src/rule-pack/provisional-pack.js';
 
 interface RunResult {
@@ -362,6 +363,28 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     const notice = result.notices.find((n) => n.code === 'rule-options-invalid');
     expect(notice?.message).toBeDefined();
     expect(notice?.detail).toEqual({ ruleId: 'unapproved-vocabulary' });
+  });
+
+  it('stays fast and correct on a large map, without the exhaustive Unicode-fold merge', () => {
+    // Direct call, not through a rule: constructing a document config with 600 `additional`
+    // entries through the full pipeline just to exercise this one internal boundary would be
+    // unwieldy for no extra coverage. `findCaseConflicts`'s exhaustive pairwise merge (for a
+    // case-fold pair `canonicalKey`'s NFKC+lowercase step does not unify, such as Greek final
+    // sigma) is O(n^2) once past `EXHAUSTIVE_FOLD_MERGE_LIMIT` entries -- measured directly at
+    // ~800ms for 2,000 pairwise-distinct entries before this limit existed. Past the limit, only
+    // the O(n) canonical-key fast path runs, which still catches an ordinary case pair.
+    const additional: Record<string, string[]> = { Foo: ['first'], foo: ['second'] };
+    for (let i = 0; i < 600; i++) additional[`word${i}`] = [`alt${i}`];
+
+    const started = Date.now();
+    const conflicts = findCaseConflicts(
+      additional,
+      (a, b) => JSON.stringify(a) === JSON.stringify(b),
+    );
+    const elapsedMs = Date.now() - started;
+
+    expect(conflicts).toEqual([['Foo', 'foo']]);
+    expect(elapsedMs).toBeLessThan(2000);
   });
 });
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -290,6 +290,36 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(result.diagnostics.some((d) => d.ruleId === 'unapproved-vocabulary')).toBe(true);
   });
 
+  it('accepts case-equivalent keys whose raw alternatives sanitize to the same value (Codex review)', () => {
+    // The equality check compared raw alternatives, but every alternative is sanitized
+    // (stripUnsafeCharacters) before it ever reaches a diagnostic or fix. Two keys whose raw
+    // alternatives differ only in a control character that sanitizes away -- a tab vs. a plain
+    // space, here -- produce the identical effective replacement and have no real conflict, even
+    // though the raw arrays themselves are different strings.
+    const tab = String.fromCharCode(0x09);
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': {
+          additional: { Use: [`sign${tab}in`], use: ['sign in'] },
+        },
+      },
+    });
+
+    expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
+    expect(result.diagnostics.some((d) => d.ruleId === 'unapproved-vocabulary')).toBe(true);
+  });
+
+  it('accepts case-equivalent preferred-terminology keys whose raw replacements sanitize to the same value (Codex review)', () => {
+    const tab = String.fromCharCode(0x09);
+    const result = runRaw({
+      rules: {
+        'preferred-terminology': { additional: { Use: `sign${tab}in`, use: 'sign in' } },
+      },
+    });
+
+    expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
+  });
+
   it('does not reject a conflict whose keys are both disabled via allow (Codex review)', () => {
     // `run()` filters `additional` entries through `allow` (case-insensitively) before matching,
     // so `{ additional: { Use: [...], use: [...] }, allow: ['use'] }` has no runtime ambiguity at

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -464,7 +464,14 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
     const elapsedMs = Date.now() - started;
 
-    expect(elapsedMs).toBeLessThan(2000);
+    // Every one of these 25,000 keys also pays a fixed per-key self-test cost now (see the
+    // "self-tests the actual termPattern shape too" test below), on top of the pairwise cost this
+    // test bounds -- a real, legitimate addition, not a regression, but it moves the wall-clock
+    // floor up enough that a tight ceiling flakes on a loaded or slower CI runner (observed
+    // directly: comfortably under a smaller bound locally, over it on CI). The bound here exists
+    // to catch a real return to unbounded O(n^2)-or-worse cost, which would take vastly longer
+    // than this, not to pin a specific millisecond figure.
+    expect(elapsedMs).toBeLessThan(10_000);
     // At least one bucket exceeded the total budget and came back unchecked rather than being
     // silently treated as conflict-free.
     expect(scan.unchecked.length).toBeGreaterThan(0);

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -584,6 +584,25 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(scan.unchecked[0]?.keys).toHaveLength(2);
   });
 
+  it('also catches a too-long key with no peer to compare it against (Codex review)', () => {
+    // The fix above only exercised a key's own compile-safety when the pairwise loop happened to
+    // use it as sameTermSpan's first argument -- a key alone in its length bucket never enters
+    // that loop at all (there is no second entry to compare it against), so it passed through
+    // untested and unchecked, the identical crash risk with no bucket-level catch anywhere near
+    // it. Every key is now self-tested up front, regardless of whether it ends up compared to
+    // anything.
+    const additional: Record<string, string[]> = {
+      [`a${'x'.repeat(50_000)}`]: ['only'],
+    };
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.conflicts).toEqual([]);
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]?.reason).toBe('comparison-failed');
+    expect(scan.unchecked[0]?.keys).toHaveLength(1);
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -465,6 +465,27 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(notices[0]).not.toContain('too many to exhaustively check');
   });
 
+  it('bounds total cost by key length as well as comparison count (Codex review)', () => {
+    // MAX_TOTAL_COMPARISONS alone assumes every comparison costs the same, but a regex match's
+    // cost scales with the length of the strings it matches -- a bucket comfortably within both
+    // the per-bucket limit (500) and the total pair-count budget (500,000) can still be expensive
+    // if its keys are individually very long. 500 keys of 201 code points each: 124,750 pairs,
+    // under every count-based limit, but 124,750 * 201 code points of matching work exceeds
+    // MAX_TOTAL_COMPARISON_WORK -- confirmed directly, before this bound existed, to take multiple
+    // seconds for keys an order of magnitude longer than this.
+    const additional: Record<string, string[]> = {};
+    for (let i = 0; i < 500; i++) {
+      const key = `${String(i).padStart(3, '0')}${'x'.repeat(198)}`;
+      additional[key] = [`v${i}`];
+    }
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]?.reason).toBe('total-budget-exceeded');
+    expect(scan.unchecked[0]?.keys).toHaveLength(500);
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -378,14 +378,33 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     for (let i = 0; i < 600; i++) additional[`word${i}`] = [`alt${i}`];
 
     const started = Date.now();
-    const conflicts = findCaseConflicts(
-      additional,
-      (a, b) => JSON.stringify(a) === JSON.stringify(b),
-    );
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
     const elapsedMs = Date.now() - started;
 
-    expect(conflicts).toEqual([['Foo', 'foo']]);
+    expect(scan.conflicts).toEqual([['Foo', 'foo']]);
+    expect(scan.unchecked).toEqual([]);
     expect(elapsedMs).toBeLessThan(2000);
+  });
+
+  it('rejects an oversized length bucket instead of silently passing it (Codex review)', () => {
+    // Silently treating a bucket too large to check exhaustively as conflict-free was the first
+    // version of this bound -- rejected on review, because that bucket could still contain a
+    // genuine conflict (`Foo`/`foo` here, buried among 500 unrelated four-code-point keys) and
+    // reporting "no conflict" without having actually checked is a false all-clear. This proves
+    // the corrected behavior: the oversized bucket comes back as `unchecked`, not silently
+    // dropped, regardless of whether it happens to contain a real conflict.
+    // Every filler key is exactly 3 code points, the same length as "Foo"/"foo", so they land in
+    // the one oversized bucket together: 500 filler keys ("000".."499") plus the real pair, 502
+    // entries total, comfortably over `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH` (500).
+    const additional: Record<string, string[]> = { Foo: ['first'], foo: ['second'] };
+    for (let i = 0; i < 500; i++) additional[String(i).padStart(3, '0')] = [`alt${i}`];
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.conflicts).toEqual([]);
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]).toHaveLength(502);
+    expect(scan.unchecked[0]).toEqual(expect.arrayContaining(['Foo', 'foo']));
   });
 
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
@@ -396,9 +415,9 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     // An earlier version of `findCaseConflicts` used exactly that canonicalisation as its
     // grouping and would have flagged this pair, incorrectly skipping the whole rule for two
     // keys that do not actually collide.
-    const conflicts = findCaseConflicts({ A: ['alfa'], Ａ: ['fullwidth-a'] }, (a, b) => a === b);
+    const scan = findCaseConflicts({ A: ['alfa'], Ａ: ['fullwidth-a'] }, (a, b) => a === b);
 
-    expect(conflicts).toEqual([]);
+    expect(scan.conflicts).toEqual([]);
   });
 
   it('bucket differing internal whitespace runs together (Codex review)', () => {
@@ -408,12 +427,12 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     // code-point counts. A length-based prefilter keyed on raw code points would put them in
     // different buckets and never test them against each other, silently missing exactly the
     // "object key order decides" conflict #125 exists to reject, for a multi-word phrase.
-    const conflicts = findCaseConflicts(
+    const scan = findCaseConflicts(
       { 'foo bar': ['first'], 'foo  bar': ['second'] },
       (a, b) => JSON.stringify(a) === JSON.stringify(b),
     );
 
-    expect(conflicts).toEqual([['foo bar', 'foo  bar']]);
+    expect(scan.conflicts).toEqual([['foo bar', 'foo  bar']]);
   });
 });
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -400,6 +400,21 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
 
     expect(conflicts).toEqual([]);
   });
+
+  it('bucket differing internal whitespace runs together (Codex review)', () => {
+    // `escapeForMatching` turns every whitespace run into a flexible `\s+`, matching one or more
+    // characters of any length on either side, so `"foo bar"` (one space) and `"foo  bar"` (two
+    // spaces) are `sameTermSpan`-equivalent -- confirmed directly -- despite differing raw
+    // code-point counts. A length-based prefilter keyed on raw code points would put them in
+    // different buckets and never test them against each other, silently missing exactly the
+    // "object key order decides" conflict #125 exists to reject, for a multi-word phrase.
+    const conflicts = findCaseConflicts(
+      { 'foo bar': ['first'], 'foo  bar': ['second'] },
+      (a, b) => JSON.stringify(a) === JSON.stringify(b),
+    );
+
+    expect(conflicts).toEqual([['foo bar', 'foo  bar']]);
+  });
 });
 
 describe('no-contractions', () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -562,6 +562,28 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(scan.unchecked[0]?.keys).toHaveLength(500);
   });
 
+  it('degrades to unchecked instead of crashing when a key is too long to compile (Codex review)', () => {
+    // sameTermSpan compiles a RegExp from each key. Neither MAX_TOTAL_COMPARISONS nor
+    // MAX_TOTAL_COMPARISON_WORK catches two case-fold-equivalent keys that are each merely very
+    // long: a bucket of two costs one comparison, comfortably under both budgets, yet the
+    // underlying regex engine refuses to compile a pattern past its own internal size limit --
+    // 50,000 code points is comfortably past that limit on the engine running this test. Uncaught,
+    // that exception would escape this function, the superRefine callback calling it, and
+    // safeParse itself, crashing the whole run instead of degrading to the rule-options-invalid
+    // this rule is supposed to produce.
+    const additional: Record<string, string[]> = {
+      [`a${'x'.repeat(50_000)}`]: ['first'],
+      [`A${'x'.repeat(50_000)}`]: ['second'],
+    };
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.conflicts).toEqual([]);
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]?.reason).toBe('comparison-failed');
+    expect(scan.unchecked[0]?.keys).toHaveLength(2);
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -603,6 +603,25 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(scan.unchecked[0]?.keys).toHaveLength(1);
   });
 
+  it('self-tests the actual termPattern shape too, not only sameTermSpan (Codex review)', () => {
+    // Confirmed directly: a compiled RegExp survives construction no matter how long the pattern
+    // is -- the compile step that can throw for an oversized or pathologically-shaped pattern
+    // happens lazily, on first *execution* (.test()/.exec()/.matchAll()), not at `new RegExp(...)`
+    // time. termPattern's lookaround-boundary shape (the one findTerm actually executes against
+    // real document text) is not guaranteed to hit that lazy-compile failure at the same size as
+    // sameTermSpan's anchored `^...$` shape for the same content, so self-testing only one of the
+    // two shapes leaves the other's failure mode unguarded. Both shapes are executed here.
+    const additional: Record<string, string[]> = {
+      [`a${'x'.repeat(100_000)}`]: ['only'],
+    };
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.conflicts).toEqual([]);
+    expect(scan.unchecked).toHaveLength(1);
+    expect(scan.unchecked[0]?.reason).toBe('comparison-failed');
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -407,6 +407,29 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(scan.unchecked[0]).toEqual(expect.arrayContaining(['Foo', 'foo']));
   });
 
+  it('bounds total cost across many buckets, not just within one (Codex review)', () => {
+    // The per-length bound alone does not stop an untrusted pack from keeping every bucket at
+    // exactly the per-length limit and supplying arbitrarily many buckets. Reproduces Codex's own
+    // repro shape: 50 distinct lengths, 500 entries each (25,000 keys total, every individual
+    // bucket within `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH`) -- confirmed to cost ~7.5s across
+    // ~6.2 million comparisons before `MAX_TOTAL_COMPARISONS` existed.
+    const additional: Record<string, string[]> = {};
+    for (let bucket = 0; bucket < 50; bucket++) {
+      const prefix = 'x'.repeat(bucket);
+      for (let i = 0; i < 500; i++)
+        additional[`${prefix}${String(i).padStart(3, '0')}`] = [`v${i}`];
+    }
+
+    const started = Date.now();
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+    const elapsedMs = Date.now() - started;
+
+    expect(elapsedMs).toBeLessThan(2000);
+    // At least one bucket exceeded the total budget and came back unchecked rather than being
+    // silently treated as conflict-free.
+    expect(scan.unchecked.length).toBeGreaterThan(0);
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -345,6 +345,24 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(notice?.message).toContain('"Use"');
     expect(notice?.message).toContain('"use"');
   });
+
+  it('catches a Unicode case fold "toLowerCase()" itself does not compute', () => {
+    // `termPattern()`'s `/iu` flag matches on full Unicode case folding, which is a different,
+    // stricter relation than `String.prototype.toLowerCase()` computes -- confirmed directly:
+    // `/s/iu` matches the Latin small letter long s (`ſ`, U+017F), a real span collision, but
+    // `'s'.toLowerCase() !== 'ſ'.toLowerCase()`. A conflict detector keyed on `toLowerCase()`
+    // would silently miss this pair, leaving exactly the object-key-order ambiguity #125 exists
+    // to reject.
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { s: ['sierra'], ſ: ['long-s'] } },
+      },
+    });
+
+    const notice = result.notices.find((n) => n.code === 'rule-options-invalid');
+    expect(notice?.message).toBeDefined();
+    expect(notice?.detail).toEqual({ ruleId: 'unapproved-vocabulary' });
+  });
 });
 
 describe('no-contractions', () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -4,7 +4,11 @@ import { analyseDocument } from '../../src/core/document.js';
 import { runDeterministicRules } from '../../src/core/runner.js';
 import type { Diagnostic, DocumentFormat } from '../../src/core/types.js';
 import { deterministicRules } from '../../src/deterministic/index.js';
-import { findCaseConflicts } from '../../src/deterministic/helpers.js';
+import {
+  findCaseConflicts,
+  reportUncheckedGroup,
+  type IssueReporter,
+} from '../../src/deterministic/helpers.js';
 import { provisionalRulePack } from '../../src/rule-pack/provisional-pack.js';
 
 interface RunResult {
@@ -370,10 +374,9 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     // entries through the full pipeline just to exercise this one internal boundary would be
     // unwieldy for no extra coverage. `findCaseConflicts` only pays its pairwise `sameTermSpan`
     // cost within a bucket of same-code-point-length keys, bounded by
-    // `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH` -- measured directly at ~800ms for 2,000
-    // pairwise-distinct same-length entries before that bound existed. `word0`..`word599` spread
-    // across four lengths (5-8 digits), each bucket comfortably under the limit, so `Foo`/`foo`
-    // (the only length-3 pair) still gets a real, confirmed conflict check.
+    // `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH`. `word0`..`word599` spread across four lengths
+    // (5-8 digits), each bucket comfortably under the limit, so `Foo`/`foo` (the only length-3
+    // pair) still gets a real, confirmed conflict check.
     const additional: Record<string, string[]> = { Foo: ['first'], foo: ['second'] };
     for (let i = 0; i < 600; i++) additional[`word${i}`] = [`alt${i}`];
 
@@ -403,16 +406,17 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
 
     expect(scan.conflicts).toEqual([]);
     expect(scan.unchecked).toHaveLength(1);
-    expect(scan.unchecked[0]).toHaveLength(502);
-    expect(scan.unchecked[0]).toEqual(expect.arrayContaining(['Foo', 'foo']));
+    expect(scan.unchecked[0]?.reason).toBe('bucket-too-large');
+    expect(scan.unchecked[0]?.keys).toHaveLength(502);
+    expect(scan.unchecked[0]?.keys).toEqual(expect.arrayContaining(['Foo', 'foo']));
   });
 
   it('bounds total cost across many buckets, not just within one (Codex review)', () => {
     // The per-length bound alone does not stop an untrusted pack from keeping every bucket at
-    // exactly the per-length limit and supplying arbitrarily many buckets. Reproduces Codex's own
-    // repro shape: 50 distinct lengths, 500 entries each (25,000 keys total, every individual
-    // bucket within `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH`) -- confirmed to cost ~7.5s across
-    // ~6.2 million comparisons before `MAX_TOTAL_COMPARISONS` existed.
+    // exactly the per-length limit and supplying arbitrarily many buckets: 50 distinct lengths,
+    // 500 entries each (25,000 keys total, every individual bucket within
+    // `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH`) reproduces the adversarial shape `MAX_TOTAL_COMPARISONS`
+    // exists to bound.
     const additional: Record<string, string[]> = {};
     for (let bucket = 0; bucket < 50; bucket++) {
       const prefix = 'x'.repeat(bucket);
@@ -428,6 +432,37 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     // At least one bucket exceeded the total budget and came back unchecked rather than being
     // silently treated as conflict-free.
     expect(scan.unchecked.length).toBeGreaterThan(0);
+    expect(scan.unchecked.some((group) => group.reason === 'total-budget-exceeded')).toBe(true);
+  });
+
+  it('reports a total-budget overflow as its own reason, not "bucket too large" (Codex review)', () => {
+    // Four buckets sitting exactly at the per-length limit (500 * 499 / 2 = 124,750 comparisons
+    // each) spend 499,000 of the 500,000-comparison total budget between them. A fifth, much
+    // smaller bucket (50 entries, nowhere near the per-length limit) then pushes the running total
+    // over budget by itself. Before distinguishing the two reasons, both this small bucket and a
+    // genuinely oversized one shared one `unchecked` shape, and `reportUncheckedGroup` always
+    // claimed "too many keys share this length" -- wrong for this bucket, which isn't oversized at
+    // all, just the one that happened to cross a budget earlier buckets already spent most of.
+    const additional: Record<string, string[]> = {};
+    for (let bucket = 0; bucket < 4; bucket++) {
+      const prefix = 'x'.repeat(bucket);
+      for (let i = 0; i < 500; i++)
+        additional[`${prefix}${String(i).padStart(3, '0')}`] = [`v${i}`];
+    }
+    const smallPrefix = 'x'.repeat(10);
+    for (let i = 0; i < 50; i++)
+      additional[`${smallPrefix}${String(i).padStart(2, '0')}`] = [`s${i}`];
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    const smallBucket = scan.unchecked.find((group) => group.keys.length === 50);
+    expect(smallBucket?.reason).toBe('total-budget-exceeded');
+
+    const notices: string[] = [];
+    const ctx: IssueReporter = { addIssue: (issue) => notices.push(issue.message) };
+    if (smallBucket !== undefined) reportUncheckedGroup(ctx, smallBucket, 'alternatives');
+    expect(notices[0]).toContain('total comparison budget');
+    expect(notices[0]).not.toContain('too many to exhaustively check');
   });
 
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -320,6 +320,37 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
   });
 
+  it('accepts case-equivalent keys whose alternatives resolve to the same empty list after visibility filtering (Codex review)', () => {
+    // The comparator was fixed (above) to compare sanitized values, but that alone was not enough:
+    // an alternative that sanitizes to no visible content (a lone ZWJ, here) is also dropped from
+    // the array entirely at runtime (`hasVisibleContent`, see unapprovedVocabularyRule.run()), so
+    // `Use: [ZWJ]` and `use: []` resolve to the identical empty alternatives list even though their
+    // sanitized-but-not-yet-filtered arrays look different (`[ZWJ]` vs `[]`).
+    const zwj = String.fromCharCode(0x200d);
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { Use: [zwj], use: [] } },
+      },
+    });
+
+    expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
+  });
+
+  it('accepts case-equivalent preferred-terminology keys whose replacements are both invisible-only (Codex review)', () => {
+    // A ZWJ-only replacement and a ZWNJ-only replacement look different once sanitized, but
+    // preferredTerminologyRule.run()'s own hasReplacement check treats any invisible-only
+    // replacement identically as "no usable replacement" -- these two are not a real conflict.
+    const zwj = String.fromCharCode(0x200d);
+    const zwnj = String.fromCharCode(0x200c);
+    const result = runRaw({
+      rules: {
+        'preferred-terminology': { additional: { Use: zwj, use: zwnj } },
+      },
+    });
+
+    expect(result.notices.some((n) => n.code === 'rule-options-invalid')).toBe(false);
+  });
+
   it('does not reject a conflict whose keys are both disabled via allow (Codex review)', () => {
     // `run()` filters `additional` entries through `allow` (case-insensitively) before matching,
     // so `{ additional: { Use: [...], use: [...] }, allow: ['use'] }` has no runtime ambiguity at

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -226,10 +226,18 @@ describe('preferred-terminology', () => {
   });
 });
 
-/** Runs a fixed trivial document, exposing notices that the `run()` helper above discards. */
+/**
+ * Runs a fixed document, exposing notices that the `run()` helper above discards. The second
+ * sentence carries a contraction so `no-contractions` -- unrelated to `additional`'s own conflict
+ * -- has something to genuinely find, not just something it happens not to flag.
+ */
 function runRaw(config: SteAiConfigInput) {
   const resolved = resolveConfig(config);
-  const doc = analyseDocument({ id: 't', format: 'markdown', text: 'Use the tool.\n' });
+  const doc = analyseDocument({
+    id: 't',
+    format: 'markdown',
+    text: "Use the tool. Don't touch the busbar.\n",
+  });
   return runDeterministicRules({
     doc,
     rules: deterministicRules,
@@ -303,9 +311,11 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     });
 
     // The malformed rule is skipped; every other rule still ran (mirrors the `unknown-rule-id`
-    // degrade-not-fail contract in `test/unit/config-strictness.test.ts`).
+    // degrade-not-fail contract in `test/unit/config-strictness.test.ts`). `no-contractions` has a
+    // real contraction to find in `runRaw`'s fixture text, so this proves it actually ran rather
+    // than merely failing to flag text it was never going to flag anyway.
     expect(result.notices.filter((n) => n.level === 'error')).toHaveLength(1);
-    expect(result.diagnostics.some((d) => d.ruleId === 'no-contractions')).toBe(false);
+    expect(result.diagnostics.some((d) => d.ruleId === 'no-contractions')).toBe(true);
   });
 });
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -317,6 +317,34 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(result.notices.filter((n) => n.level === 'error')).toHaveLength(1);
     expect(result.diagnostics.some((d) => d.ruleId === 'no-contractions')).toBe(true);
   });
+
+  it('sanitizes the conflicting keys before naming them in the notice message', () => {
+    // A pack's own `rules[].options` field is an unconstrained `z.record(z.string(),
+    // z.unknown())` (`rulePackRuleSpecSchema` in `src/rule-pack/schema.ts`) and is merged as the
+    // base of `rawOptions` before schema validation (`src/core/runner.ts`), so a case-conflicting
+    // `additional` key can itself be pack-controlled, not just operator-typed. The notice message
+    // is rendered verbatim by the CLI and by the textlint adapter's run-level notice reporting, so
+    // it needs the same control-character/bidi-override stripping as `Diagnostic.message`.
+    //
+    // The bidi-override character sits *inside* both keys, at the same position, so the keys stay
+    // case-equivalent (`.toLowerCase()` doesn't touch it) -- appending it only to one key instead
+    // would make the two keys genuinely different strings, not case variants, and the conflict
+    // detector would never fire at all.
+    const bidiOverride = String.fromCharCode(0x202e);
+    const keyA = `U${bidiOverride}se`;
+    const keyB = `u${bidiOverride}se`;
+    const result = runRaw({
+      rules: {
+        'unapproved-vocabulary': { additional: { [keyA]: ['employ'], [keyB]: ['apply'] } },
+      },
+    });
+
+    const notice = result.notices.find((n) => n.code === 'rule-options-invalid');
+    expect(notice?.message).toBeDefined();
+    expect(notice?.message).not.toContain(bidiOverride);
+    expect(notice?.message).toContain('"Use"');
+    expect(notice?.message).toContain('"use"');
+  });
 });
 
 describe('no-contractions', () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -6,6 +6,7 @@ import type { Diagnostic, DocumentFormat } from '../../src/core/types.js';
 import { deterministicRules } from '../../src/deterministic/index.js';
 import {
   findCaseConflicts,
+  findTerm,
   reportUncheckedGroup,
   type IssueReporter,
 } from '../../src/deterministic/helpers.js';
@@ -629,6 +630,29 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(scan.unchecked[0]?.reason).toBe('comparison-failed');
   });
 
+  it('charges the per-key self-test cost to the total budget too (Codex review)', () => {
+    // MAX_TOTAL_COMPARISON_WORK weighed the pairwise scan's cost, but the fixed per-key self-test
+    // (sameTermSpan and termPattern, both above) runs before that scan and was not counted at all.
+    // A near-singleton bucket costs almost nothing pairwise (bucketCost is 0 for a true singleton,
+    // 1 for a pair, and so on) regardless of key length, so a pack distributing many long keys
+    // across many distinct lengths -- never colliding, so never bucketed together, so never
+    // contributing pairwise cost -- could impose unbounded self-test work with nothing here to
+    // stop it before this fix. 6,500 keys of ~2,000 code points each, spread across enough
+    // distinct lengths that no bucket approaches EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH (500) or
+    // MAX_TOTAL_COMPARISONS (500,000 pairs) on their own, reproduces the shape: self-test cost
+    // alone accumulates enough to trip MAX_TOTAL_COMPARISON_WORK partway through.
+    const additional: Record<string, string[]> = {};
+    for (let i = 0; i < 6500; i++) {
+      const key = `${'x'.repeat(2000)}${'q'.repeat(i % 50)}${i}`;
+      additional[key] = [`v${i}`];
+    }
+
+    const scan = findCaseConflicts(additional, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+
+    expect(scan.unchecked.length).toBeGreaterThan(0);
+    for (const group of scan.unchecked) expect(group.reason).toBe('total-budget-exceeded');
+  });
+
   it('never merges keys the real matcher treats as distinct (Codex review)', () => {
     // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
     // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth
@@ -655,6 +679,23 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     );
 
     expect(scan.conflicts).toEqual([['foo bar', 'foo  bar']]);
+  });
+
+  it('findTerm degrades to no match instead of crashing on a pathological term (Codex review)', () => {
+    // findCaseConflicts's own self-test at schema-validation time cannot guarantee findTerm won't
+    // still fail later at document-analysis time: the underlying regex engine's lazy-compile
+    // failure threshold is sensitive to how much call stack is already in use at the point of
+    // execution, and the two call sites run from different points in the call stack. findTerm
+    // guards its own termPattern execution independently, rather than relying solely on that
+    // earlier check, so a pathological term degrades to "no match in this sentence" instead of
+    // crashing the whole analysis run.
+    const doc = analyseDocument({ id: 't', format: 'markdown', text: 'Use the widget.\n' });
+    const sentence = doc.sentences[0];
+    if (sentence === undefined) throw new Error('expected at least one sentence');
+
+    const pathological = `a${'x'.repeat(100_000)}`;
+    expect(() => findTerm(sentence, pathological)).not.toThrow();
+    expect(findTerm(sentence, pathological)).toEqual([]);
   });
 });
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -365,14 +365,15 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
     expect(notice?.detail).toEqual({ ruleId: 'unapproved-vocabulary' });
   });
 
-  it('stays fast and correct on a large map, without the exhaustive Unicode-fold merge', () => {
+  it('stays fast and correct on a large map, without exhaustively scanning every length', () => {
     // Direct call, not through a rule: constructing a document config with 600 `additional`
     // entries through the full pipeline just to exercise this one internal boundary would be
-    // unwieldy for no extra coverage. `findCaseConflicts`'s exhaustive pairwise merge (for a
-    // case-fold pair `canonicalKey`'s NFKC+lowercase step does not unify, such as Greek final
-    // sigma) is O(n^2) once past `EXHAUSTIVE_FOLD_MERGE_LIMIT` entries -- measured directly at
-    // ~800ms for 2,000 pairwise-distinct entries before this limit existed. Past the limit, only
-    // the O(n) canonical-key fast path runs, which still catches an ordinary case pair.
+    // unwieldy for no extra coverage. `findCaseConflicts` only pays its pairwise `sameTermSpan`
+    // cost within a bucket of same-code-point-length keys, bounded by
+    // `EXHAUSTIVE_FOLD_SCAN_LIMIT_PER_LENGTH` -- measured directly at ~800ms for 2,000
+    // pairwise-distinct same-length entries before that bound existed. `word0`..`word599` spread
+    // across four lengths (5-8 digits), each bucket comfortably under the limit, so `Foo`/`foo`
+    // (the only length-3 pair) still gets a real, confirmed conflict check.
     const additional: Record<string, string[]> = { Foo: ['first'], foo: ['second'] };
     for (let i = 0; i < 600; i++) additional[`word${i}`] = [`alt${i}`];
 
@@ -385,6 +386,19 @@ describe('case-equivalent "additional" keys are rejected, not silently order-dep
 
     expect(conflicts).toEqual([['Foo', 'foo']]);
     expect(elapsedMs).toBeLessThan(2000);
+  });
+
+  it('never merges keys the real matcher treats as distinct (Codex review)', () => {
+    // A cheap canonicalisation broad enough to unify every case `sameTermSpan` recognises (Greek
+    // final sigma, the Latin long s) is also broad enough to over-merge: ASCII `A` and fullwidth
+    // `Ａ` (U+FF21) both normalize+lowercase to `a`, but `termPattern`'s actual `/iu` regex does
+    // not treat them as the same letter -- confirmed directly: `/^A$/iu.test('Ａ')` is `false`.
+    // An earlier version of `findCaseConflicts` used exactly that canonicalisation as its
+    // grouping and would have flagged this pair, incorrectly skipping the whole rule for two
+    // keys that do not actually collide.
+    const conflicts = findCaseConflicts({ A: ['alfa'], Ａ: ['fullwidth-a'] }, (a, b) => a === b);
+
+    expect(conflicts).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Triaged the open-issue backlog and picked three concrete, well-scoped bugs to fix:

- **Fixes #123** — `preferredTerminologyRule`, `unapprovedVocabularyRule` and `noContractionsRule` (`src/deterministic/rules/vocabulary.ts`) interpolated supplier-controlled, schema-unconstrained rule-pack text (`to`, `alternatives`, `term`, `from`, `note`) directly into `Diagnostic.message` and fix `rationale` with no escaping — the same class of finding PR #116 fixed for `meta.sourceRef`, but here on the field actually rendered to a human. Added `stripUnsafeCharacters`/`sanitizeQuotedValue` to `src/deterministic/helpers.ts` and applied them at every interpolation site, including a second sink in `src/textlint/adapter.ts`'s rendered suggestion message found during review (see below). `note` gets control/bidi stripping only (not quote-escaping), since the message template never wraps it in its own quotes, and quote-escaping it turned out to mangle the bundled pack's own legitimate wording (`Ambiguous: "it is" or "it has".`) — caught by the existing `textlint-tester` fixture test.
- **Fixes #125** — `additional` maps for both vocabulary rules are matched case-insensitively (`termPattern`), so `Use` and `use` silently raced on JSON key order when they disagreed on the replacement. Both rules' option schemas now reject that case via `.superRefine`, reporting `rule-options-invalid` and skipping only the affected rule (mirrors the existing pattern in `mechanics.ts`).
- **Fixes #19** — the bundled provisional pack's doc comment (`src/core/default-pack.ts`) claimed, unconditionally, that nothing in it coincides with ASD-STE100. That's broader than the evidence: no licensed copy of the standard was ever consulted to check. Narrowed to what's actually known.

## Also in this PR

- **Closed #8 and #115 as already fixed** — verified against this branch's history (commits `6667a02` and `952929e`) that both were already resolved; commented with the citations and closed rather than duplicating the work.
- **Independent review, then fixed #127** — `chatgpt-codex-connector`'s automated review failed with a usage-limit message rather than reviewing (this repo's `AGENTS.md` treats that as "no review happened"), so I dispatched a local subagent review as the review of record. It found that `src/textlint/adapter.ts`'s suggestion-message construction was a second, untouched sink for the same untrusted text #123 targets — a gap I'd first filed separately as #127, reasoning it needed its own design decision because the same value also feeds the actual document edit. The reviewer's fix turned out to be the same display-vs-functional-value split already used elsewhere in this PR, so it's fixed here (second commit) and #127 is closed rather than left open.
- **Filed #128** — found `test/integration/pre-write-compliance-hook.test.ts` fails deterministically before `dist/` is built (the hook fails open when the preset can't resolve), not only under CI contention as the test's own comment claims. Confirmed pre-existing via `git stash` before making any changes; filed rather than fixed inline since it's unrelated to this change's scope.

## Test plan

- [x] `vp check` — clean (format + lint + typecheck)
- [x] `vp test` — 847/847 passing
- [x] Regressions: `test/integration/rule-pack.test.ts` (control-character/bidi-override/quote-breakout neutralization, both pack-supplied and project-configured origins), `test/unit/rules.test.ts` (case-conflict rejection for both rules, both key orders, non-conflicting case-equivalent keys still accepted, unrelated rules genuinely still run), `test/e2e/textlint-run.test.ts` (the adapter's rendered suggestion message is sanitized end-to-end through the real textlint kernel)
- [x] Verified the `note`-mangling regression I introduced and reverted, via the pre-existing `textlint-tester` fixture test
- [x] `docs/provisional-rules.md` additions pass the repo's own linter with zero new errors
- [x] Independent local code review completed (see PR comments); its one blocking finding and two non-blocking findings are all addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb1bNXXkHVkbfeD82BZfUN)_