### PR TITLE
Add delegation model-tier, dynamic-workflow, and commit-hygiene rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,32 @@ of those tests or CI assertion scripts now assert the old behavior. Update only 
 actually affects, not every file discovery turned up. Definition of done includes removing or
 updating stale tests, CI assertion scripts, and documentation. It is not enough to only add new ones.
 
+## Commit hygiene
+
+Prefer smaller sequential commits when a task touches multiple concerns. Split the work along
+those concern boundaries. One commit per concern reviews better than one commit carrying all of
+them.
+
+## Delegating to subagents
+
+Set the `model` parameter explicitly on every delegated call. This covers `Agent`-tool calls and
+`agent()` calls inside a workflow script alike. Omitting the parameter silently inherits the
+session model.
+
+- `haiku` — mechanical bulk work. Renames, boilerplate, format conversion, and log triage fit here.
+- `sonnet` — the default tier. It suits well-specified implementation with clear acceptance
+  criteria.
+- `opus` — genuinely tricky work. Concurrency, subtle algorithms, adversarial verify panels, and
+  gnarly debugging fit here.
+- `fable` — rare. It earns its cost only when independence from the orchestrator's own context is
+  the point. An adversarial review of the orchestrator's own plan is one example. A large diff is
+  another.
+
+Never spawn a `fable` subagent unprompted. Ask the user first, even when the task's complexity
+warrants one.
+
+Pick the cheaper tier when the choice between two is unclear. Escalate on failure.
+
 ## Delegation gotchas
 
 Read this before dispatching subagents in bulk.
@@ -174,6 +200,23 @@ orchestrator's own direct action, at the same path the same agent already owned.
 `Agent`-tool dispatch. So it stays inside the exception above for orchestrator-performed worktree
 recovery. This differs from a worktree that has real uncommitted edits destroyed outright. Here,
 there is nothing to lose but the empty directory.
+
+## Dynamic workflows (`Workflow` tool)
+
+This section applies to every session, on any model. A dynamic workflow is not something to avoid.
+Reach for the `Workflow` tool when a task has three or more independent parallelizable subtasks.
+Reach for it too when a task benefits from a pipeline or a judge panel.
+
+Opt-in is a standing rule. Invoke the tool directly when ultracode is on for the session.
+Three signals turn ultracode on. The user types the "ultracode" keyword. The user sets the
+toggle. The user asks for orchestration in their own words. Otherwise propose the workflow first. One or two sentences
+covering the rough shape and cost is enough. Wait for the user's reply. Their "yes" is the opt-in.
+
+Every `agent()` call inside a workflow script must set the `model` parameter explicitly. Choose
+the tier per "Delegating to subagents" above, with one tightening. Never use a `fable` agent in a
+dynamic workflow. Approval does not lift that. Only `haiku`, `sonnet`, and `opus` belong in a
+workflow stage. A warranted `fable` review runs after the workflow completes instead. It runs as a
+standalone `Agent`-tool call. It still needs the user's approval first.
 
 ## Verifying what an agent did: query its session log, not git state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,13 +107,21 @@ them.
 
 ## Delegating to subagents
 
-Set the `model` parameter explicitly on every delegated call. This covers `Agent`-tool calls and
+Every delegated call gets a right-sized model. Two failures break that rule. An accidental model is
+one picked without matching the work to a size. An inherited model is one the harness supplied
+because the call omitted the `model` parameter.
+
+So set the `model` parameter explicitly on every delegated call. This covers `Agent`-tool calls and
 `agent()` calls inside a workflow script alike. Omitting the parameter silently inherits the
 session model.
 
