### PR TITLE
Fix two silent-drop notice bugs; hoist redundant per-rule/per-pair work

### DIFF
--- a/docs/design/64-layered-rule-packs/02-authority-trust.md
+++ b/docs/design/64-layered-rule-packs/02-authority-trust.md
@@ -101,19 +101,18 @@ The same principle is restated in config: `src/core/config.ts:126-132`:
 
 ### Where it is enforced today
 
-| Site                            | Code                                                 | What it caps                                                                    |
-| ------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `src/rule-pack/loader.ts:80-82` | `packPermitsConformanceClaim`                        | whether output may use conformance wording                                      |
-| `src/rule-pack/loader.ts:96-97` | `verifiedAuthority`                                  | run-level authority scalar                                                      |
-| `src/core/runner.ts`            | `verifiedRuleStatus` (private)                       | the `ruleStatus` on a pack-supplied rule's diagnostics                          |
-| `src/analysis/analyse.ts:292`   | `verifiedAuthority(pack, config.trustedRulePackIds)` | `ruleStatus` on `review-required` diagnostics                                   |
-| `src/analysis/analyse.ts:607`   | `verifiedAuthority(pack, config.trustedRulePackIds)` | `ruleStatus` on every semantic diagnostic                                       |
-| `src/cli/main.ts:190-196`       | both loader functions                                | `packAuthority`, `declaredAuthority`, `conformanceClaim` per file in CLI output |
+| Site                      | Code                                                 | What it caps                                                                    |
+| ------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `src/rule-pack/loader.ts` | `packPermitsConformanceClaim`                        | whether output may use conformance wording                                      |
+| `src/rule-pack/loader.ts` | `verifiedAuthority`                                  | run-level authority scalar                                                      |
+| `src/core/runner.ts`      | `verifiedRuleStatus` (private)                       | the `ruleStatus` on a pack-supplied rule's diagnostics                          |
+| `src/analysis/analyse.ts` | `verifiedAuthority(pack, config.trustedRulePackIds)` | `ruleStatus` on `review-required` diagnostics                                   |
+| `src/analysis/analyse.ts` | `verifiedAuthority(pack, config.trustedRulePackIds)` | `ruleStatus` on every semantic diagnostic                                       |
+| `src/cli/main.ts`         | both loader functions                                | `packAuthority`, `declaredAuthority`, `conformanceClaim` per file in CLI output |
 
-All four enforcement points take a single `RulePack`. `resolveRulePack` returns exactly one
-(`src/rule-pack/loader.ts:49-56`), and `prepareRun` binds it once for the run
-(`src/analysis/analyse.ts:244`), passing it into every rule as `RuleInput.pack`
-(`src/core/runner.ts:81-89`).
+All four enforcement points take a single `RulePack`. `resolveRulePack` (`src/rule-pack/loader.ts`)
+returns exactly one, and `prepareRun` (`src/analysis/analyse.ts`) binds it once for the run, passing
+it into every rule as `RuleInput.pack` (`src/core/runner.ts`).
 
 ### Structural facts that matter for what follows
 

--- a/src/analysis/analyse.ts
+++ b/src/analysis/analyse.ts
@@ -602,7 +602,7 @@ function undecidedCandidateDiagnostics(
       {
         code: 'semantic-disabled',
         level: 'info',
-        message: semanticNotRunNoticeMessage(candidates.length),
+        message: semanticNotRunNoticeMessage(candidates.length, config.semantic.enabled),
         detail: { candidates: candidates.length },
       },
     ],

--- a/src/core/document.ts
+++ b/src/core/document.ts
@@ -96,17 +96,31 @@ export interface DocumentPreparation {
   readonly regions: readonly ProtectedRegion[];
 }
 
