### PR TITLE
fix(textlint): make shared configuration identity lossless

### DIFF
--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 
 import type { SourcePosition, SourceRange, Word } from './types.js';
@@ -136,16 +137,24 @@ export function trimRange(text: string, range: SourceRange): SourceRange {
  * Stable content hash (SHA-256, hex). Deterministic across processes and platforms.
  *
  * Used only as a cache/dedup key (`SemanticTrace.contentHash`, `SemanticBroker`'s request cache,
- * `textlint/adapter.ts`'s config-fingerprint) — an opaque, collision-resistant string, never parsed
- * or compared to a fixed length by any caller. Each part is hashed with a trailing separator so
- * `contentHash('ab', 'c')` and `contentHash('a', 'bc')` cannot collide by concatenation alone, the
- * same property the previous FNV-1a implementation preserved by mixing a delimiter after every part.
+ * `textlint/adapter.ts`'s shared-config fingerprint). Consumers treat the digest as an opaque,
+ * collision-resistant string. Each part is encoded as its UTF-16 code-unit length followed by its
+ * exact UTF-16LE code units. The framing preserves boundaries and lone surrogates.
  */
-export function contentHash(...parts: readonly string[]): string {
+export function contentHashParts(parts: readonly string[]): string {
   const hash = createHash('sha256');
-  for (const part of parts) {
-    hash.update(part);
-    hash.update('\x1f');
+  const length = Buffer.allocUnsafe(8);
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (part === undefined) throw new Error('Content-hash part disappeared during hashing.');
+    length.writeBigUInt64BE(BigInt(part.length));
+    hash.update(length);
+    hash.update(part, 'utf16le');
   }
   return hash.digest('hex');
+}
+
+/** Variadic convenience wrapper for {@link contentHashParts}. */
+export function contentHash(...parts: readonly string[]): string {
+  return contentHashParts(parts);
 }

--- a/src/textlint/adapter.ts
+++ b/src/textlint/adapter.ts
@@ -9,6 +9,7 @@ import { analyseText, type AnalysisResult } from '../analysis/analyse.js';
 import type { SteAiConfigInput } from '../core/config.js';
 import type { Diagnostic } from '../core/types.js';
 import { deterministicRules, findDeterministicRule } from '../deterministic/index.js';
+import { tryConfigFingerprint } from './config-fingerprint.js';
 import { loadSharedConfig } from './shared-config.js';
 
 /**
@@ -67,29 +68,6 @@ const reportedRunNoticesFor = new WeakMap<object, Set<string>>();
 export interface SteRuleOptions {
   readonly shared?: SteAiConfigInput;
   readonly [key: string]: unknown;
-}
-
-/**
- * Serialize a `shared` override for compatibility grouping.
- *
- * Object insertion order is preserved because some rule option maps resolve equal-length keys in
- * insertion order. Arrays preserve JSON's `undefined` and sparse-slot semantics. The grouping key
- * must never combine configurations that can produce different results.
- */
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    const entries = [];
-    for (let i = 0; i < value.length; i += 1) {
-      const entry = value[i];
-      entries.push(entry === undefined ? 'null' : stableStringify(entry));
-    }
-    return `[${entries.join(',')}]`;
-  }
-  if (!isPlainObject(value)) return JSON.stringify(value);
-  const entries = Object.keys(value)
-    .filter((key) => value[key] !== undefined)
-    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
-  return `{${entries.join(',')}}`;
 }
 
 /**
@@ -228,10 +206,9 @@ async function coordinatedAnalysis(
   // once lets every enabled preset rule register its real options before any analysis begins.
   await Promise.resolve();
   run.analyses ??= analyseRegistrationGroups(run.registrations, text, filePath, baseDir);
-  const groupKey = stableStringify(registration.shared ?? {});
-  const analysis = (await run.analyses).get(groupKey);
+  const analysis = (await run.analyses).get(registration.ruleId);
   if (analysis === undefined) {
-    throw new Error(`No analysis group was created for rule "${registration.ruleId}".`);
+    throw new Error(`No analysis was created for rule "${registration.ruleId}".`);
   }
   return analysis;
 }
@@ -243,11 +220,13 @@ async function analyseRegistrationGroups(
   baseDir: string | undefined,
 ): Promise<ReadonlyMap<string, AnalysisResult>> {
   const groups = new Map<
-    string,
+    string | RuleRegistration,
     { shared: SteAiConfigInput | undefined; registrations: RuleRegistration[] }
   >();
   for (const registration of registrations.values()) {
-    const key = stableStringify(registration.shared ?? {});
+    const fingerprint = tryConfigFingerprint(registration.shared ?? {});
+    // An unsafe value gets its own group. Validation still receives the original value below.
+    const key = fingerprint ?? registration;
     const group = groups.get(key);
     if (group === undefined) {
       groups.set(key, { shared: registration.shared, registrations: [registration] });
@@ -258,7 +237,7 @@ async function analyseRegistrationGroups(
 
   const results = new Map<string, AnalysisResult>();
   await Promise.all(
-    [...groups].map(async ([key, group]) => {
+    [...groups.values()].map(async (group) => {
       const invoked = new Set(group.registrations.map(({ ruleId }) => ruleId));
       const options = new Map<string, Record<string, unknown>>();
       for (const rule of deterministicRules) {
@@ -268,7 +247,10 @@ async function analyseRegistrationGroups(
         options.set(registration.ruleId, registration.ownOptions);
       }
       group.registrations[0]?.observer?.analysisStarted(options);
-      results.set(key, await getAnalysis(text, filePath, baseDir, group.shared, options));
+      const analysis = await getAnalysis(text, filePath, baseDir, group.shared, options);
+      for (const registration of group.registrations) {
+        results.set(registration.ruleId, analysis);
+      }
     }),
   );
   return results;

--- a/src/textlint/config-fingerprint.ts
+++ b/src/textlint/config-fingerprint.ts
@@ -1,0 +1,179 @@
+import { types as utilTypes } from 'node:util';
+import { runInNewContext } from 'node:vm';
+import { contentHashParts } from '../core/text.js';
+
+interface CleanIntrinsics {
+  readonly arrayIsArray: ArrayConstructor['isArray'];
+  readonly getOwnPropertyDescriptor: (
+    value: object,
+    key: PropertyKey,
+  ) => PropertyDescriptor | undefined;
+  readonly getPrototypeOf: (value: object) => object | null;
+  readonly numberIsNaN: (value: unknown) => boolean;
+  readonly numberIsSafeInteger: (value: unknown) => boolean;
+  readonly objectIs: (left: unknown, right: unknown) => boolean;
+  readonly ownKeys: (value: object) => PropertyKey[];
+  readonly WeakMap: WeakMapConstructor;
+}
+
+function isCleanIntrinsics(value: unknown): value is CleanIntrinsics {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'arrayIsArray' in value &&
+    typeof value.arrayIsArray === 'function' &&
+    'getOwnPropertyDescriptor' in value &&
+    typeof value.getOwnPropertyDescriptor === 'function' &&
+    'getPrototypeOf' in value &&
+    typeof value.getPrototypeOf === 'function' &&
+    'numberIsNaN' in value &&
+    typeof value.numberIsNaN === 'function' &&
+    'numberIsSafeInteger' in value &&
+    typeof value.numberIsSafeInteger === 'function' &&
+    'objectIs' in value &&
+    typeof value.objectIs === 'function' &&
+    'ownKeys' in value &&
+    typeof value.ownKeys === 'function' &&
+    'WeakMap' in value &&
+    typeof value.WeakMap === 'function'
+  );
+}
+
+const cleanIntrinsicsValue: unknown = runInNewContext(`({
+  arrayIsArray: Array.isArray,
+  getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+  getPrototypeOf: Object.getPrototypeOf,
+  numberIsNaN: Number.isNaN,
+  numberIsSafeInteger: Number.isSafeInteger,
+  objectIs: Object.is,
+  ownKeys: Reflect.ownKeys,
+  WeakMap,
+})`);
+if (!isCleanIntrinsics(cleanIntrinsicsValue)) {
+  throw new Error('Cannot establish clean configuration-fingerprint intrinsics.');
+}
+const cleanIntrinsics = cleanIntrinsicsValue;
+const hostObjectPrototype = cleanIntrinsics.getPrototypeOf({});
+const hostArrayPrototype = cleanIntrinsics.getPrototypeOf([]);
+if (hostObjectPrototype === null || hostArrayPrototype === null) {
+  throw new Error('Cannot establish host configuration prototypes.');
+}
+
+interface FingerprintObjectState {
+  readonly id: number;
+  status: 'visiting' | 'done';
+}
+
+interface FingerprintState {
+  nextId: number;
+  readonly objects: WeakMap<object, FingerprintObjectState>;
+}
+
+function appendPart(parts: string[], part: string): void {
+  parts[parts.length] = part;
+}
+
+/** Append one cache-safe value without expanding repeated references. */
+function appendFingerprint(value: unknown, state: FingerprintState, parts: string[]): boolean {
+  if (value === null) {
+    appendPart(parts, 'null');
+    return true;
+  }
+  if (typeof value === 'string') {
+    appendPart(parts, 'string');
+    appendPart(parts, value);
+    return true;
+  }
+  if (typeof value === 'boolean') {
+    appendPart(parts, 'boolean');
+    appendPart(parts, value ? 'true' : 'false');
+    return true;
+  }
+  if (typeof value === 'number') {
+    if (cleanIntrinsics.objectIs(value, -0)) appendPart(parts, 'number-negative-zero');
+    else if (cleanIntrinsics.numberIsNaN(value)) appendPart(parts, 'number-nan');
+    else if (value === Infinity) appendPart(parts, 'number-positive-infinity');
+    else if (value === -Infinity) appendPart(parts, 'number-negative-infinity');
+    else {
+      appendPart(parts, 'number');
+      appendPart(parts, `${value}`);
+    }
+    return true;
+  }
+  if (typeof value !== 'object' || utilTypes.isProxy(value)) return false;
+
+  const existing = state.objects.get(value);
+  if (existing !== undefined) {
+    if (existing.status === 'visiting') return false;
+    appendPart(parts, 'reference');
+    appendPart(parts, `${existing.id}`);
+    return true;
+  }
+
+  const objectState: FingerprintObjectState = { id: state.nextId, status: 'visiting' };
+  state.nextId += 1;
+  state.objects.set(value, objectState);
+
+  const isArray = cleanIntrinsics.arrayIsArray(value);
+  const prototype = cleanIntrinsics.getPrototypeOf(value);
+  if (
+    isArray
+      ? prototype !== hostArrayPrototype
+      : prototype !== hostObjectPrototype && prototype !== null
+  ) {
+    return false;
+  }
+
+  appendPart(parts, isArray ? 'array-start' : 'object-start');
+  appendPart(parts, `${objectState.id}`);
+  const keys = cleanIntrinsics.ownKeys(value);
+  let entries = 0;
+  for (let keyIndex = 0; keyIndex < keys.length; keyIndex += 1) {
+    const key = keys[keyIndex];
+    if (key === undefined) return false;
+    if (isArray && key === 'length') continue;
+    if (typeof key !== 'string') return false;
+    const descriptor = cleanIntrinsics.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable || !('value' in descriptor))
+      return false;
+    if (isArray) {
+      const index = +key;
+      if (
+        !cleanIntrinsics.numberIsSafeInteger(index) ||
+        index < 0 ||
+        `${index}` !== key ||
+        index >= value.length
+      ) {
+        return false;
+      }
+    }
+    appendPart(parts, 'key');
+    appendPart(parts, key);
+    if (!appendFingerprint(descriptor.value, state, parts)) return false;
+    entries += 1;
+  }
+  if (isArray && entries !== value.length) return false;
+
+  objectState.status = 'done';
+  appendPart(parts, isArray ? 'array-end' : 'object-end');
+  appendPart(parts, `${entries}`);
+  return true;
+}
+
+/** Return no key when equivalence cannot be established without side effects or information loss. */
+export function tryConfigFingerprint(value: unknown): string | undefined {
+  try {
+    const parts: string[] = [];
+    const success = appendFingerprint(
+      value,
+      {
+        nextId: 0,
+        objects: new cleanIntrinsics.WeakMap<object, FingerprintObjectState>(),
+      },
+      parts,
+    );
+    return success ? contentHashParts(parts) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/test/e2e/textlint-run.test.ts
+++ b/test/e2e/textlint-run.test.ts
@@ -117,6 +117,56 @@ describe('textlint lint run', () => {
     expect(starts[0]?.get('no-contractions')).toEqual({});
   });
 
+  it('does not let a malformed shared override join a valid configuration group', async () => {
+    const starts: ReadonlyMap<string, Readonly<Record<string, unknown>>>[] = [];
+    const observer = {
+      analysisStarted: (configuredRules: (typeof starts)[number]) => starts.push(configuredRules),
+    };
+    const result = kernel.lintText('Use the tool.\n', {
+      ...options([]),
+      rules: [
+        {
+          ruleId: 'no-contractions',
+          rule: createSteTextlintRule('no-contractions', observer),
+          options: { shared: { approvedTerms: [] } },
+        },
+        {
+          ruleId: 'punctuation-constraints',
+          rule: createSteTextlintRule('punctuation-constraints', observer),
+          options: { shared: { approvedTerms: [() => 'Utilise'] } },
+        },
+      ],
+    });
+
+    await expect(result).rejects.toThrow(/approvedTerms/);
+    expect(starts).toHaveLength(2);
+  });
+
+  it('keeps insertion-order variants in separate configuration groups', async () => {
+    const starts: ReadonlyMap<string, Readonly<Record<string, unknown>>>[] = [];
+    const observer = {
+      analysisStarted: (configuredRules: (typeof starts)[number]) => starts.push(configuredRules),
+    };
+    const result = await kernel.lintText('Use the tool.\n', {
+      ...options([]),
+      rules: [
+        {
+          ruleId: 'no-contractions',
+          rule: createSteTextlintRule('no-contractions', observer),
+          options: { shared: { approvedTerms: [], extraImperativeVerbs: [] } },
+        },
+        {
+          ruleId: 'punctuation-constraints',
+          rule: createSteTextlintRule('punctuation-constraints', observer),
+          options: { shared: { extraImperativeVerbs: [], approvedTerms: [] } },
+        },
+      ],
+    });
+
+    expect(result.messages).toHaveLength(0);
+    expect(starts).toHaveLength(2);
+  });
+
   it('isolates simultaneous document lifecycles and their rule options', async () => {
     const starts: ReadonlyMap<string, Readonly<Record<string, unknown>>>[] = [];
     const observer = {

--- a/test/unit/config-fingerprint.test.ts
+++ b/test/unit/config-fingerprint.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { tryConfigFingerprint } from '../../src/textlint/config-fingerprint.js';
+
+describe('tryConfigFingerprint', () => {
+  it('distinguishes exact primitive values and insertion order', () => {
+    expect(tryConfigFingerprint({ value: -0 })).not.toBe(tryConfigFingerprint({ value: 0 }));
+    expect(tryConfigFingerprint({ first: 1, second: 2 })).not.toBe(
+      tryConfigFingerprint({ second: 2, first: 1 }),
+    );
+    expect(tryConfigFingerprint({ value: 'a\x1fb' })).not.toBe(
+      tryConfigFingerprint({ value: 'a', b: '' }),
+    );
+  });
+
+  it('rejects values that cannot be read without loss or side effects', () => {
+    let accessorReads = 0;
+    const accessor = {};
+    Object.defineProperty(accessor, 'value', {
+      enumerable: true,
+      get() {
+        accessorReads += 1;
+        return 'unsafe';
+      },
+    });
+    const proxy = new Proxy({}, { ownKeys: () => ['hidden'] });
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+
+    expect(tryConfigFingerprint({ values: [() => 'unsafe'] })).toBeUndefined();
+    expect(tryConfigFingerprint(accessor)).toBeUndefined();
+    expect(accessorReads).toBe(0);
+    expect(tryConfigFingerprint(proxy)).toBeUndefined();
+    expect(tryConfigFingerprint(cyclic)).toBeUndefined();
+  });
+
+  it('bounds repeated acyclic references by unique object count', () => {
+    let graph: object = { leaf: true };
+    for (let depth = 0; depth < 30; depth += 1) graph = { left: graph, right: graph };
+
+    expect(tryConfigFingerprint(graph)).toBeDefined();
+  });
+
+  it('does not trust host reflection replacements present before module evaluation', async () => {
+    vi.resetModules();
+    const originalOwnKeys = Reflect.ownKeys;
+    const originalDescriptor = Reflect.getOwnPropertyDescriptor;
+    const originalGetPrototypeOf = Object.getPrototypeOf;
+    Reflect.ownKeys = (target: object): (string | symbol)[] => {
+      const keys = originalOwnKeys(target);
+      return originalDescriptor(target, 'approvedTerms') === undefined
+        ? keys
+        : keys.filter((key) => key !== 'approvedTerms');
+    };
+    Object.getPrototypeOf = (target: object): object | null =>
+      target instanceof Date ? Object.prototype : originalGetPrototypeOf(target);
+    try {
+      const reloaded = await import('../../src/textlint/config-fingerprint.js');
+      expect(reloaded.tryConfigFingerprint({ approvedTerms: [] })).not.toBe(
+        reloaded.tryConfigFingerprint({ approvedTerms: ['Utilise'] }),
+      );
+      expect(reloaded.tryConfigFingerprint(new Date(0))).toBeUndefined();
+    } finally {
+      Reflect.ownKeys = originalOwnKeys;
+      Object.getPrototypeOf = originalGetPrototypeOf;
+      vi.resetModules();
+    }
+  });
+});

--- a/test/unit/content-hash.test.ts
+++ b/test/unit/content-hash.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { contentHash, contentHashParts } from '../../src/core/text.js';
+
+describe('contentHash', () => {
+  it('frames parts whose values contain the former delimiter', () => {
+    expect(contentHash('a', 'b\x1fc')).not.toBe(contentHash('a\x1fb', 'c'));
+  });
+
+  it('preserves lone UTF-16 surrogates', () => {
+    expect(contentHash('\ud800')).not.toBe(contentHash('\ufffd'));
+  });
+
+  it('streams the same framed parts without a variadic argument list', () => {
+    expect(contentHashParts(['a', 'b\x1fc'])).toBe(contentHash('a', 'b\x1fc'));
+  });
+});


### PR DESCRIPTION
Follow-up to #117, rebased conceptually onto the document-lifecycle design merged by #126.

## Problem

The adapter's `stableStringify` could assign the same group key to different runtime values. For example, an array containing a function serialized like an empty array. A malformed `shared` override could therefore join a valid group and avoid its own validation failure.

The shared `contentHash` helper also framed parts with a literal separator. Inputs containing that separator could move the apparent part boundary. UTF-8 hashing also replaced lone UTF-16 surrogates.

## Changes

- Replace lossy serialization with an order-preserving typed graph fingerprint.
- Isolate proxies, accessors, cycles, exotic objects, and unsupported values instead of grouping them.
- Use clean-realm reflection intrinsics for the grouping decision.
- Return grouped analyses by rule id, so unsafe configurations can receive unique groups.
- Frame hash parts by UTF-16 code-unit length and hash exact UTF-16LE code units.
- Add end-to-end and unit regressions for malformed arrays, insertion order, aliases, cycles, accessors, proxies, signed zero, control characters, lone surrogates, and replaced host reflection functions.

The obsolete process-wide cache, rejection-eviction, and file-pack snapshot changes from the unpushed #117 work were not carried forward because #126 removed that cache architecture.

## Performance

A synthetic 1 MB ASCII hash averaged 1.07 ms with separator framing and 2.42 ms with exact UTF-16 framing over 30 local runs. The measured increase was about 1.35 ms per MB. Shared configuration fingerprints are much smaller.

## Verification

- `vp check`
- `vp pack`
- `vp test --coverage`
- fixture provenance and corpus integrity
- CLI exit-code contract
- provisional-rule, candidate-ground-truth, and annotation-provenance assertions
- shipped textlint configuration resolution
- pre-commit hook manifest assertion
- worked rule-pack example assertion
- dogfood lint ratchet

An unrelated current-main test cleanup defect discovered during verification is tracked in #134.