-Each tier below names its Anthropic model first and its OpenAI counterpart second. Only the
-Anthropic names are valid `model` values for the `Agent` tool in this repository. Read the OpenAI
-name as the matching tier to pick when the work runs on another harness.
+The tiers below are size classes, not a closed list of names. Each one names its Anthropic model
+first and its OpenAI counterpart second. Any other vendor's model substitutes freely at the
+equivalent size. Match the size class rather than the name.
+
+One limit applies to that substitution. The `Agent` tool in this repository accepts only the
+Anthropic names as `model` values. Substitute by size when the work runs on another harness. Pass
+the Anthropic name when the work runs on this one.
 
 - **Small** — `haiku`, `luna`. Quick bounded work. Renames, boilerplate, format conversion, and
   log triage fit here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,15 +111,19 @@ Set the `model` parameter explicitly on every delegated call. This covers `Agent
 `agent()` calls inside a workflow script alike. Omitting the parameter silently inherits the
 session model.
 
-- `haiku` — mechanical bulk work. Renames, boilerplate, format conversion, and log triage fit
-  here.
-- `sonnet` — the default tier. It suits well-specified implementation with clear acceptance
-  criteria.
-- `opus` — genuinely tricky work. Concurrency, subtle algorithms, adversarial verify panels, and
-  gnarly debugging fit here.
-- `fable` — rare. It earns its cost only when independence from the orchestrator's own context is
-  the point. An adversarial review of the orchestrator's own plan is one example. A large diff is
-  another.
+Each tier below names its Anthropic model first and its OpenAI counterpart second. Only the
+Anthropic names are valid `model` values for the `Agent` tool in this repository. Read the OpenAI
+name as the matching tier to pick when the work runs on another harness.
+
+- **Small** — `haiku`, `luna`. Quick bounded work. Renames, boilerplate, format conversion, and
+  log triage fit here.
+- **Medium** — `sonnet`, `terra`. The default tier. It suits standard instruction-driven work with
+  clear acceptance criteria.
+- **Large** — `opus`, `sol`. Architecture, coordination, and planning. Concurrency, subtle
+  algorithms, adversarial verify panels, and gnarly debugging fit here too.
+- **Independent** — `fable`. No size tier fits this one. It earns its cost only when independence
+  from the orchestrator's own context is the point. An adversarial review of the orchestrator's own
+  plan is one example. A large diff is another.
 
 Never spawn a `fable` subagent unprompted. Ask the user first, even when the task's complexity
 warrants one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,34 +115,28 @@ So set the `model` parameter explicitly on every delegated call. This covers `Ag
 `agent()` calls inside a workflow script alike. Omitting the parameter silently inherits the
 session model.
 
-The tiers below are size classes, not a closed list of names. Each one names an Anthropic model
-first and its OpenAI counterpart second. Both names are anchors. Neither defines the class.
+The classes below are sizes, not a closed list of names. Each one names an Anthropic model first
+and its OpenAI counterpart second. Both are anchors. Neither defines the class.
 
-Some harnesses expose a far wider model list than those two vendors. Kilo Code and OpenCode are two
-of them. Place any unlisted model by its own position inside its vendor's family. The fast and
-cheap member of a family is Small. The balanced everyday member is Medium. The flagship reasoning
-member is Large. Match that position rather than any name written here.
-
-Treat a model as the smaller class when its position is unclear. The escalation rule below covers
-the case where that choice proves wrong.
-
-One limit applies on this repository's own harness. The `Agent` tool accepts only the Anthropic
-names as `model` values. Substitute by size class anywhere else.
+Select from the models your own harness offers. Pick the one whose size fits the task. Kilo Code
+and OpenCode each expose a far wider list than those two vendors. A harness knows the sizes in its
+own catalogue. Claude Code is the narrow case. Its `Agent` tool accepts only `haiku`, `sonnet`,
+`opus`, and `fable` as `model` values.
 
 - **Small** — `haiku`, `luna`. Quick bounded work. Renames, boilerplate, format conversion, and
   log triage fit here.
-- **Medium** — `sonnet`, `terra`. The default tier. It suits standard instruction-driven work with
+- **Medium** — `sonnet`, `terra`. The default class. It suits standard instruction-driven work with
   clear acceptance criteria.
 - **Large** — `opus`, `sol`. Architecture, coordination, and planning. Concurrency, subtle
   algorithms, adversarial verify panels, and gnarly debugging fit here too.
-- **Independent** — `fable`. No size tier fits this one. It earns its cost only when independence
+- **Independent** — `fable`. No size class fits this one. It earns its cost only when independence
   from the orchestrator's own context is the point. An adversarial review of the orchestrator's own
   plan is one example. A large diff is another.
 
 Never spawn a `fable` subagent unprompted. Ask the user first, even when the task's complexity
 warrants one.
 
-Pick the cheaper tier when the choice between two is unclear. Escalate the tier on a
+Pick the cheaper class when the choice between two is unclear. Escalate the class on a
 quality-of-output failure. Do not escalate on a session-limit or token-limit failure. That case is
 retryable instead. See `## Delegation gotchas` below.
 
@@ -236,7 +230,7 @@ One or two sentences covering the rough shape and cost is enough. Wait for the u
 Their "yes" is the opt-in.
 
 Every `agent()` call inside a workflow script must set the `model` parameter explicitly. Choose
-the tier per "Delegating to subagents" above, with one tightening. Never use a `fable` agent in a
+the class per "Delegating to subagents" above, with one tightening. Never use a `fable` agent in a
 dynamic workflow. Approval does not lift that. Only `haiku`, `sonnet`, and `opus` belong in a
 workflow stage. A warranted `fable` review runs after the workflow completes instead. It runs as a
 standalone `Agent`-tool call. It still needs the user's approval first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,9 @@ session model.
 Never spawn a `fable` subagent unprompted. Ask the user first, even when the task's complexity
 warrants one.
 