-export function prepareDocument(
-  doc: SourceDocument,
+/**
+ * The one formula for merging a document's format with caller-supplied protected-region options.
+ * Shared by {@link prepareDocument} (which uses the result) and {@link analyseDocument}'s
+ * preparation-ownership check (which only needs it to compare against an already-prepared value) —
+ * a hand-duplicated copy of this formula in the latter would drift from the former unnoticed if a
+ * field were ever added here.
+ */
+function mergedProtectedRegionOptions(
+  format: SourceDocument['format'],
   options: Partial<ProtectedRegionOptions> = {},
-): DocumentPreparation {
-  const protectedOptions: ProtectedRegionOptions = {
+): ProtectedRegionOptions {
+  return {
     ...defaultProtectedRegionOptions,
-    format: doc.format,
+    format,
     ...options,
     approvedTerms: [...(options.approvedTerms ?? defaultProtectedRegionOptions.approvedTerms)],
     extraPatterns: [...(options.extraPatterns ?? defaultProtectedRegionOptions.extraPatterns)],
   };
+}
+
+export function prepareDocument(
+  doc: SourceDocument,
+  options: Partial<ProtectedRegionOptions> = {},
+): DocumentPreparation {
+  const protectedOptions = mergedProtectedRegionOptions(doc.format, options);
   const detectionText = normalizeLineEndings(doc.text);
   return {
     sourceText: doc.text,
@@ -180,21 +194,30 @@ export function analyseDocument(
 
   // Detection runs against a copy whose CRLF carriage returns are spaces. Length is preserved, so
   // every range is equally valid against `doc.text`, which is what all `raw` slices come from.
+  //
+  // The ownership check below only applies when a caller supplied its own `preparation` (the
+  // production analysis layer, reusing one `prepareDocument` call across every rule for a
+  // document): only then can it possibly mismatch `doc`/`options.protectedRegions`. When this
+  // function computes `preparation` itself, on the line right above, it is by construction built
+  // from the very `doc`/`options.protectedRegions` being checked against — recomputing and
+  // comparing on every call added the cost of the check to the common (no-reuse) path for a result
+  // already guaranteed by construction.
   const preparation = options.preparation ?? prepareDocument(doc, options.protectedRegions);
-  const expectedProtectedOptions: ProtectedRegionOptions = {
-    ...defaultProtectedRegionOptions,
-    format: doc.format,
-    ...options.protectedRegions,
-  };
-  const preparedOptions = preparation.protectedOptions;
-  if (
-    preparation.sourceText !== doc.text ||
-    preparation.format !== doc.format ||
-    preparedOptions.format !== expectedProtectedOptions.format ||
-    !equalStringArrays(preparedOptions.approvedTerms, expectedProtectedOptions.approvedTerms) ||
-    !equalStringArrays(preparedOptions.extraPatterns, expectedProtectedOptions.extraPatterns)
-  ) {
-    throw new Error('Document preparation does not belong to this source and configuration.');
+  if (options.preparation !== undefined) {
+    const expectedProtectedOptions = mergedProtectedRegionOptions(
+      doc.format,
+      options.protectedRegions,
+    );
+    const preparedOptions = preparation.protectedOptions;
+    if (
+      preparation.sourceText !== doc.text ||
+      preparation.format !== doc.format ||
+      preparedOptions.format !== expectedProtectedOptions.format ||
+      !equalStringArrays(preparedOptions.approvedTerms, expectedProtectedOptions.approvedTerms) ||
+      !equalStringArrays(preparedOptions.extraPatterns, expectedProtectedOptions.extraPatterns)
+    ) {
+      throw new Error('Document preparation does not belong to this source and configuration.');
+    }
   }
   const { detectionText, regions } = preparation;
   const opaqueRanges = opaqueRangesOf(regions);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -74,6 +74,18 @@ export function runDeterministicRules(options: RunOptions): DeterministicRunResu
 
   notices.push(...unknownRuleIdNotices(config, rules));
 
+  // Whether the *pack itself* is trusted, independent of what any one rule entry declares. Hoisted
+  // above the loop: `pack` and `config.trustedRulePackIds` are the same for every rule this run, so
+  // this is a single membership check per document, not one per enabled rule.
+  const packTrusted = config.trustedRulePackIds.includes(pack.metadata.id);
+
+  // `pack.metadata.id` is invariant for the whole run, so its safety check (see the citation-safety
+  // comment at this value's one use site below) and the resulting display string are computed once
+  // here rather than once per diagnostic an untrusted pack's rules produce.
+  const safePackId = isSafeRulePackId(pack.metadata.id)
+    ? pack.metadata.id
+    : '<id omitted: does not match the expected pack-id format>';
+
   for (const rule of rules) {
     const id = rule.meta.id;
     if (options.onlyRuleId !== undefined && options.onlyRuleId !== id) continue;
@@ -119,27 +131,36 @@ export function runDeterministicRules(options: RunOptions): DeterministicRunResu
     // A pack may raise a rule's authority and supply its own citation. Without this the pack's
     // `status`/`sourceRef` were parsed, validated and then ignored, so an authorised pack changed
     // nothing a reader could see. `verifiedAuthority` still caps an untrusted pack.
-    const packStatus =
+    //
+    // Bundled as one value, rather than a separate `packStatus` alongside `packSpec`: the two used
+    // to be checked independently below (`packSpec === undefined || packStatus === undefined`)
+    // even though `verifiedRuleStatus` never returns `undefined`, so the second half of that check
+    // could only ever agree with the first — one derived value with one `undefined` check keeps
+    // that redundancy from silently reappearing if a future edit to `verifiedRuleStatus` legitimately
+    // introduces its own `undefined` case, which the old pair of checks would have then conflated
+    // with "no pack entry for this rule."
+    const packInfo =
       packSpec === undefined
         ? undefined
-        : verifiedRuleStatus(packSpec.status, pack, config.trustedRulePackIds);
+        : {
+            spec: packSpec,
+            status: verifiedRuleStatus(packSpec.status, pack, config.trustedRulePackIds),
+          };
 
-    // Whether the *pack itself* is trusted, independent of what any one rule entry declares.
-    // `sourceRef` trust cannot be inferred from whether `packStatus` was downgraded (#66's original
-    // gap): an untrusted pack that declares `status: "supplementary"` directly, rather than
-    // `"normative"`, is never downgraded — `verifiedRuleStatus` only ever touches a `"normative"`
-    // declaration — so gating on the downgrade let that pack's citation straight through.
-    const packTrusted = config.trustedRulePackIds.includes(pack.metadata.id);
-
+    // `sourceRef` trust (via `packTrusted`, hoisted above the loop) cannot be inferred from whether
+    // `packInfo.status` was downgraded (#66's original gap): an untrusted pack that declares
+    // `status: "supplementary"` directly, rather than `"normative"`, is never downgraded —
+    // `verifiedRuleStatus` only ever touches a `"normative"` declaration — so gating on the downgrade
+    // let that pack's citation straight through.
     for (const diagnostic of output.diagnostics) {
       const processed = postProcess(diagnostic, rule, doc, config, blockById, severityOverride);
       if (processed === null) continue;
       diagnostics.push(
-        packSpec === undefined || packStatus === undefined
+        packInfo === undefined
           ? processed
           : {
               ...processed,
-              ruleStatus: packStatus,
+              ruleStatus: packInfo.status,
               meta: {
                 ...processed.meta,
                 // String-comparing `sourceRef` against `rule.meta.sourceRef` was tried and found
@@ -171,8 +192,8 @@ export function runDeterministicRules(options: RunOptions): DeterministicRunResu
                 // closes the class instead of extending the list.
                 sourceRef:
                   pack === provisionalRulePack || packTrusted
-                    ? packSpec.sourceRef
-                    : `unverified citation from untrusted rule pack "${isSafeRulePackId(pack.metadata.id) ? pack.metadata.id : '<id omitted: does not match the expected pack-id format>'}"`,
+                    ? packInfo.spec.sourceRef
+                    : `unverified citation from untrusted rule pack "${safePackId}"`,
               },
             },
       );

--- a/src/deterministic/helpers.ts
+++ b/src/deterministic/helpers.ts
@@ -382,11 +382,15 @@ export function findCaseConflicts<T>(
         if (current === undefined) continue;
         const group: [string, T][] = [current];
         consumed.add(i);
+        // `sameTermSpan(current[0], ...)` would recompile the same pattern from `current[0]` on
+        // every `j` below; `current` is fixed for the whole inner loop, so the pattern (identical
+        // to what `sameTermSpan` itself builds) is built once here and reused via `.test()`.
+        const currentPattern = new RegExp(`^${escapeForMatching(current[0])}$`, 'iu');
         for (let j = i + 1; j < bucket.length; j++) {
           if (consumed.has(j)) continue;
           const candidate = bucket[j];
           if (candidate === undefined) continue;
-          if (sameTermSpan(current[0], candidate[0])) {
+          if (currentPattern.test(candidate[0].trim())) {
             group.push(candidate);
             consumed.add(j);
           }

--- a/src/semantic/analyse.ts
+++ b/src/semantic/analyse.ts
@@ -42,9 +42,21 @@ export function undecidedCandidateReasonMessage(reason: string): string {
   return `Semantic adjudication did not run, so this candidate was not decided. A reviewer must decide it. Reason: ${reason}`;
 }
 
-/** Companion to {@link undecidedCandidateReasonMessage} for the run-notice summary line. */
-export function semanticNotRunNoticeMessage(count: number): string {
-  return `${count} passage(s) needed semantic adjudication, which is disabled. They are reported as review-required. No compliance conclusion was drawn about them.`;
+/**
+ * Companion to {@link undecidedCandidateReasonMessage} for the run-notice summary line.
+ *
+ * `enabled` names the call site's own `config.semantic.enabled`, not merely "did adjudication
+ * happen": {@link analyseTextDeterministic}'s `undecidedCandidateDiagnostics` (`../analysis/
+ * analyse.ts`) calls this unconditionally on the deterministic-only path, which never contacts the
+ * semantic service regardless of what `config.semantic.enabled` says — so a caller that enables
+ * semantic adjudication in config but still invokes that entry point directly would otherwise get
+ * a message falsely claiming the feature itself is disabled. `analyseSemantically`'s own call
+ * below reaches this notice only when `config.semantic.enabled` is genuinely false (or a candidate's
+ * evaluator is not configured), where "disabled" is accurate.
+ */
+export function semanticNotRunNoticeMessage(count: number, enabled: boolean): string {
+  const reason = enabled ? 'did not run on this pass' : 'is disabled';
+  return `${count} passage(s) needed semantic adjudication, which ${reason}. They are reported as review-required. No compliance conclusion was drawn about them.`;
 }
 
 /**
@@ -203,7 +215,7 @@ export async function analyseSemantically(
     notices.push({
       code: 'semantic-disabled',
       level: 'info',
-      message: semanticNotRunNoticeMessage(disabledCount),
+      message: semanticNotRunNoticeMessage(disabledCount, config.enabled),
       detail: { candidates: disabledCount },
     });
   }

--- a/src/textlint/adapter.ts
+++ b/src/textlint/adapter.ts
@@ -394,11 +394,30 @@ export function createSteTextlintRule(
         // AST once and shares it), and a fresh object every subsequent call, so this reports each
         // distinct notice exactly once per run regardless of which rule computed it, with no
         // explicit reset between runs to forget.
+        //
+        // A notice naming a specific rule in `detail.ruleId` (`rule-options-invalid`) is reported
+        // only by that rule's own handler, so textlint attributes the resulting message's `ruleId`
+        // to the rule the notice is actually about, not to whichever handler's turn came first (see
+        // "surfaces distinct notices from different rules" in test/e2e/textlint-run.test.ts).
+        // That attribution only makes sense when the named rule is actually registered this run --
+        // `unknown-rule-id`'s own `detail.ruleId` is, by construction, never one of them (it names
+        // the misconfigured id the run rejected), so gating on an exact match unconditionally made
+        // it unreachable through every handler and left the misconfiguration with no trace in the
+        // report, the exact silent-drop this whole mechanism exists to prevent. Falling through to
+        // "whichever handler arrives first reports it" for an unregistered `ruleId` restores that
+        // guarantee while leaving the registered-rule attribution above untouched.
+        const registeredRuleIds = documentRuns.get(node)?.registrations;
         let reportedForNode = reportedRunNoticesFor.get(node);
         for (const notice of analysis.notices) {
           if (notice.level === 'info') continue;
           const noticeRuleId = notice.detail?.['ruleId'];
-          if (typeof noticeRuleId === 'string' && noticeRuleId !== ruleId) continue;
+          if (
+            typeof noticeRuleId === 'string' &&
+            noticeRuleId !== ruleId &&
+            registeredRuleIds?.has(noticeRuleId) === true
+          ) {
+            continue;
+          }
           const identity = JSON.stringify([notice.code, notice.message]);
           if (reportedForNode?.has(identity) === true) continue;
           if (reportedForNode === undefined) {

--- a/test/e2e/textlint-run.test.ts
+++ b/test/e2e/textlint-run.test.ts
@@ -560,6 +560,29 @@ describe('run-level notices, reported once regardless of which rules are enabled
       'punctuation-constraints',
     ]);
   });
+
+  it('is reported for a misconfigured rule id that matches no real rule (unknown-rule-id)', async () => {
+    // Confirmed via direct reproduction that this used to report nothing at all: `unknown-rule-id`'s
+    // own `detail.ruleId` is the *misconfigured* id by construction, so it can never equal any real
+    // enabled rule's own `ruleId` -- the same per-notice filter that correctly routes a
+    // `rule-options-invalid` notice to the one rule it concerns (the tests above) then matched no
+    // enabled rule at all here, so its `continue` fired for every rule and silently dropped the
+    // notice for everyone, contradicting this describe block's own name.
+    const result = await kernel.lintText(text, {
+      ext: '.md',
+      plugins: [{ pluginId: 'markdown', plugin: markdownPlugin }],
+      rules: [
+        {
+          ruleId: 'unapproved-vocabulary',
+          rule: mustGetRule('unapproved-vocabulary'),
+          options: { shared: { rules: { 'unaproved-vocabulary': { enabled: false } } } },
+        },
+      ],
+    });
+    const notices = result.messages.filter((m) => m.message.includes('unknown-rule-id'));
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.message).toContain('unaproved-vocabulary');
+  });
 });
 
 describe('preset shape', () => {

--- a/test/integration/deterministic-parity.test.ts
+++ b/test/integration/deterministic-parity.test.ts
@@ -49,4 +49,23 @@ describe('the deterministic-only CLI path and the semantic-disabled broker path 
     expect(fromDeterministic?.message).toBeDefined();
     expect(fromBroker?.message).toBe(fromDeterministic?.message);
   });
+
+  it('does not call semantic adjudication "disabled" when config actually enables it', () => {
+    // `analyseTextDeterministic` never contacts the semantic service regardless of
+    // `config.semantic.enabled` -- its own doc comment says so -- but until this fix its
+    // `semantic-disabled` notice claimed "which is disabled" even when the caller's own config set
+    // `semantic.enabled: true` and simply invoked this deterministic-only entry point directly (the
+    // combination `ste-ai lint --semantic --deterministic-only` produces). Confirmed directly: the
+    // message text was previously identical for `enabled: true` and `enabled: false`.
+    const enabled = analyseTextDeterministic(text, { config: { semantic: { enabled: true } } });
+    const disabled = analyseTextDeterministic(text, { config: { semantic: { enabled: false } } });
+
+    const fromEnabled = enabled.notices.find((n) => n.code === 'semantic-disabled');
+    const fromDisabled = disabled.notices.find((n) => n.code === 'semantic-disabled');
+
+    expect(fromEnabled?.message).toBeDefined();
+    expect(fromEnabled?.message).not.toContain('is disabled');
+    expect(fromDisabled?.message).toContain('is disabled');
+    expect(fromEnabled?.message).not.toBe(fromDisabled?.message);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to a `/code-review --fix` pass covering the last 48 hours of commits across all code changes (not just mine). 8 parallel review agents (correctness, reuse, simplification, efficiency, altitude/design, conventions) surfaced 16 deduplicated findings; I independently verified the highest-severity ones by reading the actual code and reproducing behavior against the real textlint kernel before fixing anything. This PR fixes every CONFIRMED finding plus the doc-citation inconsistency; see the bottom of this description for what was found but deliberately not touched.

### Two real correctness bugs (reproduced directly, not just inferred from reading)

- **`src/textlint/adapter.ts`** — a misconfigured rule name (e.g. a typo in `.textlintrc.json`) produced **zero warning** through the real textlint pipeline. `createSteTextlintRule`'s per-notice `ruleId` filter routes a rule-specific notice (`rule-options-invalid`) to only the rule it concerns — correct, and covered by existing tests — but `unknown-rule-id`'s own `detail.ruleId` is, by construction, never one of the currently-enabled rules (it names the *rejected* id), so the filter matched no rule at all and silently dropped it for everyone. Reproduced against the real `TextlintKernel`: a misconfigured shared-rules entry produced 0 messages before the fix, with a positive control (a real contraction) confirming the harness itself worked. Fixed by falling through to "whichever handler arrives first reports it" only when the notice's `ruleId` doesn't match any rule actually registered this run — the existing per-rule attribution is untouched for notices that do.
- **`src/semantic/analyse.ts`** — the `semantic-disabled` notice said "which is disabled" even when `config.semantic.enabled` is `true`, whenever `analyseTextDeterministic` is invoked directly (`ste-ai lint --semantic --deterministic-only` produces exactly this). Reproduced directly: identical message text for `enabled: true` and `enabled: false`. Fixed by having the message take the call site's own `enabled` flag; verified the existing cross-entry-point parity test (both sides genuinely disabled) still holds.

### Efficiency / duplication (verified by reading the code; several found independently by 2–3 review agents)

- `src/core/runner.ts` — `packTrusted`, a pack-id safety check, and a display string were each recomputed once per enabled rule (or once per diagnostic) instead of once per document; hoisted above the loop. Also collapsed `packSpec === undefined || packStatus === undefined` (redundant — `verifiedRuleStatus` never returns `undefined`) into one `packInfo` value.
- `src/deterministic/helpers.ts` — `findCaseConflicts`'s pairwise loop recompiled a fresh `RegExp` from the same fixed key on every `(i, j)` pair; now built once per outer key and reused.
- `src/core/document.ts` — `analyseDocument` hand-duplicated `prepareDocument`'s merge formula purely to diff against it, on every call. Extracted the shared formula and skip the (now always-redundant-when-unsupplied) validation unless a caller actually passed its own `preparation`.

### Documentation

- `docs/design/64-layered-rule-packs/02-authority-trust.md` — the commit that added AGENTS.md's rule against line-number citations converted only one row of this file's own table to a symbol reference, leaving five sibling rows (and the paragraph beneath them) still citing exact lines. Finished converting that table and paragraph; verified each cited function/call site against current source along the way.

## Verification

- `vp check` — clean (format + lint + typecheck) after every commit.
- `vp test` — 919/919 passing (917 existing + 2 new regression tests).
- Both new tests confirmed to actually fail against the pre-fix code (verified via `git stash` on just the source files, running the two new tests, confirming they failed with the expected assertion errors, then restoring).
- All `scripts/ci/*.sh` assertion scripts pass, including a fresh `vp pack` before `check-candidate-ground-truth.sh`.

## Deliberately not fixed here

Per this repo's AGENTS.md ("Notice a problem, log it — never silently skip it" and the general rule against widening a change beyond what was asked), the following review findings were surfaced but not acted on in this PR:

- The vocabulary rules' case-conflict scan still re-runs its full comparison pass on every document lint rather than once per config — real, but fixing it needs a design decision about cache invalidation scope, not a mechanical hoist.
- ~9 additional PLAUSIBLE reuse/dead-code findings (duplicate trust-check implementations, `effectiveReplacement`/`effectiveAlternatives` duplication, `posIndexFor`/`winkIndexFor` near-duplicate closures, a no-op `clearAnalysisCache`, `reportUncheckedGroup`'s duplicated message branches, the duplicated case-conflict `superRefine` block) — real but lower-severity design smells, not independently re-verified against current source in this pass.
- The design doc's remaining several-dozen line-number citations elsewhere in the same file — a larger cleanup than the one specific inconsistency this PR addresses.

## Test plan

- [x] `vp check`
- [x] `vp test` (919/919)
- [x] Both new regression tests confirmed to fail against pre-fix code, then pass after the fix
- [x] All `scripts/ci/*.sh` assertion scripts

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb1bNXXkHVkbfeD82BZfUN)_