-Pick the cheaper tier when the choice between two is unclear. Escalate on failure.
+Pick the cheaper tier when the choice between two is unclear. Escalate the tier on a
+quality-of-output failure. Do not escalate on a session-limit or token-limit failure. That case is
+retryable instead. See `## Delegation gotchas` below.
 
 ## Delegation gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,11 @@ own catalogue. Claude Code is the narrow case. Its `Agent` tool accepts only `ha
   from the orchestrator's own context is the point. An adversarial review of the orchestrator's own
   plan is one example. A large diff is another.
 
+Small models make excellent validators. A bounded criteria list is what they are best at. So follow
+a piece of work by sending a small fast model to check it against stated criteria. Have it report
+what passed and what failed. This spends little time and few tokens. It also puts a second reader
+on the work.
+
 Never spawn a `fable` subagent unprompted. Ask the user first, even when the task's complexity
 warrants one.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,8 +205,9 @@ there is nothing to lose but the empty directory.
 ## Dynamic workflows (`Workflow` tool)
 
 This section applies to every session, on any model. A dynamic workflow is not something to avoid.
-Reach for the `Workflow` tool when a task has three or more independent parallelizable subtasks.
-Reach for it too when a task benefits from a pipeline or a judge panel.
+Consider the `Workflow` tool when a task has three or more independent parallelizable subtasks.
+Consider it too when a task benefits from a pipeline or a judge panel. Then apply the opt-in rule
+below, before invoking it.
 
 Opt-in is a standing rule. Invoke the tool directly when ultracode is on for the session.
 Three signals turn ultracode on. The user types the "ultracode" keyword. The user sets the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,13 +115,19 @@ So set the `model` parameter explicitly on every delegated call. This covers `Ag
 `agent()` calls inside a workflow script alike. Omitting the parameter silently inherits the
 session model.
 
-The tiers below are size classes, not a closed list of names. Each one names its Anthropic model
-first and its OpenAI counterpart second. Any other vendor's model substitutes freely at the
-equivalent size. Match the size class rather than the name.
+The tiers below are size classes, not a closed list of names. Each one names an Anthropic model
+first and its OpenAI counterpart second. Both names are anchors. Neither defines the class.
 
-One limit applies to that substitution. The `Agent` tool in this repository accepts only the
-Anthropic names as `model` values. Substitute by size when the work runs on another harness. Pass
-the Anthropic name when the work runs on this one.
+Some harnesses expose a far wider model list than those two vendors. Kilo Code and OpenCode are two
+of them. Place any unlisted model by its own position inside its vendor's family. The fast and
+cheap member of a family is Small. The balanced everyday member is Medium. The flagship reasoning
+member is Large. Match that position rather than any name written here.
+
+Treat a model as the smaller class when its position is unclear. The escalation rule below covers
+the case where that choice proves wrong.
+
+One limit applies on this repository's own harness. The `Agent` tool accepts only the Anthropic
+names as `model` values. Substitute by size class anywhere else.
 
 - **Small** — `haiku`, `luna`. Quick bounded work. Renames, boilerplate, format conversion, and
   log triage fit here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,8 @@ Set the `model` parameter explicitly on every delegated call. This covers `Agent
 `agent()` calls inside a workflow script alike. Omitting the parameter silently inherits the
 session model.
 
-- `haiku` — mechanical bulk work. Renames, boilerplate, format conversion, and log triage fit here.
+- `haiku` — mechanical bulk work. Renames, boilerplate, format conversion, and log triage fit
+  here.
 - `sonnet` — the default tier. It suits well-specified implementation with clear acceptance
   criteria.
 - `opus` — genuinely tricky work. Concurrency, subtle algorithms, adversarial verify panels, and
@@ -209,8 +210,9 @@ Reach for it too when a task benefits from a pipeline or a judge panel.
 
 Opt-in is a standing rule. Invoke the tool directly when ultracode is on for the session.
 Three signals turn ultracode on. The user types the "ultracode" keyword. The user sets the
-toggle. The user asks for orchestration in their own words. Otherwise propose the workflow first. One or two sentences
-covering the rough shape and cost is enough. Wait for the user's reply. Their "yes" is the opt-in.
+toggle. The user asks for orchestration in their own words. Otherwise propose the workflow first.
+One or two sentences covering the rough shape and cost is enough. Wait for the user's reply.
+Their "yes" is the opt-in.
 
 Every `agent()` call inside a workflow script must set the `model` parameter explicitly. Choose
 the tier per "Delegating to subagents" above, with one tightening. Never use a `fable` agent in a


### PR DESCRIPTION
## What changed

Three new sections in `AGENTS.md`, integrating instruction text supplied as a screenshot.

### `## Commit hygiene`

Split a task that touches multiple concerns into smaller sequential commits.

### `## Delegating to subagents`

Placed immediately before the existing `## Delegation gotchas`, so selection reads ahead of dispatch
mechanics.

The section leads with the goal it serves: every delegated call gets a right-sized model. It names
the two failures that rule exists to prevent. An accidental model is one picked without matching the
work to a size. An inherited model is one the harness supplied because the call omitted the `model`
parameter. Hence the standing rule to set that parameter explicitly on every delegated call,
covering `Agent`-tool calls and `agent()` calls in a workflow script alike.

The classes are sizes rather than a closed list of names:

- **Small** — `haiku`, `luna`
- **Medium** — `sonnet`, `terra`
- **Large** — `opus`, `sol`
- **Independent** — `fable`, which no size class describes

Both named vendors are anchors, not the definition of a class. The selection rule is written to be
readable from whichever harness is running it: select from the models your own harness offers, and
pick the one whose size fits the task. Kilo Code and OpenCode each expose a far wider list than
those two vendors, and a harness knows the sizes in its own catalogue. Claude Code is named as the
narrow case, because its `Agent` tool accepts only `haiku`, `sonnet`, `opus`, and `fable` as `model`
values.

No version string is recorded for any vendor. A pinned series number goes stale on the next release,
and the class names carry the meaning.

The Small class carries a standing use beyond bulk work: a bounded criteria list is what a small
model is best at, so a piece of work is followed by sending one in to check it against stated
criteria and report what passed and what failed.

A `fable` subagent is never spawned unprompted. The closing rule picks the cheaper class when the
choice is unclear, and escalates on a quality-of-output failure — explicitly not on a session-limit
or token-limit failure, which the existing gotcha already says is retryable.

### `` ## Dynamic workflows (`Workflow` tool) ``

Placed after `## Delegation gotchas`. Covers when to consider the tool (three or more independent
parallelizable subtasks, or a pipeline or judge panel), the ultracode opt-in rule that gates
invoking it, and the tightening that bans `fable` from any workflow stage even with approval. A
warranted `fable` review runs afterwards, as a standalone `Agent`-tool call.

## Notes on the adaptation

The source text was not pasted verbatim. Three adjustments:

- **Voice.** The source is written in a user's first person ("check with me first", "my reply").
  `AGENTS.md` addresses the agent, so those became "ask the user first" and "the user's reply".
- **Spelling.** The source writes "sub-agents". This file already uses "subagent" throughout, so
  the new sections match the file.
- **Prose constraints.** The source uses semicolons joining independent clauses and long
  multi-clause sentences, both of which this repository's own preset rejects. Every sentence was
  rewritten to the shapes in `.claude/skills/ste-ai-prose-style/SKILL.md`.

## Review

Codex declined this review on usage limits, which AGENTS.md treats as no review having happened. A
subagent fact-check ran instead as the review of record, dispatched with `isolation: "worktree"` and
detached at the then-current head. Verdict: approve with nits. Two findings were real and are fixed,
one commit each — see the review comment on this PR for the full record.

## Verification

Toolchain bootstrapped per `AGENTS.md`: `npx -p vite-plus@0.3.0 vp install --frozen-lockfile`, with
`git diff package-lock.json` empty afterwards, then `vp pack` to build `dist/`.

- `node_modules/.bin/textlint -f compact AGENTS.md` — zero error-severity findings.
- `node scripts/ci/check-dogfood-lint.mjs` — "dogfood lint holds: 16 files carry 1338 recorded
  errors, and nothing regressed." `AGENTS.md` still has no baseline entry, so it stays clean rather
  than accruing recorded debt.
- `vp check` — "All 176 files are correctly formatted", "Found no warnings, lint errors, or type
  errors in 120 files".

Both linter checks were re-run after every edit in this branch, including each review fix.

Per `## Discover docs and tests before a functional change`, I searched for anything asserting this
file's content. The `AGENTS.md` hits in `test/integration/plugin-contract.test.ts` write their own
fixture files in temporary repositories and never read this one, and `skills/pre-push-review/SKILL.md`
refers to `AGENTS.md` files generically rather than to any section here. Nothing needed reconciling.

## Scope note

The source screenshot began mid-list at an item numbered 6. The author has confirmed that the
captured text is the whole of what was wanted, and that the preceding list items are out of scope
here. That item stands as the `## Commit hygiene` section.

## Issues found while working here

Both logged rather than fixed, per the rule against widening a change. Nothing in this PR depends on
either.

- #140 — the repository's own pre-commit hook formats Markdown but never lints it, so prose debt
  only surfaces in CI.
- #141 — `number-unit-format` reads a decimal's fractional part as a unit, so any bare decimal such
  as `3.11` produces an unsatisfiable error-level finding. Hit while writing a version number into
  this very diff, which is why no version string appears in the final text.